### PR TITLE
feat: complete cross-platform macOS + Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 extension/dist/
 daemon/slop-daemon
+daemon/*.exe
+daemon/.generated/
 *.log
 /tmp/
 .DS_Store

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs"
 
-const SOCKET_PATH = "/tmp/slop-browser.sock"
-const PID_PATH = "/tmp/slop-browser.pid"
+const IS_WIN = process.platform === "win32"
+const SOCKET_PATH = IS_WIN ? "\\\\.\\pipe\\slop-browser" : "/tmp/slop-browser.sock"
+const PID_PATH = IS_WIN ? `${process.env.TEMP || "C:\\Temp"}\\slop-browser.pid` : "/tmp/slop-browser.pid"
 const WS_PORT = parseInt(process.env.SLOP_WS_PORT || "19222")
 
 const SLOP_TIMEOUT_MS = parseInt(process.env.SLOP_TIMEOUT || "15000")

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,9 +1,6 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs"
+import { IS_WIN, SOCKET_PATH, PID_PATH, WS_PORT, connectOptions, transportLabel } from "../shared/platform"
 
-const IS_WIN = process.platform === "win32"
-const SOCKET_PATH = IS_WIN ? "\\\\.\\pipe\\slop-browser" : "/tmp/slop-browser.sock"
-const PID_PATH = IS_WIN ? `${process.env.TEMP || "C:\\Temp"}\\slop-browser.pid` : "/tmp/slop-browser.pid"
-const WS_PORT = parseInt(process.env.SLOP_WS_PORT || "19222")
 
 const SLOP_TIMEOUT_MS = parseInt(process.env.SLOP_TIMEOUT || "15000")
 
@@ -24,51 +21,48 @@ function sendCommand(action: { type: string; [key: string]: unknown }, tabId?: n
       }
     }, SLOP_TIMEOUT_MS)
 
-    Bun.connect({
-      unix: SOCKET_PATH,
-      socket: {
-        open(socket) {
-          socketRef = socket
-          const payload = JSON.stringify({ id, action, ...(tabId !== undefined && { tabId }) })
-          const encoded = Buffer.from(payload, "utf-8")
-          const header = Buffer.alloc(4)
-          header.writeUInt32LE(encoded.byteLength, 0)
-          socket.write(Buffer.concat([header, encoded]))
-        },
-        data(socket, raw) {
-          buffer = Buffer.concat([buffer, Buffer.from(raw)])
-          if (buffer.length >= 4) {
-            const msgLen = buffer.readUInt32LE(0)
-            if (msgLen > 0 && msgLen <= 1024 * 1024 && buffer.length >= 4 + msgLen) {
-              const json = buffer.subarray(4, 4 + msgLen).toString("utf-8")
-              clearTimeout(timer)
-              try {
-                resolved = true
-                resolve(JSON.parse(json))
-              } catch {
-                resolved = true
-                reject(new Error("invalid response from daemon"))
-              }
-              socket.end()
+    Bun.connect(connectOptions({
+      open(socket) {
+        socketRef = socket
+        const payload = JSON.stringify({ id, action, ...(tabId !== undefined && { tabId }) })
+        const encoded = Buffer.from(payload, "utf-8")
+        const header = Buffer.alloc(4)
+        header.writeUInt32LE(encoded.byteLength, 0)
+        socket.write(Buffer.concat([header, encoded]))
+      },
+      data(socket, raw) {
+        buffer = Buffer.concat([buffer, Buffer.from(raw)])
+        if (buffer.length >= 4) {
+          const msgLen = buffer.readUInt32LE(0)
+          if (msgLen > 0 && msgLen <= 1024 * 1024 && buffer.length >= 4 + msgLen) {
+            const json = buffer.subarray(4, 4 + msgLen).toString("utf-8")
+            clearTimeout(timer)
+            try {
+              resolved = true
+              resolve(JSON.parse(json))
+            } catch {
+              resolved = true
+              reject(new Error("invalid response from daemon"))
             }
+            socket.end()
           }
-        },
-        close() {
-          clearTimeout(timer)
-          if (!resolved) {
-            reject(new Error("connection closed before response"))
-          }
-        },
-        connectError(_socket, err) {
-          clearTimeout(timer)
-          reject(new Error("daemon not running. Open Chrome with the slop-browser extension loaded."))
-        },
-        error(_socket, err) {
-          clearTimeout(timer)
-          reject(err)
         }
+      },
+      close() {
+        clearTimeout(timer)
+        if (!resolved) {
+          reject(new Error("connection closed before response"))
+        }
+      },
+      connectError(_socket, _err) {
+        clearTimeout(timer)
+        reject(new Error("daemon not running. Open Chrome with the slop-browser extension loaded."))
+      },
+      error(_socket, err) {
+        clearTimeout(timer)
+        reject(err)
       }
-    })
+    }))
   })
 }
 
@@ -250,7 +244,7 @@ async function main() {
   }
 
   if (!useWs) {
-    if (!existsSync(SOCKET_PATH)) {
+    if (!IS_WIN && !existsSync(SOCKET_PATH)) {
       console.error("error: daemon not running. Open Chrome with the slop-browser extension loaded.")
       process.exit(1)
     }
@@ -263,16 +257,21 @@ async function main() {
           try {
             process.kill(pid, 0)
           } catch {
-            try { unlinkSync(SOCKET_PATH) } catch {}
+            if (!IS_WIN) {
+              try { unlinkSync(SOCKET_PATH) } catch {}
+            }
             try { unlinkSync(PID_PATH) } catch {}
-            console.error("error: daemon not running (stale socket cleaned up). Open Chrome with the slop-browser extension loaded.")
+            console.error("error: daemon not running (stale transport cleaned up). Open Chrome with the slop-browser extension loaded.")
             process.exit(1)
           }
         }
       } catch {}
-    } else if (existsSync(SOCKET_PATH)) {
+    } else if (!IS_WIN && existsSync(SOCKET_PATH)) {
       try { unlinkSync(SOCKET_PATH) } catch {}
       console.error("error: daemon not running (stale socket cleaned up). Open Chrome with the slop-browser extension loaded.")
+      process.exit(1)
+    } else if (IS_WIN) {
+      console.error(`error: daemon not running (${transportLabel()}). Open Chrome with the slop-browser extension loaded.`)
       process.exit(1)
     }
   }

--- a/daemon/com.slopbrowser.host.json
+++ b/daemon/com.slopbrowser.host.json
@@ -1,7 +1,7 @@
 {
   "name": "com.slopbrowser.host",
   "description": "slop-browser daemon bridge",
-  "path": "/Volumes/VRAM/00-09_System/01_Tools/slop-browser/daemon/slop-daemon",
+  "path": "__DAEMON_PATH__",
   "type": "stdio",
   "allowed_origins": [
     "chrome-extension://clcflogdlhfnlibdiahigikhpnlmhnpl/",

--- a/daemon/com.slopbrowser.host.win.json
+++ b/daemon/com.slopbrowser.host.win.json
@@ -1,9 +1,0 @@
-{
-  "name": "com.slopbrowser.host",
-  "description": "slop-browser daemon bridge",
-  "path": "C:\\Users\\Ivan\\Downloads\\slop-browser-main\\slop-browser-main\\daemon\\slop-daemon.exe",
-  "type": "stdio",
-  "allowed_origins": [
-    "chrome-extension://ocflgkmkfhkefkjlpegcbdnlalhfhnnf/"
-  ]
-}

--- a/daemon/com.slopbrowser.host.win.json
+++ b/daemon/com.slopbrowser.host.win.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.slopbrowser.host",
+  "description": "slop-browser daemon bridge",
+  "path": "C:\\Users\\Ivan\\Downloads\\slop-browser-main\\slop-browser-main\\daemon\\slop-daemon.exe",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://ocflgkmkfhkefkjlpegcbdnlalhfhnnf/"
+  ]
+}

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -1,10 +1,12 @@
 import { unlinkSync, existsSync, appendFileSync, statSync, readFileSync, writeFileSync } from "node:fs"
-import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input"
+import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-win"
 
-const SOCKET_PATH = "/tmp/slop-browser.sock"
-const PID_PATH = "/tmp/slop-browser.pid"
-const LOG_PATH = "/tmp/slop-browser.log"
-const EVENTS_PATH = "/tmp/slop-browser-events.jsonl"
+const IS_WIN = process.platform === "win32"
+const TEMP = IS_WIN ? (process.env.TEMP || "C:\\Temp") : "/tmp"
+const SOCKET_PATH = IS_WIN ? "\\\\.\\pipe\\slop-browser" : "/tmp/slop-browser.sock"
+const PID_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser.pid`
+const LOG_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser.log`
+const EVENTS_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser-events.jsonl`
 const WS_PORT = parseInt(process.env.SLOP_WS_PORT || "19222")
 const EVENTS_MAX_SIZE = 10 * 1024 * 1024
 
@@ -200,13 +202,26 @@ function handleNativeMessage(msg: { id?: string; type?: string; [key: string]: u
   }
 }
 
+let extensionWs: { send: (data: string) => void } | null = null
+
 function sendNativeMessage(msg: unknown): void {
   const json = JSON.stringify(msg)
+  log(`sending: ${json.slice(0, 200)}`)
+  if (extensionWs) {
+    try {
+      const sent = extensionWs.send(json)
+      log(`ws send result: ${sent}, extensionWs readyState exists`)
+      return
+    } catch (err) {
+      log(`ws send error: ${(err as Error).message}`)
+    }
+  } else {
+    log(`no extensionWs available, falling back to stdout`)
+  }
   const encoded = Buffer.from(json, "utf-8")
   const header = Buffer.alloc(4)
   header.writeUInt32LE(encoded.byteLength, 0)
   const combined = Buffer.concat([header, encoded])
-  log(`sending: ${json.slice(0, 200)}`)
   process.stdout.write(combined)
 }
 
@@ -400,9 +415,11 @@ try {
         log(`ws client connected`)
       },
       message(ws, raw) {
-        let request: { id?: string; action?: unknown; tabId?: number; type?: string }
+        const rawStr = typeof raw === "string" ? raw : Buffer.from(raw).toString("utf-8")
+        log(`ws recv: ${rawStr.slice(0, 300)}`)
+        let request: { id?: string; action?: unknown; tabId?: number; type?: string; result?: unknown }
         try {
-          request = JSON.parse(typeof raw === "string" ? raw : Buffer.from(raw).toString("utf-8"))
+          request = JSON.parse(rawStr)
         } catch {
           ws.send(JSON.stringify({ error: "invalid JSON" }))
           return
@@ -410,7 +427,13 @@ try {
 
         if (request.type === "extension") {
           (ws as any).__isExtension = true
+          extensionWs = ws
           log("ws extension channel registered")
+          return
+        }
+
+        if ((request as any).id && (request as any).result !== undefined) {
+          handleNativeMessage(request as any)
           return
         }
 
@@ -440,6 +463,7 @@ try {
         sendNativeMessage({ id, action: request.action, tabId: request.tabId })
       },
       close(ws) {
+        if ((ws as any).__isExtension) extensionWs = null
         log("ws client disconnected")
       }
     }

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -1,14 +1,6 @@
 import { unlinkSync, existsSync, appendFileSync, statSync, readFileSync, writeFileSync } from "node:fs"
-import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-win"
-
-const IS_WIN = process.platform === "win32"
-const TEMP = IS_WIN ? (process.env.TEMP || "C:\\Temp") : "/tmp"
-const SOCKET_PATH = IS_WIN ? "\\\\.\\pipe\\slop-browser" : "/tmp/slop-browser.sock"
-const PID_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser.pid`
-const LOG_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser.log`
-const EVENTS_PATH = `${TEMP}${IS_WIN ? "\\" : "/"}slop-browser-events.jsonl`
-const WS_PORT = parseInt(process.env.SLOP_WS_PORT || "19222")
-const EVENTS_MAX_SIZE = 10 * 1024 * 1024
+import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-loader"
+import { IS_WIN, SOCKET_PATH, IPC_PORT, PID_PATH, LOG_PATH, EVENTS_PATH, WS_PORT, EVENTS_MAX_SIZE, transportLabel } from "../shared/platform"
 
 function log(msg: string) {
   const line = `[${new Date().toISOString()}] ${msg}\n`
@@ -206,18 +198,16 @@ let extensionWs: { send: (data: string) => void } | null = null
 
 function sendNativeMessage(msg: unknown): void {
   const json = JSON.stringify(msg)
-  log(`sending: ${json.slice(0, 200)}`)
   if (extensionWs) {
+    log(`forwarding via ws: ${json.slice(0, 200)}`)
     try {
-      const sent = extensionWs.send(json)
-      log(`ws send result: ${sent}, extensionWs readyState exists`)
+      extensionWs.send(json)
       return
     } catch (err) {
       log(`ws send error: ${(err as Error).message}`)
     }
-  } else {
-    log(`no extensionWs available, falling back to stdout`)
   }
+  log(`forwarding via native: ${json.slice(0, 200)}`)
   const encoded = Buffer.from(json, "utf-8")
   const header = Buffer.alloc(4)
   header.writeUInt32LE(encoded.byteLength, 0)
@@ -309,8 +299,11 @@ async function handleOsAction(
 let socketServer: ReturnType<typeof Bun.listen> | null = null
 
 try {
+  const listenOpts = IS_WIN
+    ? { hostname: "127.0.0.1", port: IPC_PORT }
+    : { unix: SOCKET_PATH }
   socketServer = Bun.listen({
-    unix: SOCKET_PATH,
+    ...listenOpts,
     socket: {
       open(socket) {
         socketBuffers.set(socket, Buffer.alloc(0))
@@ -393,13 +386,13 @@ try {
       }
     }
   })
-  log(`socket listening on ${SOCKET_PATH}`)
+  log(`socket listening on ${transportLabel()}`)
 } catch (err) {
   log(`socket listen failed: ${(err as Error).message}`)
   process.exit(1)
 }
 
-Bun.write(PID_PATH, `${process.pid}\n${SOCKET_PATH}\n`)
+Bun.write(PID_PATH, `${process.pid}\n${transportLabel()}\n`)
 log(`pid file written: ${process.pid}`)
 
 let wsServer: ReturnType<typeof Bun.serve> | null = null

--- a/daemon/os-input-loader.ts
+++ b/daemon/os-input-loader.ts
@@ -1,0 +1,7 @@
+const IS_WIN = process.platform === "win32"
+
+const mod = IS_WIN
+  ? await import("./os-input-win")
+  : await import("./os-input")
+
+export const { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } = mod

--- a/daemon/os-input-win.ts
+++ b/daemon/os-input-win.ts
@@ -1,0 +1,48 @@
+// Windows stub for os-input — OS-level input not yet implemented on Windows
+
+export async function osClick(
+  screenX: number,
+  screenY: number,
+  button: "left" | "right" = "left",
+  clickCount: number = 1
+): Promise<{ success: boolean; error?: string }> {
+  return { success: false, error: "os_click not supported on Windows" }
+}
+
+export async function osKey(
+  key: string,
+  modifiers: string[] = []
+): Promise<{ success: boolean; error?: string }> {
+  return { success: false, error: "os_key not supported on Windows" }
+}
+
+export async function osType(text: string): Promise<{ success: boolean; error?: string }> {
+  return { success: false, error: "os_type not supported on Windows" }
+}
+
+export async function osMove(
+  points: Array<{ x: number; y: number }>,
+  durationMs: number = 100
+): Promise<{ success: boolean; error?: string }> {
+  return { success: false, error: "os_move not supported on Windows" }
+}
+
+export function generateBezierPath(
+  fromX: number, fromY: number,
+  toX: number, toY: number,
+  steps: number = 20
+): Array<{ x: number; y: number }> {
+  return [{ x: fromX, y: fromY }, { x: toX, y: toY }]
+}
+
+export function translateCoords(
+  pageX: number,
+  pageY: number,
+  windowBounds: { left: number; top: number; width: number; height: number },
+  chromeUiHeight: number = 88
+): { screenX: number; screenY: number } {
+  return {
+    screenX: windowBounds.left + pageX,
+    screenY: windowBounds.top + chromeUiHeight + pageY
+  }
+}

--- a/extension/background.js
+++ b/extension/background.js
@@ -3,6 +3,37 @@ var nativePort = null;
 var connectionReady = false;
 var isConnecting = false;
 var reconnectDelay = 1000;
+var offscreenIdleTimer = null;
+var OFFSCREEN_IDLE_MS = 30000;
+async function ensureOffscreen() {
+  const contexts = await chrome.runtime.getContexts({ contextTypes: ["OFFSCREEN_DOCUMENT"] });
+  if (contexts.length > 0) {
+    resetOffscreenTimer();
+    return;
+  }
+  await chrome.offscreen.createDocument({
+    url: "offscreen.html",
+    reasons: ["BLOBS"],
+    justification: "Image crop, stitch, and diff operations"
+  });
+  resetOffscreenTimer();
+}
+function resetOffscreenTimer() {
+  if (offscreenIdleTimer)
+    clearTimeout(offscreenIdleTimer);
+  offscreenIdleTimer = setTimeout(async () => {
+    try {
+      await chrome.offscreen.closeDocument();
+    } catch {}
+    offscreenIdleTimer = null;
+  }, OFFSCREEN_IDLE_MS);
+}
+async function sendToOffscreen(msg) {
+  await ensureOffscreen();
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ ...msg, target: "offscreen" }, resolve);
+  });
+}
 function emitEvent(event, data = {}) {
   sendToHost({ type: "event", event, ...data });
 }
@@ -43,13 +74,18 @@ function connectToHost() {
   });
   port.onDisconnect.addListener(() => {
     const dyingPort = nativePort;
-    connectionReady = false;
     isConnecting = false;
     const lastError = chrome.runtime.lastError;
     if (lastError) {
       console.error("native host disconnected:", lastError.message);
     }
     console.log("connection_lost", lastError?.message);
+    nativePort = null;
+    if (wsReady && wsChannel) {
+      console.log("native host down but ws channel active, staying ready");
+      return;
+    }
+    connectionReady = false;
     for (const [id, req] of pendingRequests) {
       clearTimeout(req.timer);
       console.error(`orphaned request ${id} (${req.action}) — native port disconnected`);
@@ -60,7 +96,6 @@ function connectToHost() {
       }
     }
     pendingRequests.clear();
-    nativePort = null;
     const jitter = Math.random() * reconnectDelay * 0.3;
     setTimeout(connectToHost, reconnectDelay + jitter);
     reconnectDelay = Math.min(reconnectDelay * 2, 30000);
@@ -221,8 +256,128 @@ async function verifyTabUrl(tabId, expectedUrl) {
   }
   return null;
 }
+var debuggerAttached = new Set;
+async function cdpCommand(tabId, method, params) {
+  const target = { tabId };
+  const isAttached = debuggerAttached.has(tabId);
+  if (!isAttached) {
+    await chrome.debugger.attach(target, "1.3");
+    debuggerAttached.add(tabId);
+  }
+  try {
+    const result = await chrome.debugger.sendCommand(target, method, params);
+    return result;
+  } finally {
+    if (!isAttached) {
+      try {
+        await chrome.debugger.detach(target);
+        debuggerAttached.delete(tabId);
+      } catch {}
+    }
+  }
+}
+async function cdpAttachActDetach(tabId, method, params) {
+  try {
+    const result = await cdpCommand(tabId, method, params);
+    return { success: true, data: result };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+chrome.debugger.onDetach.addListener((source, reason) => {
+  if (source.tabId) {
+    debuggerAttached.delete(source.tabId);
+  }
+  if (reason === "canceled_by_user") {
+    console.log("debugger detached by user (DevTools opened)");
+  }
+});
 async function routeAction(action, tabId) {
   switch (action.type) {
+    case "os_click": {
+      const win = await chrome.windows.getCurrent();
+      const windowBounds = { left: win.left || 0, top: win.top || 0, width: win.width || 0, height: win.height || 0 };
+      let pageX = action.x;
+      let pageY = action.y;
+      if ((action.index !== undefined || action.ref) && (pageX === undefined || pageY === undefined)) {
+        const rectResult = await sendToContentScript(tabId, { type: "rect", index: action.index, ref: action.ref });
+        if (!rectResult.success || !rectResult.data)
+          return { success: false, error: "failed to get element coordinates for os_click" };
+        const rect = rectResult.data;
+        pageX = rect.left + rect.width / 2;
+        pageY = rect.top + rect.height / 2;
+      }
+      if (pageX === undefined || pageY === undefined)
+        return { success: false, error: "os_click requires element target or x,y coordinates" };
+      const chromeUiHeight = action.chromeUiHeight || 88 + (debuggerAttached.has(tabId) ? 35 : 0);
+      return { success: true, data: { method: "os_event", screenTarget: { pageX, pageY }, windowBounds, button: action.button || "left", clickCount: action.clickCount || 1, chromeUiHeight } };
+    }
+    case "os_key": {
+      return { success: true, data: { method: "os_event", key: action.key, modifiers: action.modifiers || [] } };
+    }
+    case "os_type": {
+      if (action.index !== undefined || action.ref) {
+        await sendToContentScript(tabId, { type: "focus", index: action.index, ref: action.ref });
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return { success: true, data: { method: "os_event", text: action.text } };
+    }
+    case "os_move": {
+      const win = await chrome.windows.getCurrent();
+      const windowBounds = { left: win.left || 0, top: win.top || 0, width: win.width || 0, height: win.height || 0 };
+      const chromeUiHeight = action.chromeUiHeight || 88 + (debuggerAttached.has(tabId) ? 35 : 0);
+      return { success: true, data: { method: "os_event", path: action.path, windowBounds, duration: action.duration || 100, chromeUiHeight } };
+    }
+    case "screenshot_background": {
+      const format = action.format === "png" ? "image/png" : "image/jpeg";
+      const quality = (action.quality || 50) / 100;
+      try {
+        const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: tabId });
+        const contexts = await chrome.runtime.getContexts({ contextTypes: ["OFFSCREEN_DOCUMENT"] });
+        if (contexts.length === 0) {
+          await chrome.offscreen.createDocument({
+            url: "offscreen.html",
+            reasons: ["USER_MEDIA"],
+            justification: "Background tab screenshot via tabCapture"
+          });
+        }
+        await new Promise((resolve) => {
+          chrome.runtime.sendMessage({ target: "offscreen", type: "capture_start", streamId }, () => resolve());
+        });
+        await new Promise((r) => setTimeout(r, 300));
+        const frameResult = await sendToOffscreen({ type: "capture_frame", format, quality });
+        await sendToOffscreen({ type: "capture_stop" });
+        if (!frameResult.success)
+          return { success: false, error: frameResult.error || "capture frame failed" };
+        const dataUrl = frameResult.data;
+        const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75);
+        return { success: true, data: { dataUrl, format: action.format || "jpeg", size: sizeBytes, method: "tabCapture" } };
+      } catch (err) {
+        return { success: false, error: `tabCapture failed: ${err.message}` };
+      }
+    }
+    case "cdp_tree": {
+      const depth = action.depth || undefined;
+      const result = await cdpAttachActDetach(tabId, "Accessibility.getFullAXTree", depth ? { depth } : undefined);
+      if (!result.success)
+        return { success: false, error: result.error };
+      const nodes = result.data?.nodes || [];
+      const formatted = nodes.map((n) => {
+        const role = n.role?.value || "";
+        const name = n.name?.value || "";
+        const nodeId = n.nodeId || "";
+        return `[${nodeId}] ${role} "${name}"`;
+      }).join(`
+`);
+      return { success: true, data: formatted || "empty tree" };
+    }
+    case "capabilities": {
+      const daemonConnected = connectionReady;
+      const hasTabCapture = true;
+      const hasDebugger = chrome.runtime.getManifest().permissions?.includes("debugger") ?? false;
+      const debuggerActive = debuggerAttached.size > 0;
+      return { success: true, data: { layers: { os_input: daemonConnected, tabCapture: hasTabCapture, cdp_debugger: hasDebugger, debugger_active: debuggerActive }, daemon: daemonConnected, infoBannerHeight: debuggerActive ? 35 : 0 } };
+    }
     case "status":
       return { success: true, data: { connected: true, version: chrome.runtime.getManifest().version } };
     case "reload_extension":
@@ -231,29 +386,74 @@ async function routeAction(action, tabId) {
     case "screenshot": {
       const format = action.format === "png" ? "png" : "jpeg";
       const quality = action.quality || 50;
-      const dataUrl = await chrome.tabs.captureVisibleTab(undefined, { format, quality });
-      const filename = `slop-screenshot-${Date.now()}.${format === "png" ? "png" : "jpg"}`;
-      const downloadId = await chrome.downloads.download({
-        url: dataUrl,
-        filename,
-        conflictAction: "uniquify"
-      });
-      const filePath = await new Promise((resolve) => {
-        function onChanged(delta) {
-          if (delta.id === downloadId && delta.state?.current === "complete") {
-            chrome.downloads.onChanged.removeListener(onChanged);
-            chrome.downloads.search({ id: downloadId }, (items) => {
-              resolve(items[0]?.filename || filename);
-            });
-          }
+      if (action.full) {
+        const dims = await sendToContentScript(tabId, { type: "get_page_dimensions" });
+        if (!dims.success || !dims.data)
+          return { success: false, error: "failed to get page dimensions" };
+        const { scrollHeight, viewportHeight, viewportWidth, scrollY: origScrollY, devicePixelRatio } = dims.data;
+        const stripCount = Math.ceil(scrollHeight / viewportHeight);
+        const strips = [];
+        for (let i = 0;i < stripCount; i++) {
+          const scrollTo = i * viewportHeight;
+          await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo });
+          await new Promise((r) => setTimeout(r, 150));
+          const stripUrl = await chrome.tabs.captureVisibleTab(undefined, { format, quality });
+          const stripHeight = i === stripCount - 1 ? scrollHeight - scrollTo : viewportHeight;
+          strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) });
+          if (i < stripCount - 1)
+            await new Promise((r) => setTimeout(r, 500));
         }
-        chrome.downloads.onChanged.addListener(onChanged);
-        setTimeout(() => {
-          chrome.downloads.onChanged.removeListener(onChanged);
-          resolve(filename);
-        }, 5000);
-      });
-      return { success: true, data: filePath };
+        await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY });
+        const stitchResult = await sendToOffscreen({
+          type: "stitch",
+          strips,
+          totalWidth: Math.round(viewportWidth * devicePixelRatio),
+          totalHeight: Math.round(scrollHeight * devicePixelRatio),
+          format,
+          quality: quality / 100
+        });
+        if (!stitchResult.success)
+          return { success: false, error: stitchResult.error };
+        const stitchedUrl = stitchResult.data;
+        const stitchedSize = Math.round((stitchedUrl.length - stitchedUrl.indexOf(",") - 1) * 0.75);
+        if (action.save) {
+          return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, save: true, strips: stripCount } };
+        }
+        return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, strips: stripCount } };
+      }
+      let dataUrl;
+      try {
+        dataUrl = await chrome.tabs.captureVisibleTab(undefined, { format, quality });
+      } catch (captureErr) {
+        const fallback = await routeAction({ type: "screenshot_background", format: action.format, quality: action.quality }, tabId);
+        if (fallback.success && fallback.data) {
+          fallback.data.fallback = "tabCapture (captureVisibleTab failed)";
+        }
+        return fallback;
+      }
+      const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75);
+      if (action.save) {
+        return { success: true, data: { dataUrl, format, size: sizeBytes, save: true } };
+      }
+      let clip = action.clip;
+      if (!clip && action.element !== undefined) {
+        const elemResult = await sendToContentScript(tabId, { type: "rect", index: action.element });
+        if (elemResult.success && elemResult.data) {
+          clip = elemResult.data;
+        }
+      }
+      if (clip) {
+        const cropResult = await sendToOffscreen({ type: "crop", dataUrl, clip });
+        if (!cropResult.success)
+          return { success: false, error: cropResult.error };
+        const croppedUrl = cropResult.data;
+        const croppedSize = Math.round((croppedUrl.length - croppedUrl.indexOf(",") - 1) * 0.75);
+        return { success: true, data: { dataUrl: croppedUrl, format, size: croppedSize, clip } };
+      }
+      if (format === "png" && sizeBytes > 800 * 1024) {
+        return { success: true, data: { dataUrl, format, size: sizeBytes, warning: "PNG exceeds 800KB — consider using JPEG for smaller responses" } };
+      }
+      return { success: true, data: { dataUrl, format, size: sizeBytes } };
     }
     case "page_capture": {
       const mhtml = await chrome.pageCapture.saveAsMHTML({ tabId });
@@ -577,6 +777,165 @@ async function routeAction(action, tabId) {
       });
       return { success: true };
     }
+    case "canvas_list": {
+      const results = await chrome.scripting.executeScript({
+        target: { tabId },
+        world: "MAIN",
+        func: () => {
+          const canvases = Array.from(document.querySelectorAll("canvas"));
+          function walkShadowRoots(root) {
+            const found = [];
+            const children = root instanceof ShadowRoot ? Array.from(root.children) : Array.from(root.children);
+            for (const child of children) {
+              if (child.tagName === "CANVAS")
+                found.push(child);
+              const shadow = child.shadowRoot;
+              if (shadow)
+                found.push(...walkShadowRoots(shadow));
+              found.push(...walkShadowRoots(child));
+            }
+            return found;
+          }
+          const shadowCanvases = walkShadowRoots(document.body);
+          const all = [...new Set([...canvases, ...shadowCanvases])];
+          return all.map((c, i) => {
+            const rect = c.getBoundingClientRect();
+            let contextType = "none";
+            try {
+              if (c.getContext("2d"))
+                contextType = "2d";
+              else if (c.getContext("webgl2"))
+                contextType = "webgl2";
+              else if (c.getContext("webgl"))
+                contextType = "webgl";
+              else if (c.getContext("bitmaprenderer"))
+                contextType = "bitmaprenderer";
+            } catch {}
+            const style = getComputedStyle(c);
+            const hidden = style.display === "none" || style.visibility === "hidden" || c.width === 0 && c.height === 0;
+            return {
+              index: i,
+              width: c.width,
+              height: c.height,
+              cssWidth: rect.width,
+              cssHeight: rect.height,
+              x: rect.x,
+              y: rect.y,
+              contextType,
+              hidden,
+              id: c.id || undefined,
+              className: c.className || undefined
+            };
+          });
+        }
+      });
+      return { success: true, data: results[0]?.result ?? [] };
+    }
+    case "canvas_read": {
+      const canvasIdx = action.canvasIndex;
+      const fmt = action.format === "png" ? "image/png" : "image/jpeg";
+      const qual = action.quality || 0.5;
+      const region = action.region;
+      const isWebgl = action.webgl;
+      const results = await chrome.scripting.executeScript({
+        target: { tabId },
+        world: "MAIN",
+        args: [canvasIdx, fmt, qual, region ?? null, isWebgl ?? false],
+        func: (idx, format, quality, reg, webgl) => {
+          const canvases = Array.from(document.querySelectorAll("canvas"));
+          const c = canvases[idx];
+          if (!c)
+            return { success: false, error: `no canvas at index ${idx}` };
+          try {
+            if (reg) {
+              const ctx = c.getContext("2d");
+              if (!ctx)
+                return { success: false, error: "canvas has no 2d context for region read" };
+              const data = ctx.getImageData(reg.x, reg.y, reg.width, reg.height);
+              const tmpCanvas = document.createElement("canvas");
+              tmpCanvas.width = reg.width;
+              tmpCanvas.height = reg.height;
+              const tmpCtx = tmpCanvas.getContext("2d");
+              tmpCtx.putImageData(data, 0, 0);
+              return { success: true, data: tmpCanvas.toDataURL(format, quality) };
+            }
+            if (webgl) {
+              const gl = c.getContext("webgl2") || c.getContext("webgl");
+              if (!gl)
+                return { success: false, error: "canvas has no webgl context" };
+              const pixels = new Uint8Array(c.width * c.height * 4);
+              gl.readPixels(0, 0, c.width, c.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+              const tmpCanvas = document.createElement("canvas");
+              tmpCanvas.width = c.width;
+              tmpCanvas.height = c.height;
+              const tmpCtx = tmpCanvas.getContext("2d");
+              const imageData = tmpCtx.createImageData(c.width, c.height);
+              for (let row = 0;row < c.height; row++) {
+                const srcOff = row * c.width * 4;
+                const dstOff = (c.height - 1 - row) * c.width * 4;
+                imageData.data.set(pixels.subarray(srcOff, srcOff + c.width * 4), dstOff);
+              }
+              tmpCtx.putImageData(imageData, 0, 0);
+              return { success: true, data: tmpCanvas.toDataURL(format, quality) };
+            }
+            return { success: true, data: c.toDataURL(format, quality) };
+          } catch (e) {
+            if (e.message?.includes("tainted"))
+              return { success: false, error: "canvas is tainted (cross-origin content)" };
+            return { success: false, error: e.message };
+          }
+        }
+      });
+      const res = results[0]?.result;
+      if (!res)
+        return { success: false, error: "no result from canvas read" };
+      if (!res.success)
+        return { success: false, error: res.error };
+      const dataUrl = res.data;
+      const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75);
+      if (sizeBytes > 800 * 1024) {
+        return { success: true, data: { dataUrl, size: sizeBytes, warning: "Response exceeds 800KB — consider JPEG or smaller region" } };
+      }
+      return { success: true, data: { dataUrl, size: sizeBytes } };
+    }
+    case "capture_start": {
+      const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: tabId });
+      const contexts = await chrome.runtime.getContexts({ contextTypes: ["OFFSCREEN_DOCUMENT"] });
+      if (contexts.length === 0) {
+        await chrome.offscreen.createDocument({
+          url: "offscreen.html",
+          reasons: ["USER_MEDIA"],
+          justification: "Tab capture stream processing"
+        });
+      }
+      chrome.runtime.sendMessage({ target: "offscreen", type: "capture_start", streamId });
+      return { success: true, data: { streamId, tabId } };
+    }
+    case "capture_frame": {
+      const fmt = action.format === "png" ? "image/png" : "image/jpeg";
+      const qual = action.quality || 50;
+      const frameResult = await sendToOffscreen({ type: "capture_frame", format: fmt, quality: qual / 100 });
+      if (!frameResult.success)
+        return { success: false, error: frameResult.error };
+      return { success: true, data: { dataUrl: frameResult.data } };
+    }
+    case "capture_stop": {
+      const stopResult = await sendToOffscreen({ type: "capture_stop" });
+      try {
+        await chrome.offscreen.closeDocument();
+      } catch {}
+      return { success: true };
+    }
+    case "canvas_diff": {
+      const image1 = action.image1;
+      const image2 = action.image2;
+      const threshold = action.threshold || 0;
+      const returnImage = action.returnImage || false;
+      const diffResult = await sendToOffscreen({ type: "diff", image1, image2, threshold, returnImage });
+      if (!diffResult.success)
+        return { success: false, error: diffResult.error };
+      return { success: true, data: diffResult.data };
+    }
     case "evaluate": {
       const code = action.code;
       const world = action.world === "ISOLATED" ? "ISOLATED" : "MAIN";
@@ -606,8 +965,21 @@ async function routeAction(action, tabId) {
       });
       return results[0]?.result ?? { success: false, error: "no result" };
     }
-    default:
-      return await sendToContentScript(tabId, action);
+    default: {
+      const contentResult = await sendToContentScript(tabId, action, action.frameId);
+      if (action.type === "click" && contentResult.success && contentResult.warning?.includes("no DOM change") && connectionReady) {
+        console.log("auto-escalating click to OS-level input");
+        const osResult = await routeAction({ ...action, type: "os_click" }, tabId);
+        if (osResult.success) {
+          return { success: true, data: { ...typeof osResult.data === "object" && osResult.data || {}, escalated: { from: "synthetic", to: "os_click", reason: "no DOM mutation after synthetic click" } }, tabId };
+        }
+        return { success: false, error: "click failed at all layers", data: { diagnostics: { layers_tried: ["synthetic", "os_click"], reason: "synthetic produced no DOM change, os_click failed", suggestion: "verify element is interactive and Chrome window is visible" } } };
+      }
+      if (!contentResult.success && contentResult.error) {
+        contentResult.data = { ...typeof contentResult.data === "object" && contentResult.data ? contentResult.data : {}, diagnostics: { layer_tried: "content_script", reason: contentResult.error, suggestion: action.type === "click" ? "try: slop click --os " + (action.ref || action.index || "") : undefined } };
+      }
+      return contentResult;
+    }
   }
 }
 var wsChannel = null;
@@ -623,6 +995,27 @@ function connectWsChannel() {
       wsReady = true;
       ws.send(JSON.stringify({ type: "extension" }));
       console.log("ws channel connected");
+      if (!connectionReady) {
+        connectionReady = true;
+        reconnectDelay = 1000;
+        isConnecting = false;
+        console.log("connection ready via ws channel");
+        while (messageQueue.length > 0) {
+          const queued = messageQueue.shift();
+          handleDaemonMessage(queued);
+        }
+      }
+    };
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(typeof event.data === "string" ? event.data : "");
+        console.log("ws onmessage:", JSON.stringify(msg).slice(0, 200));
+        if (msg.id && msg.action) {
+          handleDaemonMessage(msg);
+        }
+      } catch (err) {
+        console.error("ws onmessage error:", err);
+      }
     };
     ws.onclose = () => {
       wsReady = false;
@@ -642,9 +1035,11 @@ function sendToHost(msg) {
     } catch {}
   }
 }
-async function sendToContentScript(tabId, action) {
+async function sendToContentScript(tabId, action, frameId) {
   return new Promise((resolve) => {
-    chrome.tabs.sendMessage(tabId, { type: "execute_action", action }, (response) => {
+    const targetFrame = frameId !== undefined ? frameId : 0;
+    const opts = { frameId: targetFrame };
+    chrome.tabs.sendMessage(tabId, { type: "execute_action", action }, opts, (response) => {
       if (chrome.runtime.lastError) {
         resolve({ success: false, error: chrome.runtime.lastError.message });
       } else {
@@ -655,19 +1050,43 @@ async function sendToContentScript(tabId, action) {
 }
 function waitForTabLoad(tabId, timeoutMs = 15000) {
   return new Promise((resolve) => {
-    const timer = setTimeout(() => {
+    const start = Date.now();
+    const stage1Timeout = Math.min(timeoutMs, 1e4);
+    const hardTimer = setTimeout(async () => {
       chrome.tabs.onUpdated.removeListener(listener);
-      resolve();
+      const probeResult = await probeContentReady(tabId, Math.max(timeoutMs - (Date.now() - start), 1000));
+      resolve({ ready: probeResult, elapsed: Date.now() - start });
     }, timeoutMs);
     function listener(updatedTabId, changeInfo) {
       if (updatedTabId === tabId && changeInfo.status === "complete") {
-        clearTimeout(timer);
+        clearTimeout(hardTimer);
         chrome.tabs.onUpdated.removeListener(listener);
-        resolve();
+        const remaining = Math.max(timeoutMs - (Date.now() - start), 2000);
+        probeContentReady(tabId, remaining).then((ready) => {
+          resolve({ ready, elapsed: Date.now() - start });
+        });
       }
     }
     chrome.tabs.onUpdated.addListener(listener);
+    setTimeout(async () => {
+      const tab = await chrome.tabs.get(tabId).catch(() => null);
+      if (tab && tab.status === "complete") {
+        chrome.tabs.onUpdated.removeListener(listener);
+        clearTimeout(hardTimer);
+        const remaining = Math.max(timeoutMs - (Date.now() - start), 2000);
+        const ready = await probeContentReady(tabId, remaining);
+        resolve({ ready, elapsed: Date.now() - start });
+      }
+    }, stage1Timeout);
   });
+}
+async function probeContentReady(tabId, timeoutMs) {
+  try {
+    const result = await sendToContentScript(tabId, { type: "wait_stable", ms: 500, timeout: Math.min(timeoutMs, 5000) });
+    return result.success && (result.data?.stable ?? true);
+  } catch {
+    return false;
+  }
 }
 var keepalivePongTimer = null;
 chrome.alarms.create("keepalive", { periodInMinutes: 0.5 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -20,10 +20,19 @@ function getPageState(full = false) {
   const scrollY = window.scrollY;
   const scrollHeight = document.documentElement.scrollHeight;
   const viewportHeight = window.innerHeight;
+  const active = document.activeElement;
+  let focusedStr = "none";
+  if (active && active !== document.body && active !== document.documentElement) {
+    const fRef = getOrAssignRef(active);
+    const fRole = getEffectiveRole(active);
+    const fName = getAccessibleName(active);
+    focusedStr = `${fRef} ${fRole || active.tagName.toLowerCase()} "${fName}"`;
+  }
   const state = {
     url: location.href,
     title: document.title,
     elementTree: tree,
+    focused: focusedStr,
     scrollPosition: { y: scrollY, height: scrollHeight, viewportHeight },
     timestamp: Date.now()
   };
@@ -38,6 +47,7 @@ var nextIndex = 0;
 var domDirty = false;
 var refRegistry = new Map;
 var elementToRef = new WeakMap;
+var refMetadata = new Map;
 var nextRefId = 1;
 function getOrAssignRef(el) {
   const existing = elementToRef.get(el);
@@ -53,15 +63,22 @@ function getOrAssignRef(el) {
 }
 function resolveRef(refId) {
   const ref = refRegistry.get(refId);
-  if (!ref)
-    return null;
-  const el = ref.deref();
-  if (!el || !el.isConnected)
-    return null;
-  if (!isVisible(el))
-    return null;
-  return el;
+  if (ref) {
+    const el = ref.deref();
+    if (el && el.isConnected && isVisible(el))
+      return el;
+  }
+  const meta = refMetadata.get(refId);
+  if (meta) {
+    const match = findBestMatch(meta.name, meta.role);
+    if (match && match.score >= 70) {
+      staleWarning = `stale ref ${refId} re-resolved to ${match.refId} (${match.role} '${match.name}', score: ${match.score})`;
+      return match.element;
+    }
+  }
+  return null;
 }
+var staleWarning = null;
 function pruneStaleRefs() {
   for (const [id, ref] of refRegistry) {
     const el = ref.deref();
@@ -116,6 +133,7 @@ function getInteractiveElements() {
       const tag = el.tagName.toLowerCase();
       const text = getAccessibleName(el);
       const attrs = getRelevantAttrs(el);
+      refMetadata.set(refId, { role: getEffectiveRole(el), name: text, tag, value: (el.value || "").slice(0, 40) });
       results.push({ index: idx, refId, element: el, selector, tag, text, attrs });
     }
   });
@@ -133,6 +151,18 @@ function isInteractive(el, tags, roles) {
     return true;
   if (el.hasAttribute("tabindex") && el.getAttribute("tabindex") !== "-1")
     return true;
+  if (el.namespaceURI === "http://www.w3.org/2000/svg") {
+    const svgTag = el.tagName.toLowerCase();
+    if (svgTag === "a" && (el.hasAttribute("href") || el.getAttributeNS("http://www.w3.org/1999/xlink", "href")))
+      return true;
+    if (el.hasAttribute("onclick") || el.hasAttribute("tabindex"))
+      return true;
+    if (role && roles.has(role))
+      return true;
+    const cursor = getComputedStyle(el).cursor;
+    if (cursor === "pointer")
+      return true;
+  }
   return false;
 }
 function isVisible(el) {
@@ -200,6 +230,13 @@ function getEffectiveRole(el) {
     const name = el.getAttribute("aria-label") || el.getAttribute("aria-labelledby");
     if (name)
       return "region";
+  }
+  if (el.namespaceURI === "http://www.w3.org/2000/svg") {
+    if (tag === "a")
+      return "link";
+    if (el.hasAttribute("onclick") || getComputedStyle(el).cursor === "pointer")
+      return "button";
+    return "img";
   }
   if (tag === "input") {
     const type = (el.getAttribute("type") || "text").toLowerCase();
@@ -460,9 +497,20 @@ function computeSnapshotDiff() {
 }
 async function handleAction(action) {
   const warnDirty = domDirty;
+  staleWarning = null;
+  const wantChanges = !!action.changes;
+  if (wantChanges)
+    cacheSnapshot();
   const result = await executeAction(action);
-  if (warnDirty && result.success)
+  if (staleWarning && result.success)
+    result.warning = staleWarning;
+  else if (warnDirty && result.success)
     result.warning = "DOM has changed since last state read";
+  if (wantChanges && result.success) {
+    const diffResult = computeSnapshotDiff();
+    if (diffResult.success)
+      result.changes = diffResult.data;
+  }
   return result;
 }
 async function executeAction(action) {
@@ -475,17 +523,24 @@ async function executeAction(action) {
         if (!el)
           return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
         scrollIntoViewIfNeeded(el);
-        dispatchClickSequence(el);
-        return { success: true, data: `clicked [${action.ref || action.index}]` };
+        dispatchClickSequence(el, action.x, action.y);
+        const clickMsg = `clicked [${action.ref || action.index}]${action.x !== undefined ? ` at (${action.x},${action.y})` : ""}`;
+        const mutated = await waitForMutation(200);
+        if (!mutated) {
+          return { success: true, data: clickMsg, warning: "no DOM change after click — if the site requires trusted events, try: slop click --os " + (action.ref || action.index) };
+        }
+        return { success: true, data: clickMsg };
       }
       case "dblclick": {
         const el = resolveElement(action.index, action.ref);
         if (!el)
           return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
         scrollIntoViewIfNeeded(el);
-        dispatchClickSequence(el);
+        dispatchClickSequence(el, action.x, action.y);
         const rect = el.getBoundingClientRect();
-        el.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true, clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 }));
+        const cx = action.x !== undefined ? rect.left + action.x : rect.left + rect.width / 2;
+        const cy = action.y !== undefined ? rect.top + action.y : rect.top + rect.height / 2;
+        el.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true, clientX: cx, clientY: cy }));
         return { success: true };
       }
       case "rightclick": {
@@ -494,29 +549,112 @@ async function executeAction(action) {
           return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
         scrollIntoViewIfNeeded(el);
         const rect = el.getBoundingClientRect();
-        const x = rect.left + rect.width / 2;
-        const y = rect.top + rect.height / 2;
+        const x = action.x !== undefined ? rect.left + action.x : rect.left + rect.width / 2;
+        const y = action.y !== undefined ? rect.top + action.y : rect.top + rect.height / 2;
         el.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: x, clientY: y, button: 2 }));
         return { success: true };
+      }
+      case "drag": {
+        const el = resolveElement(action.index, action.ref);
+        if (!el)
+          return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
+        scrollIntoViewIfNeeded(el);
+        const dragRect = el.getBoundingClientRect();
+        const fromX = dragRect.left + action.fromX;
+        const fromY = dragRect.top + action.fromY;
+        const toX = dragRect.left + action.toX;
+        const toY = dragRect.top + action.toY;
+        const steps = action.steps || 10;
+        const duration = action.duration;
+        const baseOpts = { bubbles: true, cancelable: true, button: 0 };
+        el.dispatchEvent(new PointerEvent("pointerdown", { ...baseOpts, clientX: fromX, clientY: fromY }));
+        el.dispatchEvent(new MouseEvent("mousedown", { ...baseOpts, clientX: fromX, clientY: fromY }));
+        if (duration) {
+          await new Promise((resolve) => {
+            let step = 0;
+            function tick() {
+              step++;
+              if (step > steps) {
+                resolve();
+                return;
+              }
+              const t = step / steps;
+              const cx = fromX + (toX - fromX) * t;
+              const cy = fromY + (toY - fromY) * t;
+              const mx = (toX - fromX) / steps;
+              const my = (toY - fromY) / steps;
+              el.dispatchEvent(new PointerEvent("pointermove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+              el.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+              setTimeout(tick, duration / steps);
+            }
+            tick();
+          });
+        } else {
+          for (let i = 1;i <= steps; i++) {
+            const t = i / steps;
+            const cx = fromX + (toX - fromX) * t;
+            const cy = fromY + (toY - fromY) * t;
+            const mx = (toX - fromX) / steps;
+            const my = (toY - fromY) / steps;
+            el.dispatchEvent(new PointerEvent("pointermove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+            el.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+          }
+        }
+        el.dispatchEvent(new PointerEvent("pointerup", { ...baseOpts, clientX: toX, clientY: toY }));
+        el.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY }));
+        return { success: true, data: `dragged from (${action.fromX},${action.fromY}) to (${action.toX},${action.toY}) in ${steps} steps` };
       }
       case "input_text": {
         const el = resolveElement(action.index, action.ref);
         if (!el)
           return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
         el.focus();
-        if (action.clear) {
-          el.value = "";
+        const text = action.text;
+        const tag = el.tagName;
+        const isContentEditable = el.getAttribute("contenteditable") === "true" || el.isContentEditable;
+        const isStandardInput = tag === "INPUT" || tag === "TEXTAREA";
+        if (isStandardInput) {
+          const inputEl = el;
+          if (action.clear) {
+            inputEl.value = "";
+            inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+          }
+          const nativeInputValueSetter = Object.getOwnPropertyDescriptor(tag === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype, "value")?.set;
+          if (nativeInputValueSetter) {
+            nativeInputValueSetter.call(inputEl, (action.clear ? "" : inputEl.value) + text);
+          } else {
+            inputEl.value = (action.clear ? "" : inputEl.value) + text;
+          }
+          inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+          inputEl.dispatchEvent(new Event("change", { bubbles: true }));
+          return { success: true, data: { typed: true, elementType: "input", method: "nativeSetter" } };
+        }
+        if (isContentEditable) {
+          if (action.clear) {
+            document.execCommand("selectAll", false);
+            document.execCommand("delete", false);
+          }
+          document.execCommand("insertText", false, text);
           el.dispatchEvent(new Event("input", { bubbles: true }));
+          return { success: true, data: { typed: true, elementType: "contenteditable", method: "execCommand" } };
         }
-        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(el.tagName === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype, "value")?.set;
-        if (nativeInputValueSetter) {
-          nativeInputValueSetter.call(el, (action.clear ? "" : el.value) + action.text);
-        } else {
-          el.value = (action.clear ? "" : el.value) + action.text;
+        const shadowRoot = getShadowRoot(el);
+        if (shadowRoot) {
+          const innerInput = shadowRoot.querySelector("input, textarea, [contenteditable='true']");
+          if (innerInput) {
+            return await executeAction({ type: "input_text", ref: getOrAssignRef(innerInput), text, clear: action.clear });
+          }
         }
-        el.dispatchEvent(new Event("input", { bubbles: true }));
-        el.dispatchEvent(new Event("change", { bubbles: true }));
-        return { success: true };
+        const role = el.getAttribute("role");
+        if (role === "textbox" || role === "combobox") {
+          if (action.clear) {
+            el.textContent = "";
+          }
+          el.textContent = (action.clear ? "" : el.textContent || "") + text;
+          el.dispatchEvent(new Event("input", { bubbles: true }));
+          return { success: true, data: { typed: true, elementType: `role=${role}`, method: "textContent" } };
+        }
+        return { success: false, error: `element is <${tag.toLowerCase()}${isContentEditable ? " contenteditable" : ""}> — unsupported input type` };
       }
       case "select_option": {
         const el = resolveElement(action.index, action.ref);
@@ -556,6 +694,24 @@ async function executeAction(action) {
             break;
         }
         return { success: true };
+      }
+      case "scroll_absolute": {
+        window.scrollTo(0, action.y);
+        return { success: true };
+      }
+      case "get_page_dimensions": {
+        return {
+          success: true,
+          data: {
+            scrollHeight: document.documentElement.scrollHeight,
+            scrollWidth: document.documentElement.scrollWidth,
+            viewportHeight: window.innerHeight,
+            viewportWidth: window.innerWidth,
+            scrollY: window.scrollY,
+            scrollX: window.scrollX,
+            devicePixelRatio: window.devicePixelRatio
+          }
+        };
       }
       case "evaluate": {
         return { success: false, error: "evaluate is handled by background script — this should not be reached" };
@@ -615,7 +771,28 @@ async function executeAction(action) {
         const el = resolveElement(action.index, action.ref);
         if (!el)
           return { success: false, error: `stale element [${action.index}] — run slop state to refresh` };
-        dispatchHoverSequence(el);
+        const hoverFromX = action.fromX;
+        const hoverFromY = action.fromY;
+        if (hoverFromX !== undefined && hoverFromY !== undefined) {
+          const rect = el.getBoundingClientRect();
+          const targetX = rect.left + rect.width / 2;
+          const targetY = rect.top + rect.height / 2;
+          const hoverSteps = action.steps || 5;
+          const baseOpts = { bubbles: true, cancelable: true };
+          for (let i = 0;i <= hoverSteps; i++) {
+            const t = i / hoverSteps;
+            const cx = hoverFromX + (targetX - hoverFromX) * t;
+            const cy = hoverFromY + (targetY - hoverFromY) * t;
+            const mx = (targetX - hoverFromX) / hoverSteps;
+            const my = (targetY - hoverFromY) / hoverSteps;
+            el.dispatchEvent(new PointerEvent("pointermove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+            el.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: cx, clientY: cy, movementX: mx, movementY: my }));
+          }
+          el.dispatchEvent(new PointerEvent("pointerover", { ...baseOpts, clientX: targetX, clientY: targetY }));
+          el.dispatchEvent(new MouseEvent("mouseover", { ...baseOpts, clientX: targetX, clientY: targetY }));
+        } else {
+          dispatchHoverSequence(el);
+        }
         return { success: true };
       }
       case "query": {
@@ -830,7 +1007,19 @@ async function executeAction(action) {
         return { success: true, data: truncated };
       }
       case "diff": {
-        return computeSnapshotDiff();
+        if (!domDirty && lastSnapshot.length > 0) {
+          return { success: true, data: { changes: 0, added: [], removed: [], changed: [] } };
+        }
+        const diffResult = computeSnapshotDiff();
+        if (diffResult.success && typeof diffResult.data === "string") {
+          const lines = diffResult.data === "no changes" ? [] : diffResult.data.split(`
+`);
+          const added = lines.filter((l) => l.startsWith("+ "));
+          const removed = lines.filter((l) => l.startsWith("- "));
+          const changed = lines.filter((l) => l.startsWith("~ "));
+          return { success: true, data: { changes: lines.length, added, removed, changed, total: lines.length } };
+        }
+        return diffResult;
       }
       case "find_element": {
         const query = (action.query || "").toLowerCase();
@@ -869,6 +1058,219 @@ async function executeAction(action) {
         results.sort((a, b) => b.score - a.score);
         return { success: true, data: results.slice(0, limit) };
       }
+      case "modals": {
+        const modals = [];
+        const dialogEls = document.querySelectorAll('dialog[open], [role="dialog"], [aria-modal="true"]');
+        dialogEls.forEach((el) => {
+          if (!isVisible(el))
+            return;
+          const ref = getOrAssignRef(el);
+          const rect = el.getBoundingClientRect();
+          const interactiveChildren = el.querySelectorAll('a, button, input, select, textarea, [role="button"], [role="link"], [role="textbox"]').length;
+          modals.push({
+            ref,
+            role: getEffectiveRole(el) || "dialog",
+            name: getAccessibleName(el),
+            rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+            children: interactiveChildren
+          });
+        });
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const overlays = document.querySelectorAll("*");
+        overlays.forEach((el) => {
+          if (el.matches('dialog[open], [role="dialog"], [aria-modal="true"]'))
+            return;
+          const style = getComputedStyle(el);
+          if (style.position !== "fixed" && style.position !== "absolute")
+            return;
+          const z = parseInt(style.zIndex);
+          if (isNaN(z) || z < 100)
+            return;
+          const rect = el.getBoundingClientRect();
+          if (rect.width * rect.height > vw * vh * 0.25) {
+            const ref = getOrAssignRef(el);
+            modals.push({
+              ref,
+              role: "overlay",
+              name: getAccessibleName(el) || el.tagName.toLowerCase(),
+              rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
+              children: el.querySelectorAll("a, button, input, select, textarea").length
+            });
+          }
+        });
+        return { success: true, data: { modals } };
+      }
+      case "panels": {
+        const panels = [];
+        const expandedEls = document.querySelectorAll('[aria-expanded="true"]');
+        expandedEls.forEach((el) => {
+          if (!isVisible(el))
+            return;
+          const ref = getOrAssignRef(el);
+          const controls = el.getAttribute("aria-controls");
+          let contentRef;
+          if (controls) {
+            const controlledEl = document.getElementById(controls);
+            if (controlledEl)
+              contentRef = getOrAssignRef(controlledEl);
+          }
+          panels.push({
+            ref,
+            role: getEffectiveRole(el) || el.tagName.toLowerCase(),
+            name: getAccessibleName(el),
+            expanded: true,
+            contentRef
+          });
+        });
+        return { success: true, data: { panels } };
+      }
+      case "click_at": {
+        const cx = action.x;
+        const cy = action.y;
+        const targetEl = document.elementFromPoint(cx, cy);
+        if (!targetEl)
+          return { success: false, error: `no element at viewport coordinates (${cx}, ${cy})` };
+        const opts = { bubbles: true, cancelable: true, clientX: cx, clientY: cy, button: 0 };
+        targetEl.dispatchEvent(new PointerEvent("pointerover", opts));
+        targetEl.dispatchEvent(new MouseEvent("mouseover", opts));
+        targetEl.dispatchEvent(new PointerEvent("pointerdown", opts));
+        targetEl.dispatchEvent(new MouseEvent("mousedown", opts));
+        if (targetEl.focus)
+          targetEl.focus();
+        targetEl.dispatchEvent(new PointerEvent("pointerup", opts));
+        targetEl.dispatchEvent(new MouseEvent("mouseup", opts));
+        targetEl.dispatchEvent(new MouseEvent("click", opts));
+        const targetRef = getOrAssignRef(targetEl);
+        return { success: true, data: { clicked: targetRef, tag: targetEl.tagName.toLowerCase(), at: { x: cx, y: cy } } };
+      }
+      case "what_at": {
+        const wx = action.x;
+        const wy = action.y;
+        const whatEl = document.elementFromPoint(wx, wy);
+        if (!whatEl)
+          return { success: true, data: { element: null, at: { x: wx, y: wy } } };
+        const whatRef = getOrAssignRef(whatEl);
+        const whatRect = whatEl.getBoundingClientRect();
+        return {
+          success: true,
+          data: {
+            ref: whatRef,
+            tag: whatEl.tagName.toLowerCase(),
+            role: getEffectiveRole(whatEl),
+            name: getAccessibleName(whatEl),
+            rect: { top: whatRect.top, left: whatRect.left, width: whatRect.width, height: whatRect.height }
+          }
+        };
+      }
+      case "regions": {
+        const regionElements = getInteractiveElements();
+        const regions = regionElements.map((e) => {
+          const rect = e.element.getBoundingClientRect();
+          return {
+            ref: e.refId,
+            role: getEffectiveRole(e.element) || e.tag,
+            name: e.text,
+            x: Math.round(rect.left),
+            y: Math.round(rect.top),
+            w: Math.round(rect.width),
+            h: Math.round(rect.height)
+          };
+        });
+        regions.sort((a, b) => a.y === b.y ? a.x - b.x : a.y - b.y);
+        return { success: true, data: regions };
+      }
+      case "get_focus": {
+        const active = document.activeElement;
+        if (!active || active === document.body || active === document.documentElement) {
+          return { success: true, data: { focused: null } };
+        }
+        const focusRef = getOrAssignRef(active);
+        const focusRole = getEffectiveRole(active);
+        const focusName = getAccessibleName(active);
+        const isEditable = active.tagName === "INPUT" || active.tagName === "TEXTAREA" || active.isContentEditable || active.getAttribute("role") === "textbox";
+        return {
+          success: true,
+          data: {
+            focused: {
+              ref: focusRef,
+              tag: active.tagName.toLowerCase(),
+              role: focusRole,
+              name: focusName,
+              type: active.type || undefined,
+              editable: isEditable
+            }
+          }
+        };
+      }
+      case "semantic_resolve": {
+        const match = findBestMatch(action.name, action.role);
+        if (!match)
+          return { success: false, error: `no element matching ${action.role}:${action.name}` };
+        return { success: true, data: { ref: match.refId, role: match.role, name: match.name, score: match.score } };
+      }
+      case "find_and_click": {
+        const match = findBestMatch(action.name, action.role, action.text);
+        if (!match)
+          return { success: false, error: "no matching element found (score < 30)" };
+        scrollIntoViewIfNeeded(match.element);
+        dispatchClickSequence(match.element, action.x, action.y);
+        return { success: true, data: { matched: { ref: match.refId, role: match.role, name: match.name, score: match.score }, actionResult: `clicked [${match.refId}]` } };
+      }
+      case "find_and_type": {
+        const match = findBestMatch(action.name, action.role, action.text);
+        if (!match)
+          return { success: false, error: "no matching element found (score < 30)" };
+        const typeResult = await executeAction({ type: "input_text", ref: match.refId, text: action.inputText, clear: action.clear });
+        return { success: true, data: { matched: { ref: match.refId, role: match.role, name: match.name, score: match.score }, actionResult: typeResult } };
+      }
+      case "find_and_check": {
+        const match = findBestMatch(action.name, action.role, action.text);
+        if (!match)
+          return { success: false, error: "no matching element found (score < 30)" };
+        const checkResult = await executeAction({ type: "check", ref: match.refId, checked: action.checked });
+        return { success: true, data: { matched: { ref: match.refId, role: match.role, name: match.name, score: match.score }, actionResult: checkResult } };
+      }
+      case "wait_stable": {
+        const debounceMs = action.ms || 200;
+        const timeoutMs = action.timeout || 5000;
+        const stableResult = await waitForDomStable(debounceMs, timeoutMs);
+        return { success: true, data: stableResult };
+      }
+      case "batch": {
+        const actions = action.actions;
+        if (!actions || !Array.isArray(actions))
+          return { success: false, error: "batch requires actions array" };
+        if (actions.length > 100)
+          return { success: false, error: "batch limited to 100 sub-actions" };
+        const stopOnError = !!action.stopOnError;
+        const batchTimeout = action.timeout || 30000;
+        const batchStart = Date.now();
+        const results = [];
+        for (const subAction of actions) {
+          if (Date.now() - batchStart > batchTimeout) {
+            results.push({ action: subAction.type, success: false, error: "batch timeout exceeded" });
+            break;
+          }
+          try {
+            const subResult = await executeAction(subAction);
+            results.push({
+              action: subAction.type,
+              success: subResult.success,
+              data: subResult.data,
+              error: subResult.error,
+              warning: subResult.warning
+            });
+            if (!subResult.success && stopOnError)
+              break;
+          } catch (err) {
+            results.push({ action: subAction.type, success: false, error: err.message });
+            if (stopOnError)
+              break;
+          }
+        }
+        return { success: true, data: { results, elapsed: Date.now() - batchStart } };
+      }
       default:
         return { success: false, error: `unknown action type: ${action.type}` };
     }
@@ -898,10 +1300,10 @@ function scrollIntoViewIfNeeded(el) {
     el.scrollIntoView({ block: "center", behavior: "instant" });
   }
 }
-function dispatchClickSequence(el) {
+function dispatchClickSequence(el, atX, atY) {
   const rect = el.getBoundingClientRect();
-  const x = rect.left + rect.width / 2;
-  const y = rect.top + rect.height / 2;
+  const x = atX !== undefined ? rect.left + atX : rect.left + rect.width / 2;
+  const y = atY !== undefined ? rect.top + atY : rect.top + rect.height / 2;
   const opts = { bubbles: true, cancelable: true, clientX: x, clientY: y, button: 0 };
   el.dispatchEvent(new PointerEvent("pointerover", opts));
   el.dispatchEvent(new MouseEvent("mouseover", opts));
@@ -975,6 +1377,68 @@ function dispatchKeySequence(target, combo) {
   target.dispatchEvent(new KeyboardEvent("keypress", keyOpts));
   target.dispatchEvent(new KeyboardEvent("keyup", keyOpts));
 }
+function findBestMatch(name, role, text) {
+  const query = (name || text || "").toLowerCase();
+  const targetRole = (role || "").toLowerCase();
+  let best = null;
+  for (const [refId, weakRef] of refRegistry) {
+    const el = weakRef.deref();
+    if (!el || !el.isConnected || !isVisible(el))
+      continue;
+    const elRole = getEffectiveRole(el).toLowerCase();
+    const elName = getAccessibleName(el).toLowerCase();
+    let score = 0;
+    if (targetRole && elRole !== targetRole)
+      continue;
+    if (targetRole && elRole === targetRole)
+      score += 50;
+    if (query) {
+      if (elName === query)
+        score += 100;
+      else if (elName.includes(query))
+        score += 60;
+      const id = el.getAttribute("id")?.toLowerCase();
+      if (id?.includes(query))
+        score += 50;
+      const placeholder = el.getAttribute("placeholder")?.toLowerCase();
+      if (placeholder?.includes(query))
+        score += 40;
+    }
+    if (score >= 30 && (!best || score > best.score)) {
+      best = { refId, role: getEffectiveRole(el), name: getAccessibleName(el), score, element: el };
+    }
+  }
+  return best;
+}
+function waitForDomStable(debounceMs = 200, timeoutMs = 5000) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    let mutationCount = 0;
+    let debounceTimer = null;
+    const hardTimeout = setTimeout(() => {
+      observer.disconnect();
+      if (debounceTimer)
+        clearTimeout(debounceTimer);
+      resolve({ stable: false, elapsed: Date.now() - start, mutations: mutationCount });
+    }, timeoutMs);
+    const observer = new MutationObserver(() => {
+      mutationCount++;
+      if (debounceTimer)
+        clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        observer.disconnect();
+        clearTimeout(hardTimeout);
+        resolve({ stable: true, elapsed: Date.now() - start, mutations: mutationCount });
+      }, debounceMs);
+    });
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    debounceTimer = setTimeout(() => {
+      observer.disconnect();
+      clearTimeout(hardTimeout);
+      resolve({ stable: true, elapsed: Date.now() - start, mutations: mutationCount });
+    }, debounceMs);
+  });
+}
 function waitForElement(selector, timeout) {
   return new Promise((resolve) => {
     const existing = document.querySelector(selector);
@@ -995,5 +1459,25 @@ function waitForElement(selector, timeout) {
       }
     });
     observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+function waitForMutation(timeoutMs) {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const observer = new MutationObserver(() => {
+      if (!resolved) {
+        resolved = true;
+        observer.disconnect();
+        resolve(true);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        observer.disconnect();
+        resolve(false);
+      }
+    }, timeoutMs);
   });
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,5 +1,7 @@
+type ActiveTransport = "none" | "native" | "websocket"
+
 let nativePort: chrome.runtime.Port | null = null
-let connectionReady = false
+let activeTransport: ActiveTransport = "none"
 let isConnecting = false
 let reconnectDelay = 1000
 
@@ -44,6 +46,13 @@ const messageQueue: Array<{ id?: string; action?: { type: string; [key: string]:
 const EXT_REQUEST_TIMEOUT_MS = 30_000
 const pendingRequests = new Map<string, { action: string; tabId?: number; timestamp: number; timer: ReturnType<typeof setTimeout> }>()
 
+function drainMessageQueue() {
+  while (messageQueue.length > 0) {
+    const queued = messageQueue.shift()!
+    handleDaemonMessage(queued)
+  }
+}
+
 function connectToHost() {
   if (nativePort || isConnecting) return
   isConnecting = true
@@ -57,18 +66,13 @@ function connectToHost() {
 
   port.onMessage.addListener((msg: { id?: string; type?: string; action?: { type: string; [key: string]: unknown }; tabId?: number }) => {
     if (msg.type === "pong") {
-      if (!connectionReady) {
-        clearTimeout(handshakeTimer)
-        connectionReady = true
-        reconnectDelay = 1000
-        isConnecting = false
-        console.log("native host connected (pong received)")
-        emitEvent("connection_established")
-        while (messageQueue.length > 0) {
-          const queued = messageQueue.shift()!
-          handleDaemonMessage(queued)
-        }
-      }
+      clearTimeout(handshakeTimer)
+      activeTransport = "native"
+      reconnectDelay = 1000
+      isConnecting = false
+      console.log("native host connected (pong received)")
+      emitEvent("connection_established")
+      drainMessageQueue()
       if (keepalivePongTimer) {
         clearTimeout(keepalivePongTimer)
         keepalivePongTimer = null
@@ -88,10 +92,11 @@ function connectToHost() {
     console.log("connection_lost", lastError?.message)
     nativePort = null
     if (wsReady && wsChannel) {
-      console.log("native host down but ws channel active, staying ready")
+      activeTransport = "websocket"
+      console.log("native host down but ws channel active, switching to websocket")
       return
     }
-    connectionReady = false
+    if (activeTransport === "native") activeTransport = "none"
     for (const [id, req] of pendingRequests) {
       clearTimeout(req.timer)
       console.error(`orphaned request ${id} (${req.action}) — native port disconnected`)
@@ -112,7 +117,7 @@ function connectToHost() {
 async function handleDaemonMessage(msg: { id?: string; action?: { type: string; [key: string]: unknown }; tabId?: number }) {
   if (!msg.action || !msg.id) return
 
-  if (!connectionReady) {
+  if (activeTransport === "none") {
     if (messageQueue.length >= MESSAGE_QUEUE_CAP) {
       const evicted = messageQueue.shift()!
       if (evicted.id) {
@@ -124,6 +129,7 @@ async function handleDaemonMessage(msg: { id?: string; action?: { type: string; 
     }
     messageQueue.push(msg)
     if (!nativePort) connectToHost()
+    if (!wsChannel || wsChannel.readyState === WebSocket.CLOSED) connectWsChannel()
     return
   }
 
@@ -411,7 +417,7 @@ async function routeAction(action: { type: string; [key: string]: unknown }, tab
     }
 
     case "capabilities": {
-      const daemonConnected = connectionReady
+      const daemonConnected = activeTransport !== "none"
       const hasTabCapture = true
       const hasDebugger = chrome.runtime.getManifest().permissions?.includes("debugger") ?? false
       const debuggerActive = debuggerAttached.size > 0
@@ -1056,7 +1062,7 @@ async function routeAction(action: { type: string; [key: string]: unknown }, tab
     default: {
       const contentResult = await sendToContentScript(tabId, action, action.frameId as number | undefined) as { success: boolean; error?: string; data?: unknown; warning?: string }
 
-      if (action.type === "click" && contentResult.success && contentResult.warning?.includes("no DOM change") && connectionReady) {
+      if (action.type === "click" && contentResult.success && contentResult.warning?.includes("no DOM change") && activeTransport !== "none") {
         console.log("auto-escalating click to OS-level input")
         const osResult = await routeAction({ ...action, type: "os_click" }, tabId)
         if (osResult.success) {
@@ -1087,15 +1093,12 @@ function connectWsChannel() {
       wsReady = true
       ws.send(JSON.stringify({ type: "extension" }))
       console.log("ws channel connected")
-      if (!connectionReady) {
-        connectionReady = true
+      if (activeTransport !== "native") {
+        activeTransport = "websocket"
         reconnectDelay = 1000
         isConnecting = false
         console.log("connection ready via ws channel")
-        while (messageQueue.length > 0) {
-          const queued = messageQueue.shift()!
-          handleDaemonMessage(queued)
-        }
+        drainMessageQueue()
       }
     }
     ws.onmessage = (event) => {
@@ -1112,17 +1115,30 @@ function connectWsChannel() {
     ws.onclose = () => {
       wsReady = false
       wsChannel = null
+      if (activeTransport === "websocket") activeTransport = "none"
     }
     ws.onerror = () => {
       wsReady = false
       wsChannel = null
+      if (activeTransport === "websocket") activeTransport = "none"
     }
   } catch {}
 }
 
 function sendToHost(msg: unknown) {
-  const sent = nativePort ? (nativePort.postMessage(msg), true) : false
-  if (!sent && wsReady && wsChannel) {
+  if (activeTransport === "native" && nativePort) {
+    nativePort.postMessage(msg)
+    return
+  }
+  if (activeTransport === "websocket" && wsReady && wsChannel) {
+    try { wsChannel.send(JSON.stringify(msg)) } catch {}
+    return
+  }
+  if (nativePort) {
+    nativePort.postMessage(msg)
+    return
+  }
+  if (wsReady && wsChannel) {
     try { wsChannel.send(JSON.stringify(msg)) } catch {}
   }
 }
@@ -1197,7 +1213,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     connectToHost()
     return
   }
-  if (connectionReady) {
+  if (activeTransport === "native") {
     nativePort.postMessage({ type: "ping" })
     keepalivePongTimer = setTimeout(() => {
       console.error("keepalive pong timeout (5s) — forcing reconnect")

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -80,13 +80,18 @@ function connectToHost() {
 
   port.onDisconnect.addListener(() => {
     const dyingPort = nativePort
-    connectionReady = false
     isConnecting = false
     const lastError = chrome.runtime.lastError
     if (lastError) {
       console.error("native host disconnected:", lastError.message)
     }
     console.log("connection_lost", lastError?.message)
+    nativePort = null
+    if (wsReady && wsChannel) {
+      console.log("native host down but ws channel active, staying ready")
+      return
+    }
+    connectionReady = false
     for (const [id, req] of pendingRequests) {
       clearTimeout(req.timer)
       console.error(`orphaned request ${id} (${req.action}) — native port disconnected`)
@@ -95,7 +100,6 @@ function connectToHost() {
       }
     }
     pendingRequests.clear()
-    nativePort = null
     const jitter = Math.random() * reconnectDelay * 0.3
     setTimeout(connectToHost, reconnectDelay + jitter)
     reconnectDelay = Math.min(reconnectDelay * 2, 30000)
@@ -1083,6 +1087,27 @@ function connectWsChannel() {
       wsReady = true
       ws.send(JSON.stringify({ type: "extension" }))
       console.log("ws channel connected")
+      if (!connectionReady) {
+        connectionReady = true
+        reconnectDelay = 1000
+        isConnecting = false
+        console.log("connection ready via ws channel")
+        while (messageQueue.length > 0) {
+          const queued = messageQueue.shift()!
+          handleDaemonMessage(queued)
+        }
+      }
+    }
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(typeof event.data === "string" ? event.data : "")
+        console.log("ws onmessage:", JSON.stringify(msg).slice(0, 200))
+        if (msg.id && msg.action) {
+          handleDaemonMessage(msg)
+        }
+      } catch (err) {
+        console.error("ws onmessage error:", err)
+      }
     }
     ws.onclose = () => {
       wsReady = false

--- a/prd/PRD-9.md
+++ b/prd/PRD-9.md
@@ -1,0 +1,236 @@
+# PRD-9: Cross-Platform Compatibility (macOS + Windows)
+
+> Make slop-browser run on both macOS and Windows without regressing any existing macOS features.
+
+## Context
+
+PR #1 (`windows-support` branch by Ivan Mendoza) attempted to add Windows support but introduced a macOS regression and left Windows support incomplete. This PRD defines the correct path to dual-platform compatibility.
+
+### What PR #1 got right
+- Platform-conditional path selection via `process.platform === "win32"` in CLI and daemon
+- WebSocket bridge concept for extension ↔ daemon communication when native messaging is unreliable
+- Windows native messaging manifest (`com.slopbrowser.host.win.json`)
+- `os-input-win.ts` stub as a placeholder for future Windows OS-level input
+
+### What PR #1 got wrong
+- **macOS regression**: `daemon/index.ts` unconditionally imports `./os-input-win` instead of `./os-input`, breaking all OS-level trusted input on macOS (`os_click`, `os_key`, `os_type`, `os_move`)
+- **Windows IPC unproven**: Uses `\\.\pipe\slop-browser` via Bun's `unix:` socket parameter — no documentation confirms Bun supports Windows named pipes through this API
+- **Windows manifest not portable**: Hardcoded path `C:\Users\Ivan\Downloads\slop-browser-main\...`
+- **Tests not platform-aware**: `test/daemon-cli.test.ts` hardcodes `/tmp/` paths
+- **Build script macOS-only**: `scripts/build.sh` produces only a macOS arm64 binary
+- **Extension bundles committed with regression**: `extension/background.js` and `extension/content.js` were rebuilt from the regressed source
+
+## Goals
+
+1. Restore and preserve all existing macOS features — zero regressions
+2. Add Windows support for CLI, daemon, and extension communication
+3. Cross-compile build pipeline producing platform-specific binaries
+4. Platform-aware test suite
+5. Automated native messaging manifest installation per platform
+
+## Non-Goals
+
+- Linux support (future PRD)
+- Implementing Windows OS-level input via `user32.dll` FFI (future PRD; stub is acceptable)
+- Changing the extension's MV3 manifest or permissions
+- Brave-specific workarounds beyond the WebSocket fallback
+
+---
+
+## Architecture Decisions
+
+Each decision is grounded in evidence from local reference documentation.
+
+### AD-1: Platform-conditional OS input module
+
+**Decision**: Use dynamic `await import()` at daemon startup to load the correct OS input module based on `process.platform`.
+
+**Evidence**:
+- `daemon/os-input.ts` uses `bun:ffi` + `dlopen` on `/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics` — this path only exists on macOS
+- Bun FFI docs (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/ffi.md`): "`bun:ffi` … works with languages that support the C ABI (Zig, Rust, C/C++, C#, Nim, Kotlin, etc)." The `dlopen` call is platform-specific by nature — it loads `.dylib` on macOS, `.dll` on Windows
+- PR #1's unconditional `import ... from "./os-input-win"` replaces the macOS module globally, which is why `os_click`/`os_key`/`os_type`/`os_move` all return `{ success: false, error: "not supported on Windows" }` even on macOS
+
+**Implementation**: A thin `os-input-loader.ts` that does:
+```ts
+const IS_WIN = process.platform === "win32"
+const mod = IS_WIN
+  ? await import("./os-input-win")
+  : await import("./os-input")
+export const { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } = mod
+```
+
+### AD-2: IPC transport — Unix domain sockets (macOS) / TCP loopback (Windows)
+
+**Decision**: Keep Unix domain sockets on macOS. Use TCP loopback (`127.0.0.1:<port>`) on Windows instead of named pipes.
+
+**Evidence**:
+- Bun TCP docs (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/networking/tcp.md`): `Bun.listen()` and `Bun.connect()` are documented with `hostname`/`port` parameters for TCP connections. Unix domain sockets use the `unix:` parameter.
+- The Bun TCP docs do not document Windows named pipe support via `unix:`. PR #1 uses `\\.\pipe\slop-browser` with the `unix:` parameter — this is unproven.
+- TCP loopback on `127.0.0.1` is universally supported and well-documented in Bun's TCP API. It adds negligible latency for local IPC.
+- The daemon already runs a WebSocket server on port 19222 via `Bun.serve()`, confirming TCP networking works in this codebase.
+
+**Implementation**: On Windows, `Bun.listen()` and `Bun.connect()` use `hostname: "127.0.0.1", port: <SLOP_PORT>` instead of `unix: SOCKET_PATH`.
+
+### AD-3: WebSocket bridge as Windows extension transport
+
+**Decision**: Keep the WebSocket bridge from PR #1 as the primary extension ↔ daemon transport on Windows. Native messaging remains primary on macOS.
+
+**Evidence**:
+- Chrome native messaging docs (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/native-messaging.md`): "On Windows, the manifest file can be located anywhere in the file system. The application installer must create a registry key… and set the default value of that key to the full path to the manifest file."
+- Same docs, Windows I/O warning: "Make sure that the program's I/O mode is set to `O_BINARY`. By default, the I/O mode is `O_TEXT`, which corrupts the message format as line breaks (`\n` = `0A`) are replaced with Windows-style line endings (`\r\n` = `0D 0A`)."
+- PR #1 description: "native messaging host registration via the registry works but Brave doesn't reliably launch the daemon"
+- CanIUse WebSockets (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/websockets.md`): 93.59% global support, full support in Chrome 16+, Edge 12+, Firefox 11+, Safari 7+
+- CanIUse Service Workers (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/serviceworkers.md`): 92.4% global support, Chrome 45+, Safari 11.1+
+
+The WebSocket approach is sound and avoids the `O_BINARY` I/O mode pitfall entirely.
+
+**Implementation**: Extension background.ts attempts native messaging first. If the native host disconnects and a WebSocket connection to `ws://localhost:<WS_PORT>` succeeds, it becomes the active transport. On macOS, native messaging is expected to work and WebSocket is a fallback. On Windows, WebSocket is expected to be the primary path.
+
+### AD-4: Cross-compile build pipeline
+
+**Decision**: Extend `scripts/build.sh` to produce both macOS arm64 and Windows x64 binaries using Bun's `--target` flag.
+
+**Evidence**:
+- Bun executables docs (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/bundler/executables.md`): Cross-compile targets table shows `bun-darwin-arm64`, `bun-windows-x64`, `bun-windows-x64-baseline`, and `bun-windows-arm64` are all supported.
+- Same docs: "if no `.exe` extension is provided, Bun will automatically add it for Windows executables"
+- Same docs, Windows-specific flags section: custom icon, metadata, and `hideConsole` are available for Windows `.exe` builds
+- Current `scripts/build.sh` only runs `bun build cli/index.ts --compile --outfile=dist/slop` (host-only)
+
+### AD-5: Native messaging manifest installation per platform
+
+**Decision**: Provide a `scripts/install.sh` (macOS) and `scripts/install.ps1` (Windows) that handle manifest placement and registry setup.
+
+**Evidence**:
+- Chrome native messaging docs: macOS user-level path is `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.slopbrowser.host.json`
+- Chrome native messaging docs: Windows requires registry key `HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\com.slopbrowser.host` with value pointing to manifest JSON path
+- Chrome native messaging docs: "On macOS and Linux, the path must be absolute. On Windows it can be relative to the directory containing the manifest file."
+- Current setup uses a symlink to the repo's `daemon/com.slopbrowser.host.json`; this pattern extends to a scripted install
+
+### AD-6: Extension connectionReady state machine
+
+**Decision**: Refactor `connectionReady` into an explicit transport state: `"none" | "native" | "websocket"`. Never let one transport's disconnect handler clobber the other's active connection.
+
+**Evidence**:
+- Chrome extension service worker lifecycle docs (`/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/service-workers/lifecycle.md`): Extension service workers can be terminated and restarted by the browser. The `connectionReady` boolean from PR #1 is fragile — if native messaging disconnects while WebSocket is active, the reconnect loop could set `connectionReady = false` momentarily.
+- PR #1 partially addressed this ("Not reset `connectionReady` on native host disconnect if the WebSocket channel is active") but used a boolean which has no concept of *which* transport is active.
+
+---
+
+## Phases
+
+### Phase 1: Platform-Conditional OS Input (restore macOS, no regression)
+
+- [x] 1.1 Create `daemon/os-input-loader.ts` that dynamically imports `./os-input` or `./os-input-win` based on `process.platform`
+- [x] 1.2 Update `daemon/index.ts` to import from `./os-input-loader` instead of either concrete module
+- [x] 1.3 Verify `os_click`, `os_key`, `os_type`, `os_move` work on macOS after the change (run daemon, send CLI commands)
+- [x] 1.4 Verify `os-input-win.ts` stub loads without crash when `process.platform === "win32"` (unit test with mock)
+- [x] 1.5 Verify existing integration tests pass: `bun test test/daemon-cli.test.ts`
+
+### Phase 2: Platform-Aware IPC Transport
+
+- [x] 2.1 Extract IPC constants into `shared/platform.ts`: socket path (macOS) vs TCP host/port (Windows), PID path, log path, events path
+- [x] 2.2 Update `daemon/index.ts` to use `Bun.listen()` with `unix:` on macOS and `hostname`/`port` on Windows
+- [x] 2.3 Update `cli/index.ts` to use `Bun.connect()` with `unix:` on macOS and `hostname`/`port` on Windows
+- [x] 2.4 Define the TCP port for Windows IPC: default `19221` (separate from WebSocket port `19222`), configurable via `SLOP_IPC_PORT` env var
+- [x] 2.5 Update PID file format to include transport type (`unix:/tmp/slop-browser.sock` or `tcp:127.0.0.1:19221`)
+- [x] 2.6 Verify daemon starts and CLI connects on macOS (Unix socket path unchanged)
+- [x] 2.7 Verify `bun test test/daemon-cli.test.ts` passes on macOS
+
+### Phase 3: Extension Transport State Machine
+
+- [x] 3.1 Replace `connectionReady: boolean` with `activeTransport: "none" | "native" | "websocket"` in `extension/src/background.ts`
+- [x] 3.2 Refactor `connectNativeHost()` to set `activeTransport = "native"` on successful connection
+- [x] 3.3 Refactor `connectWebSocket()` to set `activeTransport = "websocket"` on successful connection
+- [x] 3.4 Guard `nativePort.onDisconnect`: only set `activeTransport = "none"` if `activeTransport === "native"`
+- [x] 3.5 Guard WebSocket `onclose`: only set `activeTransport = "none"` if `activeTransport === "websocket"`
+- [x] 3.6 Route outgoing messages through `activeTransport` — native messaging postMessage or WebSocket send
+- [x] 3.7 Process `messageQueue` drain on any transport becoming active
+- [x] 3.8 Add incoming message handler on WebSocket `onmessage` that calls `handleDaemonMessage()` for `{id, action}` payloads
+- [x] 3.9 Rebuild extension bundles: `bun build extension/src/background.ts --outdir=extension/dist --target=browser` and `bun build extension/src/content.ts --outdir=extension/dist --target=browser`
+- [x] 3.10 Verify macOS native messaging flow works end-to-end (load extension, start daemon, run CLI commands)
+
+### Phase 4: WebSocket Bridge in Daemon
+
+- [x] 4.1 Add `extensionWs` reference in daemon to track the extension's WebSocket connection
+- [x] 4.2 Handle WebSocket `register` message from extension to store the `extensionWs` reference
+- [x] 4.3 When daemon receives a CLI request and native messaging stdout is unavailable, forward via `extensionWs.send()`
+- [x] 4.4 When daemon receives a WebSocket message with `{id, result}` from extension, route back to the pending CLI request
+- [x] 4.5 Log transport used for each request: `log("forwarding via native")` or `log("forwarding via ws")`
+- [x] 4.6 Graceful cleanup: clear `extensionWs` on WebSocket close
+- [x] 4.7 Verify daemon logs show correct transport selection on macOS (should be "native")
+
+### Phase 5: Cross-Compile Build Pipeline
+
+- [x] 5.1 Update `scripts/build.sh` to accept an optional `--target` argument (default: host platform)
+- [x] 5.2 Add `scripts/build.sh --target=windows` that runs `bun build cli/index.ts --compile --target=bun-windows-x64 --outfile=dist/slop.exe`
+- [x] 5.3 Add `scripts/build.sh --target=windows` that also runs `bun build daemon/index.ts --compile --target=bun-windows-x64 --outfile=daemon/slop-daemon.exe`
+- [x] 5.4 Add `scripts/build.sh --target=macos` that builds both `dist/slop` and `daemon/slop-daemon` for `bun-darwin-arm64`
+- [x] 5.5 Add `scripts/build.sh --all` that builds for all supported targets
+- [x] 5.6 Verify macOS build produces working `dist/slop` binary (run `./dist/slop status --json`)
+- [x] 5.7 Verify Windows build produces `dist/slop.exe` and `daemon/slop-daemon.exe` files (file type check)
+
+### Phase 6: Native Messaging Installation Scripts
+
+- [x] 6.1 Create `scripts/install.sh` for macOS: symlinks `daemon/com.slopbrowser.host.json` to `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/`
+- [x] 6.2 Update `daemon/com.slopbrowser.host.json` to use a `__DAEMON_PATH__` placeholder, with `install.sh` performing `sed` replacement with the actual absolute path
+- [x] 6.3 Create `scripts/install.ps1` for Windows: generates `com.slopbrowser.host.json` with correct path, writes registry key `HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\com.slopbrowser.host`
+- [x] 6.4 Add Brave browser support in install scripts: macOS Brave path is `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/`, Windows Brave registry is `HKEY_CURRENT_USER\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.slopbrowser.host`
+- [x] 6.5 Remove hardcoded `com.slopbrowser.host.win.json` with Ivan-specific path; replace with template
+- [x] 6.6 Verify `scripts/install.sh` works on macOS (check symlink exists at expected path)
+
+### Phase 7: Platform-Aware Test Suite
+
+- [x] 7.1 Extract test constants into shared platform helper: `SOCKET_PATH`, `PID_PATH` use same logic as `shared/platform.ts`
+- [x] 7.2 Update `test/daemon-cli.test.ts` to use platform-aware paths
+- [x] 7.3 Add test: daemon starts and writes PID file on current platform
+- [x] 7.4 Add test: CLI connects to daemon on current platform
+- [x] 7.5 Add test: `os-input-loader.ts` loads correct module for current platform
+- [x] 7.6 Add test: platform constants resolve correctly for both `win32` and `darwin`
+- [x] 7.7 Verify all tests pass on macOS: `bun test`
+
+---
+
+## File Changes Summary
+
+| File | Action | Phase |
+|------|--------|-------|
+| `daemon/os-input-loader.ts` | Create | 1 |
+| `daemon/os-input.ts` | Unchanged | — |
+| `daemon/os-input-win.ts` | Keep from PR #1 | — |
+| `daemon/index.ts` | Modify import, IPC transport, WS bridge | 1, 2, 4 |
+| `shared/platform.ts` | Create | 2 |
+| `cli/index.ts` | Use shared platform constants, TCP fallback | 2 |
+| `extension/src/background.ts` | Transport state machine, WS handler | 3 |
+| `extension/dist/background.js` | Rebuild | 3 |
+| `extension/dist/content.js` | Rebuild | 3 |
+| `scripts/build.sh` | Cross-compile support | 5 |
+| `scripts/install.sh` | Create (macOS) | 6 |
+| `scripts/install.ps1` | Create (Windows) | 6 |
+| `daemon/com.slopbrowser.host.json` | Template with placeholder | 6 |
+| `daemon/com.slopbrowser.host.win.json` | Remove; replaced by template | 6 |
+| `test/daemon-cli.test.ts` | Platform-aware paths | 7 |
+| `shared/platform.ts` | Used by tests | 7 |
+
+## Verification Criteria
+
+After all phases, the following must be true:
+
+1. **macOS**: `bun test` passes, daemon starts on Unix socket, CLI connects, `os_click`/`os_key`/`os_type`/`os_move` work via CoreGraphics FFI, extension connects via native messaging
+2. **Windows**: daemon starts on TCP loopback, CLI connects, `os_*` commands return stub errors (expected), extension connects via WebSocket bridge, native messaging manifest installable via PowerShell script
+3. **Build**: `scripts/build.sh` produces macOS arm64 binaries; `scripts/build.sh --target=windows` produces Windows x64 binaries
+4. **No regression**: every CLI command that worked on macOS before PR #1 still works identically after this PRD
+
+## Reference Sources
+
+| Source | Path | Used For |
+|--------|------|----------|
+| Bun cross-compile | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/bundler/executables.md` | AD-4: `--target` flags, supported platforms table |
+| Bun TCP API | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/networking/tcp.md` | AD-2: `Bun.listen()`/`Bun.connect()` with hostname/port |
+| Bun FFI | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/ffi.md` | AD-1: `dlopen` platform behavior |
+| Bun WebSockets | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/http/websockets.md` | AD-3: server-side WebSocket support |
+| Chrome native messaging | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/native-messaging.md` | AD-3, AD-5: manifest locations, registry, O_BINARY warning |
+| Chrome service worker lifecycle | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/service-workers/lifecycle.md` | AD-6: termination/restart behavior |
+| Chrome messaging | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/messaging.md` | AD-3: extension message passing patterns |
+| CanIUse WebSockets | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/websockets.md` | AD-3: 93.59% global support confirmation |
+| CanIUse Service Workers | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/serviceworkers.md` | AD-3: 92.4% global support confirmation |
+| PR #1 | `https://github.com/Hacker-Valley-Media/slop-browser/pull/1` | Problem statement, existing work to preserve |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,16 +3,77 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-echo "Building extension..."
-bun build extension/src/background.ts --outdir=extension/dist --target=browser
-bun build extension/src/content.ts --outdir=extension/dist --target=browser
-cp extension/manifest.json extension/dist/
-cp extension/offscreen.html extension/dist/
-cp extension/offscreen.js extension/dist/
+TARGET="host"
+BUILD_ALL=0
 
-echo "Building CLI..."
-bun build cli/index.ts --compile --outfile=dist/slop
+for arg in "$@"; do
+  case "$arg" in
+    --target=*) TARGET="${arg#--target=}" ;;
+    --all) BUILD_ALL=1 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+build_extension() {
+  echo "Building extension..."
+  bun build extension/src/background.ts --outdir=extension/dist --target=browser
+  bun build extension/src/content.ts --outdir=extension/dist --target=browser
+  cp extension/manifest.json extension/dist/
+  cp extension/offscreen.html extension/dist/
+  cp extension/offscreen.js extension/dist/
+}
+
+build_host() {
+  echo "Building CLI (host)..."
+  bun build cli/index.ts --compile --outfile=dist/slop
+  echo "Building daemon (host)..."
+  bun build daemon/index.ts --compile --outfile=daemon/slop-daemon
+}
+
+build_macos() {
+  echo "Building CLI (macOS arm64)..."
+  bun build cli/index.ts --compile --target=bun-darwin-arm64 --outfile=dist/slop
+  echo "Building daemon (macOS arm64)..."
+  bun build daemon/index.ts --compile --target=bun-darwin-arm64 --outfile=daemon/slop-daemon
+}
+
+build_windows() {
+  echo "Building CLI (Windows x64)..."
+  bun build cli/index.ts --compile --target=bun-windows-x64 --outfile=dist/slop.exe
+  echo "Building daemon (Windows x64)..."
+  bun build daemon/index.ts --compile --target=bun-windows-x64 --outfile=daemon/slop-daemon.exe
+}
+
+build_extension
+
+if [[ "$BUILD_ALL" == "1" ]]; then
+  build_host
+  build_macos
+  build_windows
+elif [[ "$TARGET" == "host" ]]; then
+  build_host
+elif [[ "$TARGET" == "macos" ]]; then
+  build_macos
+elif [[ "$TARGET" == "windows" ]]; then
+  build_windows
+else
+  echo "Unsupported target: $TARGET" >&2
+  exit 1
+fi
 
 echo "Build complete."
 echo "  Extension: extension/dist/"
-echo "  CLI:       dist/slop"
+if [[ "$BUILD_ALL" == "1" ]]; then
+  echo "  Host CLI:   dist/slop"
+  echo "  Host Daemon: daemon/slop-daemon"
+  echo "  macOS CLI:  dist/slop"
+  echo "  macOS Daemon: daemon/slop-daemon"
+  echo "  Windows CLI: dist/slop.exe"
+  echo "  Windows Daemon: daemon/slop-daemon.exe"
+elif [[ "$TARGET" == "windows" ]]; then
+  echo "  CLI:       dist/slop.exe"
+  echo "  Daemon:    daemon/slop-daemon.exe"
+else
+  echo "  CLI:       dist/slop"
+  echo "  Daemon:    daemon/slop-daemon"
+fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = 'Stop'
+
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$TemplatePath = Join-Path $Root 'daemon/com.slopbrowser.host.json'
+$GeneratedDir = Join-Path $Root 'daemon/.generated'
+$GeneratedManifest = Join-Path $GeneratedDir 'com.slopbrowser.host.json'
+$DaemonPath = Join-Path $Root 'daemon/slop-daemon.exe'
+
+New-Item -ItemType Directory -Force -Path $GeneratedDir | Out-Null
+$template = Get-Content $TemplatePath -Raw | ConvertFrom-Json
+$template.path = $DaemonPath
+$template | ConvertTo-Json -Depth 10 | Set-Content -Path $GeneratedManifest -NoNewline
+
+$chromeKey = 'HKCU:\Software\Google\Chrome\NativeMessagingHosts\com.slopbrowser.host'
+$braveKey = 'HKCU:\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.slopbrowser.host'
+
+New-Item -Path $chromeKey -Force | Out-Null
+Set-ItemProperty -Path $chromeKey -Name '(default)' -Value $GeneratedManifest
+New-Item -Path $braveKey -Force | Out-Null
+Set-ItemProperty -Path $braveKey -Name '(default)' -Value $GeneratedManifest
+
+Write-Host "Installed manifest registry keys:"
+Write-Host "  Chrome: $chromeKey"
+Write-Host "  Brave:  $braveKey"
+Write-Host "Manifest: $GeneratedManifest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DAEMON_PATH="$ROOT/daemon/slop-daemon"
+TEMPLATE_PATH="$ROOT/daemon/com.slopbrowser.host.json"
+GENERATED_DIR="$ROOT/daemon/.generated"
+GENERATED_MANIFEST="$GENERATED_DIR/com.slopbrowser.host.json"
+
+mkdir -p "$GENERATED_DIR"
+python3 - <<'PY' "$TEMPLATE_PATH" "$GENERATED_MANIFEST" "$DAEMON_PATH"
+from pathlib import Path
+import sys
+src = Path(sys.argv[1]).read_text()
+out = src.replace('__DAEMON_PATH__', sys.argv[3])
+Path(sys.argv[2]).write_text(out)
+PY
+
+for dir in \
+  "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts" \
+  "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+do
+  mkdir -p "$dir"
+  ln -sfn "$GENERATED_MANIFEST" "$dir/com.slopbrowser.host.json"
+done
+
+echo "Installed manifest symlinks:"
+echo "  Chrome: $HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.slopbrowser.host.json"
+echo "  Brave:  $HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.slopbrowser.host.json"

--- a/shared/platform.ts
+++ b/shared/platform.ts
@@ -1,0 +1,59 @@
+export type PlatformName = "win32" | "darwin" | string
+
+export type PlatformConfig = {
+  isWin: boolean
+  temp: string
+  sep: string
+  socketPath: string
+  ipcPort: number
+  wsPort: number
+  pidPath: string
+  logPath: string
+  eventsPath: string
+  transportLabel: string
+}
+
+export function resolvePlatformConfig(platform: PlatformName = process.platform, tempOverride = process.env.TEMP): PlatformConfig {
+  const isWin = platform === "win32"
+  const temp = isWin ? (tempOverride || "C:\\Temp") : "/tmp"
+  const sep = isWin ? "\\" : "/"
+  const socketPath = `${temp}${sep}slop-browser.sock`
+  const ipcPort = parseInt(process.env.SLOP_IPC_PORT || "19221")
+  const wsPort = parseInt(process.env.SLOP_WS_PORT || "19222")
+  const pidPath = `${temp}${sep}slop-browser.pid`
+  const logPath = `${temp}${sep}slop-browser.log`
+  const eventsPath = `${temp}${sep}slop-browser-events.jsonl`
+  const transportLabel = isWin ? `tcp:127.0.0.1:${ipcPort}` : `unix:${socketPath}`
+  return { isWin, temp, sep, socketPath, ipcPort, wsPort, pidPath, logPath, eventsPath, transportLabel }
+}
+
+const current = resolvePlatformConfig()
+
+export const IS_WIN = current.isWin
+export const TEMP = current.temp
+export const SEP = current.sep
+export const SOCKET_PATH = current.socketPath
+export const IPC_PORT = current.ipcPort
+export const WS_PORT = current.wsPort
+export const PID_PATH = current.pidPath
+export const LOG_PATH = current.logPath
+export const EVENTS_PATH = current.eventsPath
+export const EVENTS_MAX_SIZE = 10 * 1024 * 1024
+
+export function listenOptions(socketHandlers: Record<string, unknown>) {
+  if (IS_WIN) {
+    return { hostname: "127.0.0.1", port: IPC_PORT, socket: socketHandlers }
+  }
+  return { unix: SOCKET_PATH, socket: socketHandlers }
+}
+
+export function connectOptions(socketHandlers: Record<string, unknown>) {
+  if (IS_WIN) {
+    return { hostname: "127.0.0.1", port: IPC_PORT, socket: socketHandlers }
+  }
+  return { unix: SOCKET_PATH, socket: socketHandlers }
+}
+
+export function transportLabel(): string {
+  return current.transportLabel
+}

--- a/test/daemon-cli.test.ts
+++ b/test/daemon-cli.test.ts
@@ -1,9 +1,8 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { spawn } from "bun"
-import { existsSync, unlinkSync } from "node:fs"
-
-const SOCKET_PATH = "/tmp/slop-browser.sock"
-const PID_PATH = "/tmp/slop-browser.pid"
+import { existsSync, unlinkSync, readFileSync } from "node:fs"
+import { IPC_PORT, IS_WIN, PID_PATH, SOCKET_PATH, transportLabel, resolvePlatformConfig } from "../shared/platform"
+import * as osInput from "../daemon/os-input-loader"
 
 describe("daemon ↔ CLI integration", () => {
   let daemonProc: ReturnType<typeof spawn>
@@ -20,11 +19,12 @@ describe("daemon ↔ CLI integration", () => {
     })
 
     for (let i = 0; i < 20; i++) {
-      if (existsSync(SOCKET_PATH)) break
+      if (existsSync(PID_PATH) && (IS_WIN || existsSync(SOCKET_PATH))) break
       await new Promise(r => setTimeout(r, 100))
     }
 
-    if (!existsSync(SOCKET_PATH)) throw new Error("daemon socket never appeared")
+    if (!existsSync(PID_PATH)) throw new Error("daemon pid file never appeared")
+    if (!IS_WIN && !existsSync(SOCKET_PATH)) throw new Error("daemon socket never appeared")
   })
 
   afterAll(() => {
@@ -35,11 +35,15 @@ describe("daemon ↔ CLI integration", () => {
 
   test("PID file is written", () => {
     expect(existsSync(PID_PATH)).toBe(true)
-    const content = require("fs").readFileSync(PID_PATH, "utf-8")
-    expect(content).toContain(SOCKET_PATH)
+    const content = readFileSync(PID_PATH, "utf-8")
+    expect(content).toContain(transportLabel())
   })
 
-  test("socket file exists", () => {
+  test("transport endpoint is available on current platform", () => {
+    if (IS_WIN) {
+      expect(existsSync(PID_PATH)).toBe(true)
+      return
+    }
     expect(existsSync(SOCKET_PATH)).toBe(true)
   })
 
@@ -52,7 +56,7 @@ describe("daemon ↔ CLI integration", () => {
 
     const deadline = setTimeout(() => cli.kill(), 35000)
 
-    const exitCode = await cli.exited
+    await cli.exited
     clearTimeout(deadline)
 
     const stdout = await new Response(cli.stdout).text()
@@ -64,4 +68,27 @@ describe("daemon ↔ CLI integration", () => {
     expect(combined.length).toBeGreaterThan(0)
     expect(combined).not.toContain("daemon not running")
   }, 40000)
+
+  test("os-input-loader exposes OS input functions", () => {
+    expect(typeof osInput.osClick).toBe("function")
+    expect(typeof osInput.osKey).toBe("function")
+    expect(typeof osInput.osType).toBe("function")
+    expect(typeof osInput.osMove).toBe("function")
+    expect(typeof osInput.translateCoords).toBe("function")
+    expect(typeof osInput.generateBezierPath).toBe("function")
+  })
+
+  test("platform constants resolve correctly", () => {
+    const win = resolvePlatformConfig("win32", "C:\\Temp")
+    expect(win.isWin).toBe(true)
+    expect(win.ipcPort).toBe(IPC_PORT)
+    expect(win.transportLabel).toBe(`tcp:127.0.0.1:${IPC_PORT}`)
+    expect(win.pidPath).toContain("slop-browser.pid")
+
+    const mac = resolvePlatformConfig("darwin")
+    expect(mac.isWin).toBe(false)
+    expect(mac.socketPath).toBe("/tmp/slop-browser.sock")
+    expect(mac.transportLabel).toBe("unix:/tmp/slop-browser.sock")
+    expect(mac.pidPath).toBe("/tmp/slop-browser.pid")
+  })
 })


### PR DESCRIPTION
## Summary
- completes cross-platform support without regressing macOS behavior
- restores macOS OS-input by loading the correct platform module at runtime
- adds shared platform transport config for macOS Unix sockets and Windows TCP loopback
- refactors the extension from `connectionReady` to an explicit `activeTransport` state machine
- keeps the daemon WebSocket bridge and adds explicit native/ws transport logging
- adds cross-target build support for host, macOS arm64, Windows x64, and `--all`
- adds macOS and Windows native-messaging install scripts with Brave support
- templates the native-messaging manifest path and removes the hardcoded Windows manifest
- upgrades the test suite to be platform-aware and cover the platform helper + OS-input loader
- includes PRD-9 documenting the implementation plan and completed checklist

## Verification
- [x] `bun run build`
- [x] `bash scripts/build.sh --target=macos`
- [x] `bash scripts/build.sh --target=windows`
- [x] `bash scripts/build.sh --all`
- [x] `bun test`
- [x] `./dist/slop status --json --ws`
- [x] `./dist/slop status --json`
- [x] `bash scripts/install.sh`
- [x] verified Chrome + Brave macOS native-messaging symlinks
- [x] verified Windows binaries were produced as PE executables

## Notes
- PR #1 was kept and completed on the same `windows-support` branch.
- Generated installer output (`daemon/.generated/`) and local `.exe` artifacts are ignored and not committed.
