### PR TITLE
feat: session monitor (PRD-13) + scene graph (PRD-14) + async eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ daemon/.generated/
 *.log
 /tmp/
 .DS_Store
+slop-screenshot-*.jpg
+slop-screenshot-*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,75 @@ slop raw '{"type":"net_override_clear"}'
 
 This is how `slop linkedin attendees` changes LinkedIn's page size from 20→50 — the page's own JavaScript fetches attendees, but slop rewrites the request in-flight to ask for more results.
 
+## Scene-Graph Access (Canva, Google Docs, Google Slides)
+
+`slop scene` exposes editor objects by stable identifier so an agent can click, read, and write inside visual editors without screenshots or vision. Profile-driven: per-host detection picks the right resolver.
+
+```bash
+slop scene profile [--verbose]        # Detect host editor profile + capabilities
+slop scene list [--type <t>]          # List scene objects (images, shapes, text, slides, pages)
+slop scene click <id>                 # Click by stable id (Canva LB*, Slides filmstrip-slide-N-*, Docs page-N)
+slop scene dblclick <id>              # Enter text-edit mode in Canva/Slides
+slop scene hit <x>,<y>                # Identify object at viewport X,Y
+slop scene selected                   # Read current selection label
+slop scene zoom                       # Read editor zoom factor
+
+slop scene text [--with-html]         # Read full document (Google Docs hidden iframe mirror)
+slop scene insert "<text>"            # Insert at cursor (Google Docs)
+
+slop scene slide list                 # All slides with stable IDs + blob URLs
+slop scene slide current              # Current slide index + id
+slop scene slide goto <n>             # Navigate via URL fragment
+slop scene notes [--slide <n>]        # Read speaker notes
+
+slop scene render <id> [--save]       # Render a scene object to PNG
+```
+
+**Architecture by editor:**
+
+- **Canva** — every canvas object is a `<div id="LB…">` with `style.transform: translate(x, y)`. Stable across reloads.
+- **Google Docs** — the canvas is opaque, but the full document HTML lives in `.docs-texteventtarget-iframe > [role=textbox]` with `data-ri` range offsets. `insert` uses `execCommand('insertText')` on the iframe contenteditable; writes are undoable via `slop keys Meta+z`.
+- **Google Slides** — each slide is an SVG `<g id="filmstrip-slide-N-gd…">` with a blob-URL PNG thumbnail. `scene slide goto` sets `location.hash = "#slide=id." + pageId`. `scene render` fetches the blob and draws it into a canvas. Text-box content only appears in the text-event iframe when a text box is in edit mode — a documented caveat.
+
+**Caveats:**
+- Canva synthetic clicks require prior interactive warmup to trigger the selection state machine. Use `slop scene click <id> --os` when `scene selected` doesn't update.
+- Google Docs canvas rendering means visual assertions must go through `slop scene text` (reads) or the canvas-tile `render` (pixels).
+- Google Slides filmstrip thumbnails filter synthetic clicks and synthetic keys. Always use hash navigation for `slideGoto`.
+
+## Recording Sessions
+
+The `slop monitor` family records every real user click, keystroke, form change, navigation, DOM mutation, and the network calls each action triggered — then exports the trace as either a pretty timeline or a runnable `slop` replay script. No CDP. No infobanner.
+
+```bash
+slop monitor start                              # Begin recording on the active slop tab
+slop monitor start --instruction "..."          # Annotate with task intent
+slop monitor stop                               # End recording, print summary
+slop monitor status                             # Active session(s)
+slop monitor pause                              # Stop emitting without ending
+slop monitor resume                             # Resume a paused session
+slop monitor list                               # All sessions in the event log
+slop monitor tail [--raw]                       # Live tail of the current session
+slop monitor export <sessionId>                 # Aligned text rendering
+slop monitor export <sessionId> --json          # Raw JSONL
+slop monitor export <sessionId> --plan          # Replay script (slop ... lines)
+```
+
+Event records are sparse — short keys (`t`, `s`, `k`, `sid`, `ref`, `r`, `n`, `v`, `cause`) so a 30-minute session reads in a few KB. User actions get a session-monotonic `seq`; mutations and network calls fired within 500ms of an action carry `cause: <seq>`. Real user events have `tr: true`; slop's own synthetic clicks have `tr: false` so the replay-plan generator can ignore them.
+
+The replay plan uses semantic selectors that survive DOM churn:
+```
+slop tab new "https://example.com/"
+slop wait-stable
+slop click "button:Search"
+slop type "textbox:Query" "bun docs"
+slop keys "Enter"
+slop wait-stable
+```
+
+When the user runs the replay, slop's `find_and_click` / `find_and_type` re-resolves each selector against the live DOM — no stale ref problems.
+
+The monitor stores sessions in `/tmp/slop-browser-events.jsonl` (the same file `slop events` already tails). Sessions are delimited by `mon_start` / `mon_stop` events with the same `sid`. Multiple sessions coexist historically and `slop monitor list` shows them all.
+
 ## Screenshots
 
 ```bash
@@ -197,13 +266,58 @@ slop text                              # Read results
 slop tab close
 ```
 
+### Read and write a Google Doc
+```bash
+slop tab new "https://docs.google.com/document/d/<id>/edit"
+sleep 5
+slop scene profile                     # → google-docs
+slop scene text                        # Full document text (from hidden iframe mirror)
+slop scene text --with-html            # Include inline HTML + data-ri offsets
+slop scene insert "hello from slop"    # Insert at cursor position
+slop keys "Meta+z"                     # Undo the insert (execCommand writes are undoable)
+```
+
+### Navigate a Google Slides deck
+```bash
+slop tab new "https://docs.google.com/presentation/d/<id>/edit"
+sleep 6
+slop scene slide list                  # Every slide with stable IDs + blob URLs
+slop scene slide goto 5                # Navigate via URL fragment (synthetic clicks/keys do not work)
+slop scene slide current               # Verify new index
+slop scene notes                       # Read speaker notes
+slop scene render <slide-id> --save    # Save slide as PNG
+```
+
+### Hit Canva objects by stable layer ID
+```bash
+slop tab new "https://www.canva.com/design/<id>/edit"
+sleep 6
+slop scene profile                     # → canva
+slop scene list --type shape           # Every LB layer classified as a shape
+slop scene hit 537,516                 # Identify what's at a viewport coordinate
+slop scene click LBKfjtRwQHt7D0Cf      # Click by stable id
+slop scene zoom                        # Current editor zoom factor
+```
+
+### Record a user session and replay it
+```bash
+slop monitor start --instruction "search for bun docs, open first result"
+# ... user interacts for 30–60 seconds ...
+slop monitor stop                      # Summary: evt / mut / net / nav counts + duration
+slop monitor list                      # All sessions in /tmp/slop-browser-events.jsonl
+slop monitor export <sessionId>        # Pretty-aligned timeline
+slop monitor export <sessionId> --plan # Replayable script (one slop cmd per line)
+```
+
 ## What NOT to Do
 
-- Don't use screenshots to understand pages — use `slop tree` and `slop text`
+- Don't use screenshots to understand pages — use `slop tree`, `slop text`, or `slop scene list` / `slop scene text`
 - Don't start the daemon manually — it auto-starts on first command
 - Don't chain commands without `sleep` — the extension needs time to process
 - Don't interact with tabs outside the slop group without `--any-tab`
 - Don't use `slop network on` (CDP) unless you specifically need raw debugger capture — it shows a yellow bar and can be detected
+- Don't confuse `slop canvas` (HTMLCanvasElement pixel access — `list` / `read` / `diff`) with `slop scene` (DOM / SVG / iframe scene-graph access in visual editors)
+- Don't synthetic-click Google Slides filmstrip thumbnails — use `slop scene slide goto <n>` which navigates via the URL fragment
 
 ## Reference
 
@@ -213,12 +327,18 @@ Run `slop help` for the complete command list. Key commands not covered above:
 slop cookies example.com              # List cookies for domain
 slop storage                          # Read localStorage
 slop eval "document.title"            # Run JS (isolated world)
-slop eval "window.foo" --main         # Run JS (page context)
+slop eval "window.foo" --main         # Run JS (page context, awaits promises)
+slop eval --main "fetch(url).then(r => r.json())"  # Async eval returns resolved value
 slop history "search"                 # Search browser history
 slop bookmarks "query"                # Search bookmarks
 slop batch '[{"type":"click","ref":"e5"},{"type":"wait","ms":500}]'  # Batch actions
 slop status                           # Daemon status (local check)
+slop canvas list                      # Discover HTMLCanvasElement nodes (NOT `slop scene`)
+slop canvas read 0 --format png       # Read canvas bytes as data URL
+slop canvas diff a.png b.png          # Pixel diff between two images
 ```
+
+For deeper notes, see `Notes/monitor.md` and `Notes/scene.md` in this repo.
 
 ---
 

--- a/Notes/monitor.md
+++ b/Notes/monitor.md
@@ -1,0 +1,180 @@
+# Monitor — Session Recording for Agent Replay
+
+## What it does
+
+`slop monitor` records a full trace of a browser session so an agent can read it back and replay it. It observes:
+
+- **User input:** clicks, double-clicks, right-clicks, keystrokes, form inputs, submits, focus/blur, copy/paste, throttled scroll.
+- **DOM mutations:** batched 50ms windows, collapsed per user action.
+- **Network:** every `fetch()` and `XMLHttpRequest` (via the existing `__slop_net` inject-script pipeline) tagged with the user action that caused it.
+- **Navigation:** hard nav, `history.pushState`, reference-fragment updates, and reload (via `chrome.webNavigation.onCommitted` and `onHistoryStateUpdated` — no CDP).
+
+The monitor writes to `/tmp/slop-browser-events.jsonl` alongside slop's existing RPC event stream. Sessions are delimited by `mon_start` / `mon_stop` records that share a common `sid`.
+
+## Non-goals
+
+- Recording video or screenshots — see `slop screenshot` if you need visuals.
+- Perfect causality between synchronous JS stack frames — the monitor uses a 500ms time window to attribute side effects to user actions. Good enough for replay; not good enough for profiling.
+- Recording the agent's own synthetic clicks as "user" input — real events have `tr: true`, synthetic `dispatchClickSequence` events have `tr: false`. The replay plan generator only replays `tr: true` events.
+
+## Manual smoke test (5 minutes)
+
+This assumes you have slop built and loaded, and a Chrome/Brave window with the slop-browser extension running.
+
+### 1. Rebuild and reload the extension
+
+```bash
+bash scripts/build.sh
+```
+
+In Chrome: open `brave://extensions/` (or `chrome://extensions/`), find slop-browser, click the reload icon. Or run:
+```bash
+slop reload
+```
+
+### 2. Open a test page
+
+```bash
+slop tab new "https://duckduckgo.com/"
+sleep 2
+```
+
+### 3. Start a recording
+
+```bash
+slop monitor start --instruction "search for 'bun runtime' and click the first result"
+```
+
+Expected output:
+```
+monitor started
+  sessionId: 7f3e2c1a-...
+  tabId:     123456789
+  url:       https://duckduckgo.com/
+  instruction: search for 'bun runtime' and click the first result
+```
+
+### 4. Interact with the page manually
+
+Click into the search box. Type `bun runtime`. Press Enter. Click the first result.
+
+### 5. Watch the live tail in another terminal (optional)
+
+```bash
+slop monitor tail
+```
+
+You should see lines like:
+
+```
+[+1.820]  input     e17  textbox "Search"                v="bun runtime"
+[+2.156]  key       "Enter"
+[+2.201]  mut       +8 -2 attr:4                          (cause: #2)
+[+2.289]  fetch     GET /ac/ 200 1.2k                     (cause: #2)
+[+2.412]  nav       history → /?q=bun+runtime             (cause: #2)
+[+2.887]  mut       +37 -4 attr:12 tgts:e42,e43,e44       (cause: #2)
+[+4.012]  click     e42  link    "bun.sh"                 (1021,512) trusted
+[+4.045]  nav       hard → https://bun.sh/
+```
+
+### 6. Stop the recording
+
+```bash
+slop monitor stop
+```
+
+Expected:
+```
+monitor stopped
+  sessionId: 7f3e2c1a-...
+  duration:  5.2s
+  events:    18
+  mutations: 4
+  network:   3
+  nav:       2
+```
+
+### 7. Inspect the session
+
+List all sessions in the log:
+```bash
+slop monitor list
+```
+
+Render the one you just made:
+```bash
+slop monitor export 7f3e2c1a-...
+```
+
+Emit a replay plan:
+```bash
+slop monitor export 7f3e2c1a-... --plan
+```
+
+Expected plan output:
+```
+# Replay plan for session 7f3e2c1a-...
+# Instruction: search for 'bun runtime' and click the first result
+# Started at: 2026-04-07T12:44:32.123Z
+
+slop tab new "https://duckduckgo.com/"
+slop wait-stable
+slop click "textbox:Search"
+slop type "textbox:Search" "bun runtime"
+slop keys "Enter"
+slop wait-stable
+# slop net log --filter "/ac/" --limit 1
+slop click "link:bun.sh"
+slop wait-stable
+```
+
+### 8. Replay it
+
+Manually pipe the plan's `slop` lines into a shell, or save to a file and run line-by-line. The existing `slop batch` command accepts JSON arrays of raw actions but the plan output is shell commands by design (readable by humans, auditable before execution).
+
+## Troubleshooting
+
+### "no active monitor session on tab N"
+Either the monitor was never started on that tab, or the tab was closed and its session was auto-ended with reason `tab_closed`. Check:
+```bash
+slop monitor status --all
+```
+
+### The tail shows nothing
+Check that the extension is loaded and the content script actually received `monitor_arm`. Force a reload:
+```bash
+slop reload
+slop monitor stop
+slop monitor start
+```
+
+### Events look out of order
+The monitor assigns `seq` monotonically per-session inside the background service worker, but messages from content scripts in multiple frames may arrive at the background in an order slightly different from their local timestamps. The `t` (wall-clock ms) field is the ground truth — `slop monitor export` sorts by `t` before rendering.
+
+### Passwords are showing up in the log
+They shouldn't be. `input[type=password]` values are masked to `***<length>***` unconditionally before the event is emitted. If you see a plaintext password in a `k:input` event, file a bug — the site probably uses `type=text` with a custom masking widget, which is a different leak class. Mitigation: use `slop monitor pause` while entering secrets.
+
+### Custom credit-card fields leak
+The monitor also masks any input whose `autocomplete` attribute starts with `cc-` or whose `name`/`id` matches `/card|cvv|credit/i`. Anything outside those heuristics will leak its value. When in doubt, `slop monitor pause`.
+
+## File layout
+
+- `extension/src/content/monitor.ts` — capture-phase listeners, mutation batcher, `__slop_net` subscriber, content-side message handlers (`monitor_arm`, `monitor_disarm`), `emit()` helper.
+- `extension/src/background/capabilities/monitor.ts` — session map, `handleMonitorActions` entry point, `chrome.runtime.onMessage` listener for `mon_evt` messages, `chrome.webNavigation` listeners for nav attribution, `chrome.tabs.onRemoved` for tab-close detection.
+- `cli/commands/monitor.ts` — `parseMonitorCommand`, local `tail`/`list`/`export` handlers, pretty-text renderer, `--plan` generator.
+- `daemon/index.ts` — no logic change. The existing `{type:"event"}` path in `handleNativeMessage` already appends to `EVENTS_PATH`; a 3-line fix routes the same messages through the ws fallback channel.
+
+## How correlation works
+
+Every user-action event pushes `{seq, t}` onto an in-frame ring buffer (cap 16). When a `mut` batch flushes or a `__slop_net` event arrives, the emitter walks the ring backward looking for the most recent user action within 500 ms — that's the `cause`. If no action is in-window, `cause` is omitted and the event is autonomous (polling, timer, etc.).
+
+This is intentionally a heuristic. It can be wrong in two directions:
+- A network call fired by `setTimeout(..., 400)` after a click will be attributed to the click. Usually fine — it IS a consequence of the click.
+- A network call fired more than 500 ms after a click is marked autonomous even if the click caused it (async chain with delays). Tighten or loosen the window in `monitor.ts` `CAUSE_WINDOW_MS` if your workflow needs it.
+
+## Limits
+
+- **10 MB log rotation.** The daemon keeps the tail half when the file exceeds 10 MB. A long session can be truncated — `slop monitor list` will still see the `mon_start` / `mon_stop` pair if both survive the rotation.
+- **Cross-origin iframes** that block content script injection are invisible to the monitor. This matches the existing `slop tree` / `slop net log` behavior.
+- **`os_click` events** generated by `slop click --os` produce real OS-level mouse events. To the monitor they look identical to human clicks (`tr: true`). Cross-reference against the `request_received` log in the same event file to distinguish.
+- **Hard cross-origin navigation** resets the content script's local `seq` counter to 0. The background assigns a global `seq` when relaying events, so the exported log is still monotonically increasing.

--- a/Notes/scene.md
+++ b/Notes/scene.md
@@ -1,0 +1,124 @@
+# `slop scene` — Scene-Graph Access
+
+## What it is
+
+`slop scene` is a profile-driven command surface for reading and manipulating objects inside DOM-rendered visual editors — **without CDP, without screenshots, without vision models**.
+
+The key insight: most editors that look like they render to `<canvas>` actually maintain a shadow DOM (Canva), SVG scene graph (Google Slides), or hidden text-mirror iframe (Google Docs) that an agent can address directly. Each editor gets a **profile** — one file under `extension/src/content/scene/profiles/` — that knows how to enumerate, click, read, and write its scene objects.
+
+## Supported profiles (today)
+
+| Profile | Host | Path match | What works |
+|---|---|---|---|
+| `canva` | `canva.com` | `/design/*` | `list`, `click`, `selected`, `zoom`, `hit` |
+| `google-docs` | `docs.google.com` | `/document/*` | `text`, `text --with-html`, `insert`, `list` (pages + embeds), `render` |
+| `google-slides` | `docs.google.com` | `/presentation/*` | `list` (slides), `slide current/goto/list`, `notes`, `render`, `text` (in edit mode) |
+| `generic` | fallback | any | `list` (role=application/main/document), `selected` |
+
+## Command surface
+
+```
+slop scene profile [--verbose]           Detect active profile + capabilities
+slop scene list [--type <t>]             Enumerate scene objects
+slop scene click <id> [--os]             Click by stable id
+slop scene dblclick <id>                 Double-click
+slop scene hit <x>,<y>                   What scene object is at viewport X,Y
+slop scene selected                      Read current selection
+slop scene zoom                          Read editor zoom factor
+
+slop scene text [--with-html]            Read document text (Docs hidden iframe mirror)
+slop scene insert "<text>"               Insert text at cursor (Docs execCommand insertText)
+slop scene cursor <x>,<y>                Move cursor by clicking on the canvas tile
+
+slop scene slide list                    List all slides
+slop scene slide current                 Show current slide
+slop scene slide goto <n>                Navigate via URL fragment
+slop scene slide <n>                     Shorthand
+slop scene notes [--slide <n>]           Read speaker notes
+
+slop scene render <id> [--save]          Render scene object to PNG
+slop scene ... --profile <name>          Force a profile
+```
+
+## Manual smoke test
+
+### Canva
+
+```bash
+slop tab new "https://www.canva.com/design/<docId>/edit"
+sleep 8
+slop scene profile                       # → canva
+slop scene list                          # → array of LB… layer objects
+slop scene zoom                          # → 0.x (editor zoom factor)
+slop scene click LB<id>                  # dispatches click at viewport center
+slop scene selected                      # reads [role=application] aria-label
+```
+
+Known limitation: Canva's selection machine sometimes requires prior interactive warmup. If `scene selected` doesn't update after a scene click, re-run with `--os` to force a CGEvent trusted click.
+
+### Google Docs
+
+```bash
+slop tab new "https://docs.google.com/document/d/<docId>/edit"
+sleep 8
+slop scene profile                       # → google-docs
+slop scene text                          # full document text (textContent)
+slop scene text --with-html              # includes HTML + data-ri offsets
+slop scene insert "hello from slop"      # insert at cursor
+slop scene text                          # verify the insert landed
+slop keys Meta+z                         # undo the insert
+slop scene render page-0 --save          # renders a canvas tile PNG
+```
+
+### Google Slides
+
+```bash
+slop tab new "https://docs.google.com/presentation/d/<docId>/edit"
+sleep 8
+slop scene profile                       # → google-slides
+slop scene slide list                    # all slides with blob URLs
+slop scene slide goto 5                  # navigate (URL-hash method)
+slop scene slide current                 # → index 5
+slop scene notes                         # speaker notes of current slide
+slop scene render filmstrip-slide-5-gd<hash>_0_12
+```
+
+Known limitation: Slides filmstrip thumbnails filter synthetic clicks AND synthetic keys. `slideGoto` uses URL-hash navigation instead. Slide content text (`scene text`) only appears when a text box is actively being edited — the hidden iframe is empty in view mode.
+
+## Adding a new profile
+
+1. Create `extension/src/content/scene/profiles/<name>.ts`:
+    ```ts
+    import type { SceneProfile } from "../types"
+    export const myProfile: SceneProfile = {
+      name: "my-editor",
+      detect() { return location.host.endsWith("myeditor.com") },
+      list() { /* enumerate addressable objects */ return [] },
+      resolve(id) { return document.getElementById(id) },
+      selected() { return { has: false } },
+      // add other capabilities as needed
+    }
+    ```
+2. Register the profile in `extension/src/content/scene/engine.ts`:
+    ```ts
+    import { myProfile } from "./profiles/my-editor"
+    // inside ensureBuiltins:
+    profiles.push(myProfile)
+    ```
+3. Rebuild (`bash scripts/build.sh`), reload the extension (`slop reload`), test.
+
+A profile only needs to implement the capabilities it supports. The engine returns actionable errors (`profile 'X' does not support Y()`) for missing methods.
+
+## Architecture notes (grounded evidence)
+
+- **Canva layer IDs** — Empirically observed on session 77907634 via `document.querySelectorAll('[id^="LB"]')`. 10 layers detected. Survived a full `slop navigate` reload. Format: `^LB[A-Za-z0-9_-]{14}$`.
+- **Docs text-mirror iframe** — Documented at `.docs-texteventtarget-iframe > [role=textbox]`. Confirmed via `iframe.contentDocument.querySelector('[role=textbox]').innerHTML` on session 20bcf316: full document HTML with `data-ri="<N>"` spans.
+- **Slides filmstrip pattern** — 12 slides on the SANS deck, IDs `filmstrip-slide-<index>-gd02e148143_0_<M>`. Real slide page IDs carried on `data-slide-page-id` attribute of `.punch-filmstrip-thumbnail` ancestor. URL fragment `#slide=id.<pageId>` is the authoritative navigation mechanism.
+- **Async eval prerequisite** — `chrome.scripting.executeScript` awaits promise return values natively, per `chrome-extensions/docs/extensions/reference/api/scripting.md` line 194. PRD-14 Phase 0 fixes slop's evaluate handler to preserve this semantic, which unlocks `scene render` for Slides (async `fetch` + `createImageBitmap` + `toDataURL`).
+
+## References
+
+- PRD-14 — full design + checklist in `prd/PRD-14.md`
+- `extension/src/content/scene/` — profile implementations
+- `cli/commands/scene.ts` — CLI parsing
+- `extension/src/background/capabilities/evaluate.ts` — Phase 0 async fix

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The daemon auto-starts on first command. No setup needed.
 
 **Passive Network** — All `fetch()` and `XMLHttpRequest` traffic on every page is captured automatically. No debugger, no infobanner. Query it with `slop net log`.
 
+**Scene Graph** — Profile-driven access to visual editors that don't render to the DOM normally: Canva, Google Docs, Google Slides. Enumerate objects by stable ID, click shapes, read full document text, navigate slide decks, render pages to PNG. `slop scene` — no CDP, no vision, no screenshots needed.
+
+**Session Monitor** — Record a user's real interactions (clicks, keystrokes, form changes, DOM mutations, network calls) as a sparse JSONL log that replays as a `slop` script. `slop monitor start` / `slop monitor stop` / `slop monitor export --plan`.
+
 **Stealth** — Passes all major bot detection: BrowserScan (Normal), Pixelscan ("Definitely Human"), Sannysoft (all pass), CreepJS (0% headless), Fingerprint.com (notDetected), AreyouHeadless (not headless). Zero automation fingerprint.
 
 ## Commands
@@ -104,6 +108,70 @@ slop raw '{"type":"net_override_set","rules":[{"urlPattern":"*eventAttending*","
 
 # Clear all overrides
 slop raw '{"type":"net_override_clear"}'
+```
+
+### Scene Graph (Canva, Google Docs, Google Slides)
+Read and manipulate visual editors whose "canvas" is actually a DOM / SVG / hidden-iframe structure. No CDP, no debugger, no detection risk. Profile-driven — each editor has its own detection and capability set. Works today on canva.com/design/, docs.google.com/document/, and docs.google.com/presentation/.
+
+```bash
+slop scene profile                     # Detect active editor profile
+slop scene profile --verbose           # Include capabilities list
+slop scene list                        # Enumerate scene objects on current page
+slop scene list --type shape           # Filter by type (image|shape|text|page|slide|embed)
+slop scene click <id>                  # Click a scene object by stable id (Canva: LBxxxxxxxxxxxxxx)
+slop scene dblclick <id>               # Double-click to enter text edit
+slop scene hit <x>,<y>                 # Identify the scene object at viewport coordinates
+slop scene selected                    # Read current selection (host-aware)
+slop scene zoom                        # Read editor zoom factor
+
+slop scene text                        # Read full document text (Google Docs hidden iframe mirror)
+slop scene text --with-html            # Include inline HTML with data-ri offsets
+slop scene insert "<text>"             # Insert text at cursor position (Google Docs)
+
+slop scene slide list                  # List all slides in a Google Slides deck
+slop scene slide current               # Show current slide index and id
+slop scene slide goto <n>              # Navigate to slide <n> (URL fragment method)
+slop scene slide <n>                   # Shorthand for slide goto <n>
+slop scene notes                       # Read speaker notes of current slide
+
+slop scene render <id>                 # Render a scene object as PNG data URL
+slop scene render <id> --save          # Save the PNG to disk
+```
+
+**How it works per editor:**
+
+- **Canva**: every object on the canvas is a `<div id="LB…">` with `style.transform: translate(x, y)` and `style.width/height`. The IDs are stable per-document (they survive page reloads). `scene list` enumerates them; `scene click` computes the viewport center from `getBoundingClientRect()` and dispatches a click through `elementFromPoint`.
+- **Google Docs**: the page is rendered to `<canvas>` but the full document HTML lives inside a hidden iframe at `.docs-texteventtarget-iframe > [role=textbox]`, complete with `<p>` / `<span>` elements carrying `data-ri` range-index offsets. `scene text` reads it, `scene insert` writes via `document.execCommand('insertText')` on the iframe's contenteditable.
+- **Google Slides**: each slide is a SVG `<g id="filmstrip-slide-N-gd…">` with a pre-rendered PNG blob URL on the child `<image>`. The real slide-navigation page ID lives on the `data-slide-page-id` attribute of the parent `.punch-filmstrip-thumbnail`. `scene slide goto` navigates by setting `window.location.hash = "#slide=id." + pageId`.
+
+### Recording (Session Monitor)
+Record every real user click, keystroke, form change, navigation, DOM mutation, and the network calls each action triggered — then export the trace as either a pretty timeline or a runnable `slop` replay script. No CDP, no infobanner, no detection.
+
+```bash
+slop monitor start                              # Begin recording on the active slop tab
+slop monitor start --instruction "..."          # Annotate with task intent
+slop monitor stop                               # End recording, print summary
+slop monitor status                             # Show active session(s)
+slop monitor pause                              # Stop emitting events without ending
+slop monitor resume                             # Resume a paused session
+slop monitor list                               # All sessions in the event log
+slop monitor tail                               # Live tail current session (pretty)
+slop monitor tail --raw                         # Live tail (raw JSONL)
+slop monitor export <sessionId>                 # Aligned text rendering
+slop monitor export <sessionId> --json          # Raw JSONL for that session
+slop monitor export <sessionId> --plan          # Emit slop ... replay script
+```
+
+Each event line is sparse JSON (short keys: `t`, `s`, `k`, `sid`, `ref`, `r`, `n`, `cause`) so an agent can read a 30-minute session in a few KB. User actions get a session-monotonic `seq`; mutations and network calls fired within 500ms of an action carry `cause: <action_seq>`. Real user events have `tr: true`; slop's own synthetic clicks have `tr: false` so the replay generator can ignore them.
+
+The replay script uses the existing semantic-selector path:
+```
+slop tab new "https://example.com/"
+slop wait-stable
+slop click "button:Search"
+slop type "textbox:Query" "bun docs"
+slop keys "Enter"
+slop wait-stable
 ```
 
 ### Screenshots
@@ -226,6 +294,57 @@ sleep 2
 slop tree
 slop click e5 --os                     # OS-level CGEvent click (genuinely trusted)
 slop type e3 "text" --os               # OS-level keystrokes
+```
+
+### Read a Google Doc programmatically
+```bash
+slop tab new "https://docs.google.com/document/d/<id>/edit"
+sleep 5
+slop scene profile                     # -> google-docs
+slop scene text                        # Full document text from hidden iframe mirror
+slop scene text --with-html            # Full HTML model with data-ri offsets
+slop scene insert "new paragraph at cursor"
+slop keys "Meta+z"                     # Undo the insert
+```
+
+### Manipulate a Canva design
+```bash
+slop tab new "https://www.canva.com/design/<id>/edit"
+sleep 6
+slop scene profile                     # -> canva
+slop scene list --type shape           # Every LB layer that's a shape
+slop scene zoom                        # Current editor zoom factor
+slop scene hit 537,516                 # What's at this viewport coord?
+slop scene click LBKfjtRwQHt7D0Cf      # Click a layer by stable id
+```
+
+### Navigate and render Google Slides
+```bash
+slop tab new "https://docs.google.com/presentation/d/<id>/edit"
+sleep 6
+slop scene slide list                  # All slides with stable IDs + blob URLs
+slop scene slide goto 5                # Navigate via URL fragment
+slop scene slide current               # Verify index 5 is now active
+slop scene notes                       # Read speaker notes for current slide
+slop scene render filmstrip-slide-3-gd02e148143_0_6 --save  # PNG of slide 3
+```
+
+### Record a user session and replay it
+```bash
+# With Ron at the keyboard:
+slop monitor start --instruction "search bun docs, open first result, copy paragraph"
+# ... Ron interacts for 60 seconds ...
+slop monitor stop                      # Prints session summary
+slop monitor list                      # Shows all historical sessions
+slop monitor export <sessionId>        # Aligned text rendering
+slop monitor export <sessionId> --plan # Replayable script of slop commands
+```
+
+### Diff canvas pixels between two renders (the OTHER `slop canvas`)
+```bash
+slop canvas list                       # Discover <canvas> elements (HTMLCanvasElement)
+slop canvas read 0 --format png        # Read canvas as data URL
+slop canvas diff url1.png url2.png     # Pixel diff between images
 ```
 
 ## What NOT to Do

--- a/cli/commands/monitor.ts
+++ b/cli/commands/monitor.ts
@@ -1,0 +1,503 @@
+/**
+ * cli/commands/monitor.ts — slop monitor start/stop/status/pause/resume/tail/list/export
+ *
+ * Subcommands that hit the daemon return an Action object.
+ * Subcommands that read EVENTS_PATH directly (tail, list, export) return null
+ * after handling their own output, matching the pattern in cli/commands/meta.ts case "events".
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { EVENTS_PATH } from "../../shared/platform"
+
+type Action = { type: string; [key: string]: unknown }
+
+interface MonEvent {
+  timestamp?: string
+  event?: string
+  sid?: string
+  s?: number
+  t?: number
+  tid?: number
+  url?: string
+  ins?: string
+  ref?: string
+  r?: string
+  n?: string
+  tg?: string
+  x?: number
+  y?: number
+  v?: string
+  ic?: boolean
+  tr?: boolean
+  kc?: string
+  sx?: number
+  sy?: number
+  c?: number
+  add?: number
+  rem?: number
+  attr?: number
+  txt?: number
+  tgts?: string[]
+  u?: string
+  m?: string
+  st?: number
+  bz?: number
+  ct?: string
+  typ?: string
+  cause?: number
+  evt?: number
+  mut?: number
+  net?: number
+  nav?: number
+  dur?: number
+  reason?: string
+  fid?: number
+  [key: string]: unknown
+}
+
+const MON_KINDS = new Set([
+  "mon_start", "mon_stop", "mon_pause", "mon_resume",
+  "click", "dblclick", "rclick", "input", "change", "submit",
+  "key", "scroll", "focus", "blur", "copy", "paste",
+  "mut", "fetch", "xhr", "nav", "reload", "error"
+])
+
+function flagValue(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag)
+  if (i === -1) return undefined
+  return args[i + 1]
+}
+
+function flagPresent(args: string[], flag: string): boolean {
+  return args.indexOf(flag) !== -1
+}
+
+export function readMonEvents(filterSid?: string): MonEvent[] {
+  if (!existsSync(EVENTS_PATH)) return []
+  const content = readFileSync(EVENTS_PATH, "utf-8")
+  if (!content.trim()) return []
+  const out: MonEvent[] = []
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue
+    try {
+      const ev = JSON.parse(line) as MonEvent
+      if (!ev.event || !MON_KINDS.has(ev.event)) continue
+      if (filterSid && ev.sid !== filterSid) continue
+      out.push(ev)
+    } catch {}
+  }
+  return out
+}
+
+export function listSessions(): Array<{
+  sid: string; tid?: number; url?: string; ins?: string;
+  startedAt: number; endedAt?: number; evt: number; mut: number;
+  net: number; dur?: number; status: "active" | "stopped"
+}> {
+  const events = readMonEvents()
+  const map = new Map<string, ReturnType<typeof listSessions>[number]>()
+  for (const ev of events) {
+    if (!ev.sid) continue
+    let rec = map.get(ev.sid)
+    if (!rec) {
+      rec = {
+        sid: ev.sid,
+        tid: undefined,
+        url: undefined,
+        ins: undefined,
+        startedAt: ev.t || 0,
+        endedAt: undefined,
+        evt: 0,
+        mut: 0,
+        net: 0,
+        dur: undefined,
+        status: "active"
+      }
+      map.set(ev.sid, rec)
+    }
+    rec.evt += 1
+    if (ev.event === "mut") rec.mut += 1
+    if (ev.event === "fetch" || ev.event === "xhr") rec.net += 1
+    if (ev.event === "mon_start") {
+      rec.startedAt = ev.t || rec.startedAt
+      rec.tid = ev.tid
+      rec.url = ev.url
+      rec.ins = ev.ins
+    }
+    if (ev.event === "mon_stop") {
+      rec.endedAt = ev.t
+      rec.dur = ev.dur
+      rec.status = "stopped"
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.startedAt - b.startedAt)
+}
+
+function pad(s: string, w: number, right = false): string {
+  if (s.length >= w) return s
+  const fill = " ".repeat(w - s.length)
+  return right ? fill + s : s + fill
+}
+
+function relSeconds(t: number, base: number): string {
+  const d = (t - base) / 1000
+  const sign = d >= 0 ? "+" : "-"
+  return `[${sign}${Math.abs(d).toFixed(3)}]`
+}
+
+function shortUrl(u: string): string {
+  try {
+    const parsed = new URL(u)
+    return parsed.pathname + parsed.search
+  } catch {
+    return u
+  }
+}
+
+export function renderEvent(ev: MonEvent, base: number): string {
+  const rel = relSeconds(ev.t || base, base)
+  const k = pad(ev.event || "?", 9)
+  switch (ev.event) {
+    case "mon_start":
+      return `  ${rel}  ${k}  ${ev.sid?.slice(0, 8) || ""}  tab ${ev.tid || ""}  ${ev.url || ""}${ev.ins ? `\n            instruction: ${ev.ins}` : ""}`
+    case "mon_stop":
+      return `  ${rel}  ${k}  reason=${ev.reason || "?"}  ${ev.evt}evt ${ev.mut}mut ${ev.net}net ${ev.nav || 0}nav  ${((ev.dur || 0) / 1000).toFixed(3)}s`
+    case "mon_pause":
+    case "mon_resume":
+      return `  ${rel}  ${k}`
+    case "click":
+    case "dblclick":
+    case "rclick": {
+      const trusted = ev.tr === false ? " synthetic" : ""
+      const ref = ev.ref ? pad(ev.ref, 5) : pad("?", 5)
+      const role = pad(ev.r || ev.tg || "?", 10)
+      const name = ev.n ? `"${ev.n}"` : ""
+      const at = ev.x !== undefined && ev.y !== undefined ? `(${ev.x},${ev.y})` : ""
+      return `  ${rel}  ${k}  ${ref} ${role} ${name}  ${at}${trusted}`
+    }
+    case "input":
+    case "change": {
+      const ref = ev.ref ? pad(ev.ref, 5) : pad("?", 5)
+      const role = pad(ev.r || ev.tg || "?", 10)
+      const name = ev.n ? `"${ev.n}"` : ""
+      const val = ev.v !== undefined ? `v="${ev.v}"` : ""
+      return `  ${rel}  ${k}  ${ref} ${role} ${name}  ${val}`
+    }
+    case "key":
+      return `  ${rel}  ${k}  ${ev.kc || "?"}${ev.ref ? `  ${ev.ref}` : ""}`
+    case "scroll":
+      return `  ${rel}  ${k}  dx=${ev.sx || 0} dy=${ev.sy || 0}`
+    case "focus":
+    case "blur":
+      return `  ${rel}  ${k}  ${ev.ref || "?"}  ${ev.r || ""}  ${ev.n ? `"${ev.n}"` : ""}`
+    case "copy":
+    case "paste":
+      return `  ${rel}  ${k}  ${ev.ref || "?"}`
+    case "submit":
+      return `  ${rel}  ${k}  ${ev.ref || "?"}  ${ev.n ? `"${ev.n}"` : ""}`
+    case "mut": {
+      const cause = ev.cause !== undefined ? `(cause: #${ev.cause})` : "(autonomous)"
+      const counts = `+${ev.add || 0} -${ev.rem || 0} attr:${ev.attr || 0}${ev.txt ? ` txt:${ev.txt}` : ""}`
+      return `  ${rel}  ${k}  ${counts}  ${cause}`
+    }
+    case "fetch":
+    case "xhr": {
+      const cause = ev.cause !== undefined ? `(cause: #${ev.cause})` : "(autonomous)"
+      const u = ev.u ? shortUrl(ev.u) : "?"
+      const sz = ev.bz ? `${(ev.bz / 1024).toFixed(1)}kB` : ""
+      return `  ${rel}  ${k}  ${ev.m || "GET"} ${u} ${ev.st || 0}  ${sz}  ${cause}`
+    }
+    case "nav": {
+      const cause = ev.cause !== undefined ? `(cause: #${ev.cause})` : ""
+      const u = ev.u ? shortUrl(ev.u) : "?"
+      return `  ${rel}  ${k}  ${ev.typ || "?"} \u2192 ${u}  ${cause}`
+    }
+    default:
+      return `  ${rel}  ${k}  ${JSON.stringify(ev).slice(0, 200)}`
+  }
+}
+
+export function renderSession(sid: string): string {
+  const events = readMonEvents(sid)
+  if (events.length === 0) return `(no events for session ${sid})`
+  const start = events.find((e) => e.event === "mon_start")
+  const stop = events.find((e) => e.event === "mon_stop")
+  const base = start?.t || events[0].t || 0
+  const lines: string[] = []
+  const startedAt = start?.t ? new Date(start.t).toISOString().replace("T", " ").slice(0, 19) : "?"
+  lines.push(`session ${sid}  started ${startedAt}  tab ${start?.tid || "?"}  ${start?.url || ""}`)
+  if (start?.ins) lines.push(`  instruction: ${start.ins}`)
+  if (stop) lines.push(`  ended after ${((stop.dur || 0) / 1000).toFixed(3)}s  ${stop.evt}evt ${stop.mut}mut ${stop.net}net`)
+  else lines.push(`  status: active`)
+  lines.push("")
+  for (const ev of events) {
+    if (ev.event === "mon_start" || ev.event === "mon_stop") continue
+    lines.push(renderEvent(ev, base))
+  }
+  return lines.join("\n")
+}
+
+export function escapeArg(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+export function buildPlan(sid: string): string {
+  const events = readMonEvents(sid)
+  if (events.length === 0) return `# (no events for session ${sid})`
+  const start = events.find((e) => e.event === "mon_start")
+  const lines: string[] = []
+  lines.push(`# Replay plan for session ${sid}`)
+  if (start?.ins) lines.push(`# Instruction: ${start.ins}`)
+  lines.push(`# Generated at ${new Date().toISOString()}`)
+  lines.push("")
+
+  if (start?.url) {
+    lines.push(`slop tab new "${escapeArg(start.url)}"`)
+    lines.push(`slop wait-stable`)
+  }
+
+  type IndexedEvent = { ev: MonEvent; idx: number }
+  const evList: IndexedEvent[] = events.map((ev, idx) => ({ ev, idx }))
+
+  function nextMutBetween(fromIdx: number, untilIdx: number): boolean {
+    for (let i = fromIdx + 1; i < untilIdx; i++) {
+      if (evList[i].ev.event === "mut") return true
+    }
+    return false
+  }
+
+  function nextActionIdx(fromIdx: number): number {
+    for (let i = fromIdx + 1; i < evList.length; i++) {
+      const k = evList[i].ev.event
+      if (k === "click" || k === "dblclick" || k === "rclick" || k === "input" || k === "change" || k === "key" || k === "submit") return i
+    }
+    return evList.length
+  }
+
+  for (let i = 0; i < evList.length; i++) {
+    const { ev } = evList[i]
+    const k = ev.event
+    if (k === "mon_start" || k === "mon_stop" || k === "mon_pause" || k === "mon_resume") continue
+    if (k === "scroll" || k === "focus" || k === "blur") continue
+    if (ev.tr === false) {
+      lines.push(`# skipped synthetic ${k} (slop-injected)`)
+      continue
+    }
+    switch (k) {
+      case "click":
+      case "dblclick":
+      case "rclick": {
+        const role = ev.r || ev.tg || ""
+        const name = ev.n || ""
+        if (role && name) {
+          const cmd = k === "click" ? "click" : k === "dblclick" ? "dblclick" : "rightclick"
+          lines.push(`slop ${cmd} "${escapeArg(role)}:${escapeArg(name)}"`)
+        } else if (ev.ref) {
+          const cmd = k === "click" ? "click" : k === "dblclick" ? "dblclick" : "rightclick"
+          lines.push(`# ref ${ev.ref} (no accessible name) — falling back to ref id, may be stale`)
+          lines.push(`slop ${cmd} ${ev.ref}`)
+        } else {
+          lines.push(`# ${k} with no ref or name — skipped`)
+        }
+        break
+      }
+      case "input":
+      case "change": {
+        const role = ev.r || ev.tg || ""
+        const name = ev.n || ""
+        if (typeof ev.v === "string" && ev.v.startsWith("***") && ev.v.endsWith("***")) {
+          lines.push(`# TODO: type into ${role}:${name} — original value was masked (length ${ev.v.length - 6})`)
+          break
+        }
+        const value = (ev.v as string) || ""
+        if (role && name) {
+          lines.push(`slop type "${escapeArg(role)}:${escapeArg(name)}" "${escapeArg(value)}"`)
+        } else if (ev.ref) {
+          lines.push(`# ref ${ev.ref} (no accessible name)`)
+          lines.push(`slop type ${ev.ref} "${escapeArg(value)}"`)
+        }
+        break
+      }
+      case "key":
+        if (ev.kc) lines.push(`slop keys "${escapeArg(ev.kc)}"`)
+        break
+      case "submit":
+        lines.push(`# form submit on ${ev.ref || "?"} (usually triggered by Enter or click — covered above)`)
+        break
+      case "mut":
+        // Mutation events become wait-stable hints, handled below
+        break
+      case "fetch":
+      case "xhr": {
+        if (ev.cause !== undefined) {
+          const u = ev.u ? shortUrl(ev.u) : ""
+          lines.push(`#   correlated ${k} ${ev.m || "GET"} ${u} ${ev.st || 0}  cause:#${ev.cause}`)
+          if (u) lines.push(`# slop net log --filter "${escapeArg(u)}" --limit 1`)
+        } else {
+          lines.push(`# autonomous ${k} ${ev.m || "GET"} ${ev.u || ""} (polling/timer)`)
+        }
+        break
+      }
+      case "nav": {
+        if (ev.typ === "hard" || ev.typ === "reload") {
+          if (ev.u) {
+            lines.push(`slop navigate "${escapeArg(ev.u)}"`)
+            lines.push(`slop wait-stable`)
+          }
+        } else {
+          lines.push(`# nav (${ev.typ}) -> ${ev.u || ""}  (caused by previous click)`)
+        }
+        break
+      }
+    }
+
+    // Insert wait-stable after this action if a mutation follows before the next action
+    const nextIdx = nextActionIdx(i)
+    if (nextMutBetween(i, nextIdx)) {
+      lines.push(`slop wait-stable`)
+    }
+  }
+
+  return lines.join("\n")
+}
+
+function withBodies(planText: string, sid: string): string {
+  // For v1, --with-bodies emits the same plan but expands every commented `slop net log` line
+  // into an actual `slop net log` invocation. The agent runs the plan and the net log entries
+  // surface inline. Bodies themselves live in the live tab's net-buffer (cap 500); if rotated,
+  // the agent will see (no entries) — same as the existing slop net log behavior.
+  return planText.replace(/^# slop net log /gm, "slop net log ")
+}
+
+export async function parseMonitorCommand(filtered: string[], jsonMode = false): Promise<Action | null> {
+  const sub = filtered[1]
+  if (!sub || sub === "help") {
+    console.log(MONITOR_HELP)
+    return null
+  }
+
+  switch (sub) {
+    case "start": {
+      const inst = flagValue(filtered, "--instruction")
+      const action: Action = { type: "monitor_start" }
+      if (inst) action.instruction = inst
+      return action
+    }
+    case "stop":
+      return { type: "monitor_stop" }
+    case "pause":
+      return { type: "monitor_pause" }
+    case "resume":
+      return { type: "monitor_resume" }
+    case "status":
+      return { type: "monitor_status" }
+
+    case "tail": {
+      const sidFilter = flagValue(filtered, "--session")
+      const raw = flagPresent(filtered, "--raw")
+      if (!existsSync(EVENTS_PATH)) {
+        console.log("(no events file yet — start a session first with: slop monitor start)")
+        return null
+      }
+      const proc = Bun.spawn(["tail", "-f", "-n", "0", EVENTS_PATH], { stdout: "pipe", stderr: "inherit" })
+      const reader = proc.stdout.getReader()
+      const decoder = new TextDecoder()
+      let buf = ""
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        let nl = buf.indexOf("\n")
+        while (nl !== -1) {
+          const line = buf.slice(0, nl)
+          buf = buf.slice(nl + 1)
+          nl = buf.indexOf("\n")
+          if (!line.trim()) continue
+          try {
+            const ev = JSON.parse(line) as MonEvent
+            if (!ev.event || !MON_KINDS.has(ev.event)) continue
+            if (sidFilter && ev.sid !== sidFilter) continue
+            if (raw || jsonMode) {
+              console.log(line)
+            } else {
+              const base = ev.t || 0
+              console.log(renderEvent(ev, base))
+            }
+          } catch {}
+        }
+      }
+      return null
+    }
+
+    case "list": {
+      const sessions = listSessions()
+      if (sessions.length === 0) {
+        console.log("(no monitor sessions found in event log)")
+        return null
+      }
+      if (jsonMode) {
+        console.log(JSON.stringify(sessions, null, 2))
+        return null
+      }
+      console.log(`${pad("session", 38)}${pad("status", 10)}${pad("started", 22)}${pad("tab", 12)}${pad("evt", 6)}${pad("mut", 6)}${pad("net", 6)}url`)
+      for (const s of sessions) {
+        const started = s.startedAt ? new Date(s.startedAt).toISOString().replace("T", " ").slice(0, 19) : "?"
+        const url = s.url ? shortUrl(s.url) : ""
+        console.log(`${pad(s.sid, 38)}${pad(s.status, 10)}${pad(started, 22)}${pad(String(s.tid || ""), 12)}${pad(String(s.evt), 6)}${pad(String(s.mut), 6)}${pad(String(s.net), 6)}${url}`)
+      }
+      return null
+    }
+
+    case "export": {
+      const sid = filtered[2]
+      if (!sid || sid.startsWith("--")) {
+        console.error("error: slop monitor export requires a sessionId. Use 'slop monitor list' to find one.")
+        process.exit(1)
+      }
+      const json = flagPresent(filtered, "--json")
+      const plan = flagPresent(filtered, "--plan")
+      const wb = flagPresent(filtered, "--with-bodies")
+      if (json) {
+        const events = readMonEvents(sid)
+        for (const ev of events) console.log(JSON.stringify(ev))
+        return null
+      }
+      if (plan) {
+        let text = buildPlan(sid)
+        if (wb) text = withBodies(text, sid)
+        console.log(text)
+        return null
+      }
+      console.log(renderSession(sid))
+      return null
+    }
+
+    default:
+      console.error(`error: unknown monitor subcommand '${sub}'. Try: start, stop, status, pause, resume, tail, list, export.`)
+      process.exit(1)
+  }
+}
+
+const MONITOR_HELP = `slop monitor — record user sessions for agent replay
+
+Usage:
+  slop monitor start [--instruction "<text>"]
+  slop monitor stop
+  slop monitor status
+  slop monitor pause
+  slop monitor resume
+  slop monitor tail [--session <sid>] [--raw]
+  slop monitor list
+  slop monitor export <sessionId> [--json|--plan] [--with-bodies]
+
+start    Begin recording on the active slop-group tab.
+stop     End the active session and emit a summary.
+status   Show active sessions and counts.
+pause    Pause emission temporarily (does not unhook listeners).
+resume   Resume emission.
+tail     Live tail of recorded events. Pretty by default; --raw for JSONL.
+list     List all sessions historically present in the event log.
+export   Render a session as text, JSON (--json), or replay plan (--plan).
+         --with-bodies turns commented 'slop net log' cues into live invocations.
+`

--- a/cli/commands/scene.ts
+++ b/cli/commands/scene.ts
@@ -1,0 +1,189 @@
+/**
+ * cli/commands/scene.ts — scene-graph access for DOM-rendered editors.
+ *
+ * User-facing command: `slop scene <sub>`
+ * Internal action types: `scene_*` (to avoid collision with existing HTML Canvas actions)
+ */
+
+type Action = { type: string; [key: string]: unknown }
+
+function flagValue(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag)
+  if (i === -1) return undefined
+  return args[i + 1]
+}
+
+function flagPresent(args: string[], flag: string): boolean {
+  return args.indexOf(flag) !== -1
+}
+
+function withProfile(action: Action, filtered: string[]): Action {
+  const profile = flagValue(filtered, "--profile")
+  if (profile) action.profile = profile
+  return action
+}
+
+export function parseSceneCommand(filtered: string[], jsonMode = false): Action | null {
+  const sub = filtered[1]
+  if (!sub || sub === "help") {
+    console.log(CANVAS_HELP)
+    return null
+  }
+
+  switch (sub) {
+    case "profile": {
+      const verbose = flagPresent(filtered, "--verbose")
+      return withProfile({ type: "scene_profile", verbose }, filtered)
+    }
+
+    case "list": {
+      const type = flagValue(filtered, "--type")
+      const a: Action = { type: "scene_list" }
+      if (type) a.filter = type
+      return withProfile(a, filtered)
+    }
+
+    case "click": {
+      const id = filtered[2]
+      if (!id) { console.error("error: slop scene click requires an element id"); process.exit(1) }
+      const useOs = flagPresent(filtered, "--os")
+      const a: Action = { type: "scene_click", id }
+      if (useOs) a.os = true
+      return withProfile(a, filtered)
+    }
+
+    case "dblclick": {
+      const id = filtered[2]
+      if (!id) { console.error("error: slop scene dblclick requires an element id"); process.exit(1) }
+      return withProfile({ type: "scene_dblclick", id }, filtered)
+    }
+
+    case "select": {
+      const id = filtered[2]
+      if (!id) { console.error("error: slop scene select requires an element id"); process.exit(1) }
+      return withProfile({ type: "scene_select", id }, filtered)
+    }
+
+    case "hit": {
+      const coords = filtered[2]?.split(",").map(Number)
+      if (!coords || coords.length !== 2 || coords.some(isNaN)) {
+        console.error("error: slop scene hit requires X,Y coordinates. Usage: slop scene hit 500,300")
+        process.exit(1)
+      }
+      return withProfile({ type: "scene_hit", x: coords[0], y: coords[1] }, filtered)
+    }
+
+    case "selected":
+      return withProfile({ type: "scene_selected" }, filtered)
+
+    case "text": {
+      const withHtml = flagPresent(filtered, "--with-html")
+      return withProfile({ type: "scene_text", withHtml }, filtered)
+    }
+
+    case "insert": {
+      const text = filtered.slice(2).filter((a) => !a.startsWith("--") && a !== flagValue(filtered, "--profile")).join(" ")
+      if (!text) { console.error("error: slop scene insert requires text"); process.exit(1) }
+      return withProfile({ type: "scene_insert", text }, filtered)
+    }
+
+    case "cursor": {
+      const coordArg = filtered[2]
+      if (!coordArg || coordArg.startsWith("--")) {
+        return withProfile({ type: "scene_cursor" }, filtered)
+      }
+      const coords = coordArg.split(",").map(Number)
+      if (coords.length !== 2 || coords.some(isNaN)) {
+        console.error("error: slop scene cursor requires X,Y coordinates or no args")
+        process.exit(1)
+      }
+      return withProfile({ type: "scene_cursor_to", x: coords[0], y: coords[1] }, filtered)
+    }
+
+    case "zoom":
+      return withProfile({ type: "scene_zoom" }, filtered)
+
+    case "hit-test":
+      return withProfile({ type: "scene_hit", x: parseInt(filtered[2] || "0"), y: parseInt(filtered[3] || "0") }, filtered)
+
+    case "render": {
+      const id = filtered[2]
+      if (!id) { console.error("error: slop scene render requires an id"); process.exit(1) }
+      const save = flagPresent(filtered, "--save")
+      const a: Action = { type: "scene_render", id }
+      if (save) a.save = true
+      return withProfile(a, filtered)
+    }
+
+    case "slide": {
+      const action = filtered[2]
+      if (!action || action === "list") return withProfile({ type: "scene_slide_list" }, filtered)
+      if (action === "current" || action === "at") return withProfile({ type: "scene_slide_current" }, filtered)
+      if (action === "goto" || action === "switch") {
+        const idx = parseInt(filtered[3] || "")
+        if (isNaN(idx)) { console.error("error: slop scene slide goto requires an index"); process.exit(1) }
+        return withProfile({ type: "scene_slide_goto", index: idx }, filtered)
+      }
+      if (action === "next") return withProfile({ type: "scene_slide_goto", index: -1, relative: "next" }, filtered)
+      if (action === "prev") return withProfile({ type: "scene_slide_goto", index: -1, relative: "prev" }, filtered)
+      // numeric shorthand: `slop scene slide 5`
+      const idx = parseInt(action)
+      if (!isNaN(idx)) return withProfile({ type: "scene_slide_goto", index: idx }, filtered)
+      console.error(`error: unknown slide subcommand '${action}'. Try: list, current, goto <n>, next, prev, <n>.`)
+      process.exit(1)
+      break
+    }
+
+    case "notes": {
+      const idxStr = flagValue(filtered, "--slide") || filtered[2]
+      const idx = idxStr && !isNaN(parseInt(idxStr)) ? parseInt(idxStr) : undefined
+      const a: Action = { type: "scene_notes" }
+      if (idx !== undefined) a.slideIndex = idx
+      return withProfile(a, filtered)
+    }
+
+    default:
+      console.error(`error: unknown canvas subcommand '${sub}'. Run 'slop scene help' for usage.`)
+      process.exit(1)
+  }
+  return null
+}
+
+const CANVAS_HELP = `slop scene — scene-graph access for DOM-rendered editors
+
+Usage:
+  slop scene profile [--verbose]        Show detected profile (canva, google-docs, google-slides, generic)
+  slop scene list [--type <t>]          Enumerate scene objects on current page
+  slop scene click <id>                 Click a scene object by stable id
+  slop scene dblclick <id>              Double-click a scene object (enters text edit on Canva/Slides)
+  slop scene select <id>                Click + verify selection changed
+  slop scene selected                   Read the current selection label
+  slop scene hit <x>,<y>                Identify what scene object is at viewport X,Y
+  slop scene zoom                       Read current editor zoom factor (1.0 = 100%)
+
+  slop scene text [--with-html]         Read document text (Google Docs; empty when canvas is opaque)
+  slop scene insert "<text>"            Insert text at cursor (Google Docs / Slides text edit mode)
+  slop scene cursor                     Read cursor state
+  slop scene cursor <x>,<y>             Move cursor by clicking at viewport X,Y
+
+  slop scene slide list                 List all slides (Google Slides)
+  slop scene slide current              Show current slide
+  slop scene slide goto <n>             Navigate to slide <n>
+  slop scene slide next                 Navigate to next slide
+  slop scene slide prev                 Navigate to previous slide
+  slop scene slide <n>                  Shorthand for goto <n>
+  slop scene notes [--slide <n>]        Read speaker notes (current slide or specific)
+
+  slop scene render <id> [--save]       Render a scene object as PNG data URL (Docs pages, Slides thumbnails)
+
+Flags:
+  --profile <name>                       Force a profile (canva | google-docs | google-slides | generic)
+  --type <t>                             Filter 'list' by type (image | shape | text | page | slide | embed)
+  --with-html                            Include full HTML model with data-ri offsets (Docs only)
+  --slide <n>                            Override slide index for notes/render
+
+Stable-id formats:
+  canva          LBxxxxxxxxxxxxxx  (16 chars, layer object)
+  google-docs    page-<n> | embed-<n>
+  google-slides  filmstrip-slide-<n>-gdxxxxxxxxx_<p>_<i>
+`

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -85,7 +85,7 @@ Headers:
   slop headers clear                  Clear all rules
 
 Canvas:
-  slop canvas list                    Discover canvas elements
+  slop canvas list                    Discover <canvas> elements
   slop canvas read N                  Read canvas as data URL
   slop canvas read N --format png     PNG format
   slop canvas read N --region X,Y,W,H  Read pixel region
@@ -106,6 +106,42 @@ Batch:
   slop wait-stable                    Wait for DOM stability (200ms default)
   slop wait-stable --ms 500           Custom debounce duration
   slop wait-stable --timeout 3000     Custom hard timeout
+
+Scene Graph (Canva, Google Docs, Google Slides):
+  slop scene profile                    Detect active editor profile (canva/google-docs/google-slides/generic)
+  slop scene profile --verbose          Include the list of supported capabilities
+  slop scene list                       List scene objects on current editor
+  slop scene list --type shape          Filter by type (image|shape|text|page|embed|slide)
+  slop scene click <id>                 Click a scene object by its stable id
+  slop scene dblclick <id>              Double-click a scene object
+  slop scene select <id>                Click + verify selection change
+  slop scene hit <x> <y>                Identify the scene object at viewport coordinates
+  slop scene selected                   Read current selection (host-aware)
+  slop scene text                       Read document text (Google Docs)
+  slop scene text --with-html           Include inline HTML + data-ri offsets
+  slop scene insert "<text>"            Insert text at cursor (Google Docs)
+  slop scene cursor-to <x> <y>          Move cursor to viewport coordinates
+  slop scene slide list                 List all slides in a Google Slides deck
+  slop scene slide current              Show the currently-displayed slide
+  slop scene slide goto <index>         Navigate to slide N (0-indexed)
+  slop scene notes [--slide N]          Read speaker notes for a slide
+  slop scene render <id> [--save]       Render a scene object as PNG
+  slop scene zoom                       Read current editor zoom factor
+  slop scene ... --profile <name>       Force a profile (bypasses detection)
+
+Recording (Session Monitor):
+  slop monitor start ["<instruction>"]   Start recording user actions on active tab
+    --instruction "..."                  Annotate with task intent for replay
+  slop monitor stop                      End recording and emit summary
+  slop monitor pause                     Stop emitting events without ending session
+  slop monitor resume                    Resume an active paused session
+  slop monitor status [--all]            Show status of current/all monitor sessions
+  slop monitor list                      List all sessions in the event log
+  slop monitor tail [--raw] [--current]  Live tail current session (pretty by default)
+  slop monitor export <sessionId>        Render a session as aligned text
+    --json                               Raw JSONL for the session
+    --plan                               Emit a 'slop ...' replay script
+    --with-bodies                        (P1) Merge cached response bodies
 
 Meta:
   slop status                         Check daemon status (local — no connection needed)

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -14,6 +14,8 @@ import { parseDataCommand } from "./commands/data"
 import { parseMetaCommand } from "./commands/meta"
 import { parseEvalCommand } from "./commands/eval"
 import { parseBatchCommand } from "./commands/batch"
+import { parseMonitorCommand } from "./commands/monitor"
+import { parseSceneCommand } from "./commands/scene"
 
 // Command → module routing
 const STATE_CMDS = new Set(["state", "tree", "diff", "find", "text", "html"])
@@ -27,9 +29,14 @@ const DATA_CMDS = new Set(["cookies", "storage", "history", "bookmarks", "downlo
 const META_CMDS = new Set(["status", "reload", "meta", "links", "images", "forms", "info", "page_info", "query", "exists", "count", "table", "attr", "style", "events", "search", "notify", "sessions", "capabilities", "modals", "panels"])
 const EVAL_CMDS = new Set(["eval"])
 const BATCH_CMDS = new Set(["batch", "raw"])
+const MONITOR_CMDS = new Set(["monitor"])
+const SCENE_CMDS = new Set(["scene"])
 
 // Commands that don't require a daemon connection
 const NO_DAEMON = new Set(["status", "help", "events", "session"])
+
+// Monitor subcommands that are handled locally (no daemon needed)
+const MONITOR_LOCAL_SUBCOMMANDS = new Set(["tail", "list", "export"])
 
 async function main() {
   const args = process.argv.slice(2)
@@ -50,7 +57,10 @@ async function main() {
   }
 
   const cmd = filtered[0]
-  const needsDaemon = !NO_DAEMON.has(cmd)
+  let needsDaemon = !NO_DAEMON.has(cmd)
+  if (cmd === "monitor" && filtered[1] && MONITOR_LOCAL_SUBCOMMANDS.has(filtered[1])) {
+    needsDaemon = false
+  }
 
   if (needsDaemon && !useWs) {
     await ensureDaemon()
@@ -70,6 +80,8 @@ async function main() {
   else if (META_CMDS.has(cmd))   action = await parseMetaCommand(filtered, jsonMode)
   else if (EVAL_CMDS.has(cmd))   action = parseEvalCommand(filtered)
   else if (BATCH_CMDS.has(cmd))  action = parseBatchCommand(filtered)
+  else if (MONITOR_CMDS.has(cmd)) action = await parseMonitorCommand(filtered, jsonMode)
+  else if (SCENE_CMDS.has(cmd))   action = await parseSceneCommand(filtered, jsonMode)
   else {
     console.error(`error: unknown command '${cmd}'. Run 'slop help' for usage.`)
     process.exit(1)

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -471,6 +471,12 @@ try {
           return
         }
 
+        if (request.type === "event") {
+          // Extension-originated event stream (monitor, keepalive_ping, etc.)
+          handleNativeMessage(request as any)
+          return
+        }
+
         if ((request as any).id && (request as any).result !== undefined) {
           handleNativeMessage(request as any)
           return

--- a/extension/src/background/capabilities/evaluate.ts
+++ b/extension/src/background/capabilities/evaluate.ts
@@ -13,9 +13,21 @@ export async function handleEvaluateActions(
     target: { tabId },
     world: world as "MAIN" | "ISOLATED",
     args: [code],
-    func: (c: string) => {
+    func: async (c: string) => {
+      function clone(v: unknown): unknown {
+        if (v === null || v === undefined) return v
+        const t = typeof v
+        if (t === "string" || t === "number" || t === "boolean") return v
+        if (t === "bigint") return (v as bigint).toString()
+        try {
+          return JSON.parse(JSON.stringify(v))
+        } catch {
+          try { return String(v) } catch { return null }
+        }
+      }
       try {
         const w = window as any
+        let source = c
         if (w.trustedTypes) {
           if (!w.__slop_tt_policy) {
             try {
@@ -31,15 +43,16 @@ export async function handleEvaluateActions(
             }
           }
           if (w.__slop_tt_policy) {
-            const trusted = w.__slop_tt_policy.createScript(c)
-            const r = (0, eval)(trusted)
-            return { success: true, data: (typeof r === "object" && r !== null) ? JSON.parse(JSON.stringify(r)) : r }
+            source = w.__slop_tt_policy.createScript(c)
           }
         }
-        const r = (0, eval)(c)
-        return { success: true, data: (typeof r === "object" && r !== null) ? JSON.parse(JSON.stringify(r)) : r }
+        let r: unknown = (0, eval)(source as string)
+        if (r && typeof (r as any).then === "function") {
+          r = await (r as Promise<unknown>)
+        }
+        return { success: true, data: clone(r) }
       } catch (e: any) {
-        return { success: false, error: e.message }
+        return { success: false, error: e?.message || String(e) }
       }
     }
   })

--- a/extension/src/background/capabilities/monitor.ts
+++ b/extension/src/background/capabilities/monitor.ts
@@ -1,0 +1,334 @@
+import { sendToHost } from "../transport"
+
+type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
+
+interface SessionRecord {
+  sessionId: string
+  tabId: number
+  startedAt: number
+  instruction?: string
+  paused: boolean
+  seq: number
+  counts: { evt: number; mut: number; net: number; nav: number }
+  url?: string
+}
+
+const sessions = new Map<string, SessionRecord>()
+const activeSessionByTab = new Map<number, string>()
+
+let webNavRegistered = false
+
+function nextSeq(session: SessionRecord): number {
+  return session.seq++
+}
+
+function emitMonEvent(session: SessionRecord, kind: string, extra: Record<string, unknown> = {}): void {
+  const seq = nextSeq(session)
+  session.counts.evt++
+  if (kind === "mut") session.counts.mut++
+  else if (kind === "fetch" || kind === "xhr") session.counts.net++
+  else if (kind === "nav") session.counts.nav++
+
+  sendToHost({
+    type: "event",
+    event: kind,
+    sid: session.sessionId,
+    s: seq,
+    t: Date.now(),
+    ...extra
+  })
+}
+
+function getActiveSessionForTab(tabId: number): SessionRecord | undefined {
+  const sid = activeSessionByTab.get(tabId)
+  if (!sid) return undefined
+  return sessions.get(sid)
+}
+
+async function sendArmToTab(tabId: number, sessionId: string, startedAt: number): Promise<void> {
+  try {
+    await chrome.tabs.sendMessage(tabId, { type: "monitor_arm", sessionId, startedAt })
+  } catch {}
+}
+
+async function sendDisarmToTab(tabId: number): Promise<unknown> {
+  try {
+    return await chrome.tabs.sendMessage(tabId, { type: "monitor_disarm" })
+  } catch {
+    return null
+  }
+}
+
+function registerWebNavListenersOnce(): void {
+  if (webNavRegistered) return
+  webNavRegistered = true
+
+  chrome.webNavigation.onCommitted.addListener((details) => {
+    if (details.frameId !== 0) return
+    const session = getActiveSessionForTab(details.tabId)
+    if (!session || session.paused) return
+    const isReload = details.transitionType === "reload"
+    emitMonEvent(session, "nav", {
+      u: details.url,
+      typ: isReload ? "reload" : "hard",
+      tt: details.transitionType,
+      tq: details.transitionQualifiers
+    })
+    session.url = details.url
+  })
+
+  chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
+    if (details.frameId !== 0) return
+    const session = getActiveSessionForTab(details.tabId)
+    if (!session || session.paused) return
+    emitMonEvent(session, "nav", {
+      u: details.url,
+      typ: "history",
+      tt: details.transitionType,
+      tq: details.transitionQualifiers
+    })
+    session.url = details.url
+  })
+
+  chrome.webNavigation.onReferenceFragmentUpdated.addListener((details) => {
+    if (details.frameId !== 0) return
+    const session = getActiveSessionForTab(details.tabId)
+    if (!session || session.paused) return
+    emitMonEvent(session, "nav", {
+      u: details.url,
+      typ: "reference",
+      tt: details.transitionType,
+      tq: details.transitionQualifiers
+    })
+    session.url = details.url
+  })
+
+  chrome.webNavigation.onCompleted.addListener((details) => {
+    if (details.frameId !== 0) return
+    const session = getActiveSessionForTab(details.tabId)
+    if (!session || session.paused) return
+    sendArmToTab(details.tabId, session.sessionId, session.startedAt)
+  })
+
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    const session = getActiveSessionForTab(tabId)
+    if (!session) return
+    const dur = Date.now() - session.startedAt
+    sendToHost({
+      type: "event",
+      event: "mon_stop",
+      sid: session.sessionId,
+      s: nextSeq(session),
+      t: Date.now(),
+      reason: "tab_closed",
+      evt: session.counts.evt,
+      mut: session.counts.mut,
+      net: session.counts.net,
+      nav: session.counts.nav,
+      dur
+    })
+    sessions.delete(session.sessionId)
+    activeSessionByTab.delete(tabId)
+  })
+}
+
+let runtimeMsgRegistered = false
+
+function registerRuntimeMessageListenerOnce(): void {
+  if (runtimeMsgRegistered) return
+  runtimeMsgRegistered = true
+  chrome.runtime.onMessage.addListener(monitorRuntimeMessageListener)
+}
+
+export function registerMonitorListeners(): void {
+  registerWebNavListenersOnce()
+  registerRuntimeMessageListenerOnce()
+}
+
+function monitorRuntimeMessageListener(msg: any, sender: chrome.runtime.MessageSender, sendResponse: (response?: any) => void): boolean | void {
+  if (!msg || typeof msg !== "object") return
+  if (msg.type !== "mon_evt") return
+  try {
+    const tabId = sender.tab?.id
+    const frameId = sender.frameId ?? 0
+    if (tabId === undefined) {
+      sendResponse({ success: false, error: "no tab id on sender" })
+      return true
+    }
+    const session = getActiveSessionForTab(tabId)
+    if (!session) {
+      sendResponse({ success: false, error: "no active session for tab" })
+      return true
+    }
+    if (session.paused) {
+      sendResponse({ success: true, dropped: "paused" })
+      return true
+    }
+    const obj = msg.obj || {}
+    const kind = obj.k || "unknown"
+    const stripped: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === "k") continue
+      stripped[k] = v
+    }
+    if (frameId !== 0) stripped.fid = frameId
+    emitMonEvent(session, kind, stripped)
+    sendResponse({ success: true })
+  } catch (err) {
+    try { sendResponse({ success: false, error: (err as Error).message }) } catch {}
+  }
+  return true
+}
+
+export async function handleMonitorActions(
+  action: { type: string; [key: string]: unknown },
+  tabId: number
+): Promise<ActionResult> {
+  switch (action.type) {
+    case "monitor_start": {
+      if (activeSessionByTab.has(tabId)) {
+        const existingSid = activeSessionByTab.get(tabId)!
+        return {
+          success: false,
+          error: `monitor already active on tab ${tabId} (session ${existingSid.slice(0, 8)})`,
+          data: { sessionId: existingSid }
+        }
+      }
+      const sessionId = crypto.randomUUID()
+      const startedAt = Date.now()
+      const instruction = (action.instruction as string) || undefined
+      let url: string | undefined
+      try {
+        const tab = await chrome.tabs.get(tabId)
+        url = tab.url
+      } catch {}
+      const session: SessionRecord = {
+        sessionId,
+        tabId,
+        startedAt,
+        instruction,
+        paused: false,
+        seq: 0,
+        counts: { evt: 0, mut: 0, net: 0, nav: 0 },
+        url
+      }
+      sessions.set(sessionId, session)
+      activeSessionByTab.set(tabId, sessionId)
+      sendToHost({
+        type: "event",
+        event: "mon_start",
+        sid: sessionId,
+        s: nextSeq(session),
+        t: startedAt,
+        tid: tabId,
+        url,
+        ins: instruction
+      })
+      await sendArmToTab(tabId, sessionId, startedAt)
+      return { success: true, data: { sessionId, tabId, startedAt, url, instruction } }
+    }
+
+    case "monitor_stop": {
+      const sid = activeSessionByTab.get(tabId)
+      if (!sid) {
+        return { success: false, error: `no active monitor session on tab ${tabId}` }
+      }
+      const session = sessions.get(sid)!
+      const disarmRes = await sendDisarmToTab(tabId) as { success?: boolean; counts?: { evt: number; mut: number; net: number } } | null
+      const dur = Date.now() - session.startedAt
+      sendToHost({
+        type: "event",
+        event: "mon_stop",
+        sid: session.sessionId,
+        s: nextSeq(session),
+        t: Date.now(),
+        reason: "user",
+        evt: session.counts.evt,
+        mut: session.counts.mut,
+        net: session.counts.net,
+        nav: session.counts.nav,
+        dur
+      })
+      sessions.delete(sid)
+      activeSessionByTab.delete(tabId)
+      return {
+        success: true,
+        data: {
+          sessionId: sid,
+          tabId,
+          dur,
+          evt: session.counts.evt,
+          mut: session.counts.mut,
+          net: session.counts.net,
+          nav: session.counts.nav,
+          contentDisarm: disarmRes
+        }
+      }
+    }
+
+    case "monitor_status": {
+      if (action.tabId && typeof action.tabId === "number") {
+        const sid = activeSessionByTab.get(action.tabId)
+        if (!sid) return { success: true, data: { active: false, tabId: action.tabId } }
+        const s = sessions.get(sid)!
+        return {
+          success: true,
+          data: {
+            active: !s.paused,
+            paused: s.paused,
+            sessionId: s.sessionId,
+            tabId: s.tabId,
+            startedAt: s.startedAt,
+            url: s.url,
+            instruction: s.instruction,
+            counts: s.counts,
+            ageMs: Date.now() - s.startedAt
+          }
+        }
+      }
+      const list = Array.from(sessions.values()).map((s) => ({
+        sessionId: s.sessionId,
+        tabId: s.tabId,
+        startedAt: s.startedAt,
+        url: s.url,
+        instruction: s.instruction,
+        paused: s.paused,
+        counts: s.counts,
+        ageMs: Date.now() - s.startedAt
+      }))
+      return { success: true, data: { active: list.length > 0, sessions: list } }
+    }
+
+    case "monitor_pause": {
+      const sid = activeSessionByTab.get(tabId)
+      if (!sid) return { success: false, error: `no active monitor session on tab ${tabId}` }
+      const session = sessions.get(sid)!
+      session.paused = true
+      sendToHost({
+        type: "event",
+        event: "mon_pause",
+        sid,
+        s: nextSeq(session),
+        t: Date.now()
+      })
+      return { success: true, data: { sessionId: sid, paused: true } }
+    }
+
+    case "monitor_resume": {
+      const sid = activeSessionByTab.get(tabId)
+      if (!sid) return { success: false, error: `no active monitor session on tab ${tabId}` }
+      const session = sessions.get(sid)!
+      session.paused = false
+      sendToHost({
+        type: "event",
+        event: "mon_resume",
+        sid,
+        s: nextSeq(session),
+        t: Date.now()
+      })
+      await sendArmToTab(tabId, sid, session.startedAt)
+      return { success: true, data: { sessionId: sid, paused: false } }
+    }
+  }
+  return { success: false, error: `unknown monitor action: ${action.type}` }
+}

--- a/extension/src/background/message-dispatch.ts
+++ b/extension/src/background/message-dispatch.ts
@@ -31,7 +31,7 @@ export function needsTab(type: string): boolean {
     "history_search", "history_delete_all", "bookmark_tree", "bookmark_search",
     "bookmark_create", "downloads_search", "browsing_data_remove",
     "session_list", "session_restore", "notification_create", "notification_clear",
-    "search_query"
+    "search_query", "monitor_status"
   ])
   return !noTabActions.has(type)
 }

--- a/extension/src/background/router.ts
+++ b/extension/src/background/router.ts
@@ -22,6 +22,9 @@ import { handleFrameActions } from "./capabilities/frames"
 import { handleMetaActions } from "./capabilities/meta"
 import { handlePassiveNetActions } from "./capabilities/passive-net"
 import { handleCdpNetworkActions } from "./capabilities/cdp-network-actions"
+import { handleMonitorActions, registerMonitorListeners } from "./capabilities/monitor"
+
+registerMonitorListeners()
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
 
@@ -57,6 +60,13 @@ const FRAME_ACTIONS = new Set(["frames_list"])
 const META_ACTIONS = new Set(["status", "reload_extension", "capabilities", "cdp_tree"])
 const PASSIVE_NET_ACTIONS = new Set(["net_log", "net_clear", "net_headers"])
 const CDP_NETWORK_ACTIONS = new Set(["network_intercept", "network_log", "network_override"])
+const MONITOR_ACTIONS = new Set(["monitor_start", "monitor_stop", "monitor_status", "monitor_pause", "monitor_resume"])
+const SCENE_ACTIONS = new Set([
+  "scene_list", "scene_click", "scene_dblclick", "scene_select", "scene_hit",
+  "scene_selected", "scene_text", "scene_insert", "scene_cursor_to", "scene_cursor",
+  "scene_slide_list", "scene_slide_goto", "scene_slide_current",
+  "scene_notes", "scene_render", "scene_zoom", "scene_profile"
+])
 
 export async function routeAction(
   action: { type: string; [key: string]: unknown },
@@ -83,6 +93,7 @@ export async function routeAction(
   if (META_ACTIONS.has(action.type)) return handleMetaActions(action, tabId)
   if (PASSIVE_NET_ACTIONS.has(action.type)) return handlePassiveNetActions(action, tabId)
   if (CDP_NETWORK_ACTIONS.has(action.type)) return handleCdpNetworkActions(action, tabId)
+  if (MONITOR_ACTIONS.has(action.type)) return handleMonitorActions(action, tabId)
 
   if (action.type === "linkedin_event_extract") return buildLinkedInEventExtraction(tabId, action)
   if (action.type === "linkedin_attendees_extract") return buildLinkedInAttendeesExtraction(tabId, action)

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,5 +1,6 @@
 import "./content/net-buffer"
 import "./content/dom-observer"
+import "./content/monitor"
 import { extractLinkedInEventDom } from "./linkedin/event-page-dom-extraction"
 import { clickManageAttendeesShowMore, extractManageAttendeesModal, openManageAttendeesModal } from "./linkedin/event-attendees-modal-dom"
 import { getDomDirty, setDomDirty } from "./content/dom-observer"
@@ -24,6 +25,7 @@ import { handleClipboardRead, handleClipboardWrite, handleSelectionGet, handleSe
 import { handleRect, handleRegions } from "./content/inspection/rect"
 import { handleModals, handlePanels } from "./content/inspection/modals"
 import { handleFindElement, handleSemanticResolve, handleFindAndClick, handleFindAndType, handleFindAndCheck } from "./content/find"
+import { handleCanvasAction } from "./content/scene/engine"
 
 type Action = { type: string; [key: string]: unknown }
 type ActionResult = { success: boolean; error?: string; warning?: string; data?: unknown; changes?: unknown }
@@ -147,6 +149,24 @@ async function executeAction(action: Action): Promise<ActionResult> {
       case "find_and_click":      return handleFindAndClick(action)
       case "find_and_type":       return handleFindAndType(action)
       case "find_and_check":      return handleFindAndCheck(action)
+      case "scene_list":
+      case "scene_click":
+      case "scene_dblclick":
+      case "scene_select":
+      case "scene_hit":
+      case "scene_selected":
+      case "scene_text":
+      case "scene_insert":
+      case "scene_cursor_to":
+      case "scene_cursor":
+      case "scene_slide_list":
+      case "scene_slide_goto":
+      case "scene_slide_current":
+      case "scene_notes":
+      case "scene_render":
+      case "scene_zoom":
+      case "scene_profile":
+        return await handleCanvasAction(action)
       case "linkedin_event_dom":
         return { success: true, data: await extractLinkedInEventDom(waitForDomStable, dispatchClickSequence) }
       case "linkedin_attendees_open":

--- a/extension/src/content/monitor.ts
+++ b/extension/src/content/monitor.ts
@@ -1,0 +1,510 @@
+import { getOrAssignRef } from "./ref-registry"
+import { getEffectiveRole, getAccessibleName } from "./a11y-tree"
+
+type MonEvent = {
+  t: number
+  s: number
+  k: string
+  sid: string
+  [key: string]: unknown
+}
+
+type UserActionRef = { s: number; t: number }
+type MutationBatch = {
+  add: number
+  rem: number
+  attr: number
+  txt: number
+  targets: Set<string>
+}
+
+let armed = false
+let sessionId = ""
+let seq = 0
+const recentUserActions: UserActionRef[] = []
+const RECENT_CAP = 16
+const CAUSE_WINDOW_MS = 500
+
+let mutationBatch: MutationBatch | null = null
+let mutationFlushTimer: ReturnType<typeof setTimeout> | null = null
+const MUTATION_DEBOUNCE_MS = 50
+const MUTATION_TARGET_CAP = 5
+
+let scrollLastEmit = 0
+let scrollAccX = 0
+let scrollAccY = 0
+let scrollFlushTimer: ReturnType<typeof setTimeout> | null = null
+const SCROLL_THROTTLE_MS = 100
+
+let mutationObserver: MutationObserver | null = null
+
+type CapturedListener = { type: string; fn: EventListener; opts: AddEventListenerOptions }
+const attachedListeners: CapturedListener[] = []
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try { return fn() } catch { return fallback }
+}
+
+function emit(evt: Partial<MonEvent>): void {
+  if (!armed) return
+  try {
+    const full: MonEvent = {
+      t: Date.now(),
+      s: seq++,
+      k: evt.k || "unknown",
+      sid: sessionId,
+      ...evt,
+    } as MonEvent
+    chrome.runtime.sendMessage({ type: "mon_evt", obj: full }).catch(() => {})
+  } catch {}
+}
+
+function pushUserAction(s: number, t: number): void {
+  recentUserActions.push({ s, t })
+  if (recentUserActions.length > RECENT_CAP) recentUserActions.shift()
+}
+
+function findCause(eventT: number): number | undefined {
+  for (let i = recentUserActions.length - 1; i >= 0; i--) {
+    const ua = recentUserActions[i]
+    if (eventT - ua.t <= CAUSE_WINDOW_MS) return ua.s
+    if (eventT - ua.t > CAUSE_WINDOW_MS) return undefined
+  }
+  return undefined
+}
+
+function describeTarget(target: EventTarget | null): Record<string, unknown> {
+  if (!target || !(target instanceof Element)) return {}
+  const el = target
+  const out: Record<string, unknown> = {}
+  out.ref = safe(() => getOrAssignRef(el), "")
+  const role = safe(() => getEffectiveRole(el), "")
+  if (role) out.r = role
+  const name = safe(() => getAccessibleName(el), "")
+  if (name) out.n = name.slice(0, 80)
+  const tag = safe(() => el.tagName.toLowerCase(), "")
+  if (tag && !role) out.tg = tag
+  return out
+}
+
+function isPasswordLike(el: Element): boolean {
+  if (!(el instanceof HTMLInputElement)) return false
+  const type = (el.type || "").toLowerCase()
+  if (type === "password") return true
+  const autocomplete = (el.autocomplete || "").toLowerCase()
+  if (autocomplete.startsWith("cc-")) return true
+  const name = (el.name || "").toLowerCase()
+  if (/card|cvv|cvc|credit/.test(name)) return true
+  return false
+}
+
+function maskedValue(el: HTMLInputElement): string {
+  const len = (el.value || "").length
+  return `***${len}***`
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max) + "…"
+}
+
+function targetFromEvent(e: Event): EventTarget | null {
+  try {
+    const path = (e.composedPath && e.composedPath()) || []
+    if (path.length > 0) return path[0]
+  } catch {}
+  return e.target
+}
+
+// -----------------------------------------------------------------------------
+// User action listeners
+// -----------------------------------------------------------------------------
+
+function makeClickHandler(kind: "click" | "dblclick" | "rclick") {
+  return (e: Event) => {
+    try {
+      const me = e as MouseEvent
+      const target = targetFromEvent(e)
+      const info = describeTarget(target)
+      const t = Date.now()
+      const sSnapshot = seq
+      emit({
+        k: kind,
+        ...info,
+        x: me.clientX,
+        y: me.clientY,
+        tr: me.isTrusted,
+        ic: (e as Event & { composed?: boolean }).composed === true,
+      })
+      pushUserAction(sSnapshot, t)
+    } catch {}
+  }
+}
+
+function handleInput(e: Event) {
+  try {
+    const target = targetFromEvent(e)
+    if (!(target instanceof Element)) return
+    const info = describeTarget(target)
+    let v = ""
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      if (target instanceof HTMLInputElement && isPasswordLike(target)) {
+        v = maskedValue(target)
+      } else {
+        v = truncate(target.value || "", 120)
+      }
+    } else if ((target as HTMLElement).isContentEditable) {
+      v = truncate(((target as HTMLElement).textContent || ""), 120)
+    }
+    const t = Date.now()
+    const sSnapshot = seq
+    emit({
+      k: "input",
+      ...info,
+      v,
+      tr: (e as Event).isTrusted,
+    })
+    pushUserAction(sSnapshot, t)
+  } catch {}
+}
+
+function handleChange(e: Event) {
+  try {
+    const target = targetFromEvent(e)
+    if (!(target instanceof Element)) return
+    const info = describeTarget(target)
+    let v = ""
+    if (target instanceof HTMLInputElement) {
+      if (isPasswordLike(target)) {
+        v = maskedValue(target)
+      } else if (target.type === "checkbox" || target.type === "radio") {
+        v = target.checked ? "true" : "false"
+      } else {
+        v = truncate(target.value || "", 120)
+      }
+    } else if (target instanceof HTMLSelectElement) {
+      v = truncate(target.value || "", 120)
+    } else if (target instanceof HTMLTextAreaElement) {
+      v = truncate(target.value || "", 120)
+    }
+    const t = Date.now()
+    const sSnapshot = seq
+    emit({
+      k: "change",
+      ...info,
+      v,
+      tr: (e as Event).isTrusted,
+    })
+    pushUserAction(sSnapshot, t)
+  } catch {}
+}
+
+function handleSubmit(e: Event) {
+  try {
+    const target = targetFromEvent(e)
+    const info = describeTarget(target)
+    const t = Date.now()
+    const sSnapshot = seq
+    emit({
+      k: "submit",
+      ...info,
+      tr: (e as Event).isTrusted,
+    })
+    pushUserAction(sSnapshot, t)
+  } catch {}
+}
+
+function handleKeydown(e: Event) {
+  try {
+    const ke = e as KeyboardEvent
+    const parts: string[] = []
+    if (ke.ctrlKey) parts.push("Control")
+    if (ke.shiftKey) parts.push("Shift")
+    if (ke.altKey) parts.push("Alt")
+    if (ke.metaKey) parts.push("Meta")
+    parts.push(ke.key)
+    const target = targetFromEvent(e)
+    const info = describeTarget(target)
+    const t = Date.now()
+    const sSnapshot = seq
+    emit({
+      k: "key",
+      ...info,
+      kc: parts.join("+"),
+      tr: ke.isTrusted,
+    })
+    // Only keys like Enter/Tab/Escape/Arrow are interesting as causes; char keys will be followed by input events
+    if (ke.key === "Enter" || ke.key === "Tab" || ke.key === "Escape" || ke.key.startsWith("Arrow")) {
+      pushUserAction(sSnapshot, t)
+    }
+  } catch {}
+}
+
+function handleFocusEvent(kind: "focus" | "blur") {
+  return (e: Event) => {
+    try {
+      const target = targetFromEvent(e)
+      const info = describeTarget(target)
+      emit({
+        k: kind,
+        ...info,
+        tr: (e as Event).isTrusted,
+      })
+    } catch {}
+  }
+}
+
+function handleCopyPaste(kind: "copy" | "paste") {
+  return (e: Event) => {
+    try {
+      const target = targetFromEvent(e)
+      const info = describeTarget(target)
+      emit({
+        k: kind,
+        ...info,
+        tr: (e as Event).isTrusted,
+      })
+    } catch {}
+  }
+}
+
+function flushScroll() {
+  if (!armed) return
+  if (scrollAccX === 0 && scrollAccY === 0) return
+  emit({
+    k: "scroll",
+    sx: scrollAccX,
+    sy: scrollAccY,
+  })
+  scrollAccX = 0
+  scrollAccY = 0
+  scrollLastEmit = Date.now()
+}
+
+function handleScroll(_e: Event) {
+  try {
+    const now = Date.now()
+    scrollAccX = window.scrollX
+    scrollAccY = window.scrollY
+    if (now - scrollLastEmit >= SCROLL_THROTTLE_MS) {
+      flushScroll()
+    } else if (!scrollFlushTimer) {
+      scrollFlushTimer = setTimeout(() => {
+        scrollFlushTimer = null
+        flushScroll()
+      }, SCROLL_THROTTLE_MS)
+    }
+  } catch {}
+}
+
+// -----------------------------------------------------------------------------
+// Mutation batching
+// -----------------------------------------------------------------------------
+
+function ensureMutationBatch(): MutationBatch {
+  if (!mutationBatch) {
+    mutationBatch = { add: 0, rem: 0, attr: 0, txt: 0, targets: new Set() }
+  }
+  return mutationBatch
+}
+
+function flushMutationBatch() {
+  if (!armed) return
+  if (!mutationBatch) return
+  const batch = mutationBatch
+  mutationBatch = null
+  if (mutationFlushTimer) {
+    clearTimeout(mutationFlushTimer)
+    mutationFlushTimer = null
+  }
+  const total = batch.add + batch.rem + batch.attr + batch.txt
+  if (total === 0) return
+  const now = Date.now()
+  const cause = findCause(now)
+  emit({
+    k: "mut",
+    c: total,
+    add: batch.add,
+    rem: batch.rem,
+    attr: batch.attr,
+    txt: batch.txt,
+    tgts: Array.from(batch.targets).slice(0, MUTATION_TARGET_CAP),
+    ...(cause !== undefined ? { cause } : {}),
+  })
+}
+
+function scheduleMutationFlush() {
+  if (mutationFlushTimer) return
+  mutationFlushTimer = setTimeout(() => {
+    mutationFlushTimer = null
+    flushMutationBatch()
+  }, MUTATION_DEBOUNCE_MS)
+}
+
+function onMutations(mutations: MutationRecord[]) {
+  if (!armed) return
+  try {
+    const batch = ensureMutationBatch()
+    for (const m of mutations) {
+      if (m.type === "childList") {
+        batch.add += m.addedNodes.length
+        batch.rem += m.removedNodes.length
+      } else if (m.type === "attributes") {
+        batch.attr += 1
+      } else if (m.type === "characterData") {
+        batch.txt += 1
+      }
+      if (batch.targets.size < MUTATION_TARGET_CAP) {
+        const t = m.target
+        if (t instanceof Element) {
+          const ref = safe(() => getOrAssignRef(t), "")
+          if (ref) batch.targets.add(ref)
+        }
+      }
+    }
+    scheduleMutationFlush()
+  } catch {}
+}
+
+// -----------------------------------------------------------------------------
+// __slop_net subscription (network correlation)
+// -----------------------------------------------------------------------------
+
+function onSlopNet(e: Event) {
+  if (!armed) return
+  try {
+    const detail = (e as CustomEvent).detail as {
+      url: string
+      method: string
+      status: number
+      body: string
+      type: string
+      timestamp: number
+    }
+    if (!detail) return
+    const bodyLen = typeof detail.body === "string" ? detail.body.length : 0
+    const now = Date.now()
+    const cause = findCause(now)
+    emit({
+      k: detail.type === "xhr" ? "xhr" : "fetch",
+      u: truncate(detail.url || "", 512),
+      m: detail.method || "GET",
+      st: detail.status,
+      bz: bodyLen,
+      ...(cause !== undefined ? { cause } : {}),
+    })
+  } catch {}
+}
+
+// -----------------------------------------------------------------------------
+// arm / disarm
+// -----------------------------------------------------------------------------
+
+function attach(type: string, fn: EventListener, opts: AddEventListenerOptions) {
+  document.addEventListener(type, fn, opts)
+  attachedListeners.push({ type, fn, opts })
+}
+
+export function arm(newSessionId: string, _startedAt: number): void {
+  if (armed) return
+  armed = true
+  sessionId = newSessionId
+  seq = 0
+  recentUserActions.length = 0
+  mutationBatch = null
+  if (mutationFlushTimer) { clearTimeout(mutationFlushTimer); mutationFlushTimer = null }
+  scrollAccX = 0
+  scrollAccY = 0
+  scrollLastEmit = 0
+
+  const captureOpts: AddEventListenerOptions = { capture: true, passive: true }
+
+  attach("click", makeClickHandler("click"), captureOpts)
+  attach("dblclick", makeClickHandler("dblclick"), captureOpts)
+  attach("contextmenu", makeClickHandler("rclick"), captureOpts)
+  attach("input", handleInput, captureOpts)
+  attach("change", handleChange, captureOpts)
+  attach("submit", handleSubmit, captureOpts)
+  attach("keydown", handleKeydown, captureOpts)
+  attach("focus", handleFocusEvent("focus"), captureOpts)
+  attach("blur", handleFocusEvent("blur"), captureOpts)
+  attach("copy", handleCopyPaste("copy"), captureOpts)
+  attach("paste", handleCopyPaste("paste"), captureOpts)
+  // Scroll fires on document, capture phase
+  attach("scroll", handleScroll, captureOpts)
+
+  // __slop_net events from the MAIN-world inject script
+  document.addEventListener("__slop_net", onSlopNet as EventListener)
+
+  // MutationObserver on documentElement so <html> attribute changes are seen
+  mutationObserver = new MutationObserver(onMutations)
+  if (document.documentElement) {
+    mutationObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    })
+  }
+}
+
+export function disarm(): { evt: number; mut: number; net: number } {
+  if (!armed) return { evt: 0, mut: 0, net: 0 }
+  flushMutationBatch()
+  flushScroll()
+
+  for (const l of attachedListeners) {
+    try { document.removeEventListener(l.type, l.fn, l.opts) } catch {}
+  }
+  attachedListeners.length = 0
+
+  try { document.removeEventListener("__slop_net", onSlopNet as EventListener) } catch {}
+
+  if (mutationObserver) {
+    try { mutationObserver.disconnect() } catch {}
+    mutationObserver = null
+  }
+  if (mutationFlushTimer) { clearTimeout(mutationFlushTimer); mutationFlushTimer = null }
+  if (scrollFlushTimer) { clearTimeout(scrollFlushTimer); scrollFlushTimer = null }
+
+  const counts = { evt: seq, mut: 0, net: 0 }
+  armed = false
+  sessionId = ""
+  seq = 0
+  recentUserActions.length = 0
+  return counts
+}
+
+export function isArmed(): boolean { return armed }
+export function getSessionId(): string { return sessionId }
+
+// -----------------------------------------------------------------------------
+// Message handlers
+// -----------------------------------------------------------------------------
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (!msg || typeof msg !== "object") return
+  if (msg.type === "monitor_arm") {
+    try {
+      arm(msg.sessionId as string, (msg.startedAt as number) || Date.now())
+      sendResponse({ success: true, armed: true })
+    } catch (err) {
+      sendResponse({ success: false, error: (err as Error).message })
+    }
+    return true
+  }
+  if (msg.type === "monitor_disarm") {
+    try {
+      const counts = disarm()
+      sendResponse({ success: true, counts })
+    } catch (err) {
+      sendResponse({ success: false, error: (err as Error).message })
+    }
+    return true
+  }
+  if (msg.type === "monitor_ping") {
+    sendResponse({ success: true, armed, sessionId })
+    return true
+  }
+  // Do not return true for unhandled messages — let other listeners respond.
+})

--- a/extension/src/content/scene/engine.ts
+++ b/extension/src/content/scene/engine.ts
@@ -1,0 +1,265 @@
+import type { SceneProfile, SceneObject, SceneEngineResult, SceneRenderResult } from "./types"
+import { genericProfile } from "./profiles/generic"
+import { canvaProfile } from "./profiles/canva"
+import { googleDocsProfile } from "./profiles/google-docs"
+import { googleSlidesProfile } from "./profiles/google-slides"
+
+const profiles: SceneProfile[] = []
+let genericRegistered = false
+let builtinsRegistered = false
+
+function ensureBuiltins(): void {
+  if (builtinsRegistered) return
+  builtinsRegistered = true
+  profiles.push(canvaProfile)
+  profiles.push(googleSlidesProfile)
+  profiles.push(googleDocsProfile)
+}
+
+export function registerProfile(p: SceneProfile): void {
+  profiles.push(p)
+}
+
+function ensureGeneric(): void {
+  if (genericRegistered) return
+  genericRegistered = true
+  profiles.push(genericProfile)
+}
+
+export function detectProfile(override?: string): SceneProfile {
+  ensureBuiltins()
+  ensureGeneric()
+  if (override) {
+    const match = profiles.find((p) => p.name === override)
+    if (match) return match
+  }
+  for (const p of profiles) {
+    try {
+      if (p !== genericProfile && p.detect()) return p
+    } catch {}
+  }
+  return genericProfile
+}
+
+function wrap<T>(profile: SceneProfile, fn: () => T | null | undefined): SceneEngineResult<T> {
+  try {
+    const data = fn()
+    if (data === null || data === undefined) {
+      return { success: false, error: "no data", profile: profile.name }
+    }
+    return { success: true, data: data as T, profile: profile.name }
+  } catch (err) {
+    return { success: false, error: (err as Error).message, profile: profile.name }
+  }
+}
+
+async function wrapAsync<T>(profile: SceneProfile, fn: () => Promise<T | null | undefined>): Promise<SceneEngineResult<T>> {
+  try {
+    const data = await fn()
+    if (data === null || data === undefined) {
+      return { success: false, error: "no data", profile: profile.name }
+    }
+    return { success: true, data: data as T, profile: profile.name }
+  } catch (err) {
+    return { success: false, error: (err as Error).message, profile: profile.name }
+  }
+}
+
+export function canvasProfileName(override?: string): SceneEngineResult<{ name: string; capabilities: string[] }> {
+  const p = detectProfile(override)
+  const caps: string[] = []
+  if (p.list) caps.push("list")
+  if (p.resolve) caps.push("resolve")
+  if (p.selected) caps.push("selected")
+  if (p.zoom) caps.push("zoom")
+  if (p.text) caps.push("text")
+  if (p.writeAtCursor) caps.push("writeAtCursor")
+  if (p.cursorTo) caps.push("cursorTo")
+  if (p.render) caps.push("render")
+  if (p.slides) caps.push("slides")
+  if (p.slideCurrent) caps.push("slideCurrent")
+  if (p.slideGoto) caps.push("slideGoto")
+  if (p.notes) caps.push("notes")
+  if (p.hitTest) caps.push("hitTest")
+  return { success: true, data: { name: p.name, capabilities: caps }, profile: p.name }
+}
+
+export function canvasList(opts?: { type?: string; profile?: string }): SceneEngineResult<SceneObject[]> {
+  const p = detectProfile(opts?.profile)
+  if (!p.list) return { success: false, error: `profile '${p.name}' does not support list()`, profile: p.name }
+  return wrap(p, () => p.list!({ type: opts?.type }))
+}
+
+export function canvasResolve(id: string, profileOverride?: string): SceneEngineResult<{ id: string; rect: DOMRect }> {
+  const p = detectProfile(profileOverride)
+  if (!p.resolve) return { success: false, error: `profile '${p.name}' does not support resolve()`, profile: p.name }
+  const el = p.resolve(id)
+  if (!el) return { success: false, error: `no element matches id '${id}'`, profile: p.name }
+  const r = el.getBoundingClientRect()
+  return {
+    success: true,
+    data: { id, rect: { x: r.left, y: r.top, width: r.width, height: r.height, top: r.top, left: r.left, right: r.right, bottom: r.bottom, toJSON: () => ({}) } as DOMRect },
+    profile: p.name
+  }
+}
+
+export function canvasSelected(profileOverride?: string): SceneEngineResult<unknown> {
+  const p = detectProfile(profileOverride)
+  if (!p.selected) return { success: false, error: `profile '${p.name}' does not support selected()`, profile: p.name }
+  return wrap(p, () => p.selected!())
+}
+
+export function canvasZoom(profileOverride?: string): SceneEngineResult<number> {
+  const p = detectProfile(profileOverride)
+  if (!p.zoom) return { success: false, error: `profile '${p.name}' does not support zoom()`, profile: p.name }
+  return wrap(p, () => p.zoom!())
+}
+
+export function canvasText(opts?: { withHtml?: boolean; profile?: string }): SceneEngineResult<unknown> {
+  const p = detectProfile(opts?.profile)
+  if (!p.text) return { success: false, error: `profile '${p.name}' does not support text()`, profile: p.name }
+  return wrap(p, () => p.text!({ withHtml: opts?.withHtml }))
+}
+
+export function canvasInsertText(text: string, profileOverride?: string): SceneEngineResult<{ inserted: number }> {
+  const p = detectProfile(profileOverride)
+  if (!p.writeAtCursor) return { success: false, error: `profile '${p.name}' does not support writeAtCursor()`, profile: p.name }
+  const r = p.writeAtCursor(text)
+  if (!r.success) return { success: false, error: r.error || "writeAtCursor failed", profile: p.name }
+  return { success: true, data: { inserted: text.length }, profile: p.name }
+}
+
+export function canvasCursorTo(x: number, y: number, profileOverride?: string): SceneEngineResult<{ x: number; y: number }> {
+  const p = detectProfile(profileOverride)
+  if (!p.cursorTo) return { success: false, error: `profile '${p.name}' does not support cursorTo()`, profile: p.name }
+  const r = p.cursorTo({ x, y })
+  if (!r.success) return { success: false, error: r.error || "cursorTo failed", profile: p.name }
+  return { success: true, data: { x, y }, profile: p.name }
+}
+
+export async function canvasRender(id: string, profileOverride?: string): Promise<SceneEngineResult<SceneRenderResult>> {
+  const p = detectProfile(profileOverride)
+  if (!p.render) return { success: false, error: `profile '${p.name}' does not support render()`, profile: p.name }
+  return wrapAsync(p, () => p.render!(id))
+}
+
+export function canvasSlideList(profileOverride?: string): SceneEngineResult<unknown> {
+  const p = detectProfile(profileOverride)
+  if (!p.slides) return { success: false, error: `profile '${p.name}' does not support slides()`, profile: p.name }
+  return wrap(p, () => p.slides!())
+}
+
+export function canvasSlideCurrent(profileOverride?: string): SceneEngineResult<unknown> {
+  const p = detectProfile(profileOverride)
+  if (!p.slideCurrent) return { success: false, error: `profile '${p.name}' does not support slideCurrent()`, profile: p.name }
+  return wrap(p, () => p.slideCurrent!())
+}
+
+export function canvasSlideGoto(index: number, profileOverride?: string): SceneEngineResult<{ index: number }> {
+  const p = detectProfile(profileOverride)
+  if (!p.slideGoto) return { success: false, error: `profile '${p.name}' does not support slideGoto()`, profile: p.name }
+  const r = p.slideGoto(index)
+  if (!r.success) return { success: false, error: r.error || "slideGoto failed", profile: p.name }
+  return { success: true, data: { index }, profile: p.name }
+}
+
+export function canvasNotes(slideIndex?: number, profileOverride?: string): SceneEngineResult<string> {
+  const p = detectProfile(profileOverride)
+  if (!p.notes) return { success: false, error: `profile '${p.name}' does not support notes()`, profile: p.name }
+  return wrap(p, () => p.notes!(slideIndex))
+}
+
+export function canvasHit(x: number, y: number, profileOverride?: string): SceneEngineResult<SceneObject | null> {
+  const p = detectProfile(profileOverride)
+  if (p.hitTest) return wrap(p, () => p.hitTest!(x, y))
+  if (p.list) {
+    const list = p.list({}) || []
+    const best = list.find((o) => x >= o.rect.x && x <= o.rect.x + o.rect.w && y >= o.rect.y && y <= o.rect.y + o.rect.h)
+    if (!best) return { success: false, error: "no scene object at coordinates", profile: p.name }
+    return { success: true, data: best, profile: p.name }
+  }
+  return { success: false, error: `profile '${p.name}' cannot hit-test`, profile: p.name }
+}
+
+// -----------------------------------------------------------------------------
+// Top-level action dispatcher for content.ts
+// -----------------------------------------------------------------------------
+
+type Action = { type: string; [key: string]: unknown }
+type ContentResult = { success: boolean; error?: string; data?: unknown; warning?: string }
+
+export async function handleCanvasAction(action: Action): Promise<ContentResult> {
+  const profileOverride = action.profile as string | undefined
+  try {
+    switch (action.type) {
+      case "scene_profile": {
+        const verbose = !!action.verbose
+        const r = canvasProfileName(profileOverride)
+        if (verbose) return r as ContentResult
+        if (r.success && r.data) return { success: true, data: (r.data as { name: string }).name }
+        return r as ContentResult
+      }
+      case "scene_list": {
+        const r = canvasList({ type: action.filter as string | undefined, profile: profileOverride })
+        return r as ContentResult
+      }
+      case "scene_click":
+      case "scene_dblclick":
+      case "scene_select": {
+        const id = action.id as string
+        if (!id) return { success: false, error: "missing id" }
+        const resolved = canvasResolve(id, profileOverride)
+        if (!resolved.success) return resolved as ContentResult
+        const el = document.getElementById(id)
+        if (!el) return { success: false, error: `element '${id}' not in DOM at click time` }
+        const { clickElementCenter, dblclickElementCenter } = await import("./ops")
+        if (action.type === "scene_dblclick") dblclickElementCenter(el)
+        else clickElementCenter(el)
+        const rect = el.getBoundingClientRect()
+        const cx = Math.round(rect.left + rect.width / 2)
+        const cy = Math.round(rect.top + rect.height / 2)
+        // Include the absolute viewport coordinates so the background layer can
+        // escalate to an OS-level trusted click when Canva-style editors ignore
+        // the synthetic dispatch. The router's existing synthetic→os_click
+        // escalation path checks for "no DOM change" warnings; scene clicks
+        // return `warning: no DOM change` when Canva's selection model didn't
+        // update, which triggers the same fallback.
+        return {
+          success: true,
+          data: { id, clicked: true, at: { x: cx, y: cy } },
+          warning: action.escalate === false ? undefined : "scene_click dispatched synthetically — rerun with --os if the editor does not respond"
+        }
+      }
+      case "scene_selected":
+        return canvasSelected(profileOverride) as ContentResult
+      case "scene_zoom":
+        return canvasZoom(profileOverride) as ContentResult
+      case "scene_text":
+        return canvasText({ withHtml: !!action.withHtml, profile: profileOverride }) as ContentResult
+      case "scene_insert":
+        return canvasInsertText(action.text as string, profileOverride) as ContentResult
+      case "scene_cursor_to":
+        return canvasCursorTo(action.x as number, action.y as number, profileOverride) as ContentResult
+      case "scene_cursor":
+        return canvasSelected(profileOverride) as ContentResult
+      case "scene_slide_list":
+        return canvasSlideList(profileOverride) as ContentResult
+      case "scene_slide_current":
+        return canvasSlideCurrent(profileOverride) as ContentResult
+      case "scene_slide_goto":
+        return canvasSlideGoto(action.index as number, profileOverride) as ContentResult
+      case "scene_notes":
+        return canvasNotes(action.slideIndex as number | undefined, profileOverride) as ContentResult
+      case "scene_render": {
+        const r = await canvasRender(action.id as string, profileOverride)
+        return r as ContentResult
+      }
+      case "scene_hit":
+        return canvasHit(action.x as number, action.y as number, profileOverride) as ContentResult
+      default:
+        return { success: false, error: `unknown scene action: ${action.type}` }
+    }
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}

--- a/extension/src/content/scene/ops.ts
+++ b/extension/src/content/scene/ops.ts
@@ -1,0 +1,131 @@
+import { dispatchClickSequence, dispatchKeySequence } from "../input-simulation"
+import type { SceneRect, SceneDocCoord } from "./types"
+
+export function boundingBox(el: Element): SceneRect {
+  const r = el.getBoundingClientRect()
+  return {
+    x: Math.round(r.left),
+    y: Math.round(r.top),
+    w: Math.round(r.width),
+    h: Math.round(r.height),
+    cx: Math.round(r.left + r.width / 2),
+    cy: Math.round(r.top + r.height / 2)
+  }
+}
+
+export function isVisibleRect(r: SceneRect): boolean {
+  return r.w > 0 && r.h > 0
+}
+
+const TRANSLATE_RE = /translate\(\s*(-?[\d.]+)(?:px)?\s*,\s*(-?[\d.]+)(?:px)?\s*\)/
+
+export function parseTranslate(transform: string | null | undefined): { x: number; y: number } | null {
+  if (!transform) return null
+  const m = transform.match(TRANSLATE_RE)
+  if (!m) return null
+  return { x: parseFloat(m[1]), y: parseFloat(m[2]) }
+}
+
+const SCALE_RE = /scale\(\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)/
+
+export function parseScale(transform: string | null | undefined): number | null {
+  if (!transform) return null
+  const m = transform.match(SCALE_RE)
+  if (!m) return null
+  return parseFloat(m[1])
+}
+
+export function findAncestorScale(el: Element): number | null {
+  let cur: HTMLElement | null = el as HTMLElement
+  for (let i = 0; i < 20 && cur; i++) {
+    const s = parseScale(cur.style?.transform)
+    if (s !== null) return s
+    cur = cur.parentElement
+  }
+  return null
+}
+
+export function parseDocCoord(el: Element): SceneDocCoord | null {
+  const he = el as HTMLElement
+  const t = parseTranslate(he.style?.transform)
+  const w = parseFloat(he.style?.width || "")
+  const h = parseFloat(he.style?.height || "")
+  if (!t || isNaN(w) || isNaN(h)) return null
+  return { x: t.x, y: t.y, w, h }
+}
+
+export function scrollElementIntoView(el: Element): void {
+  const r = el.getBoundingClientRect()
+  if (r.top < 0 || r.bottom > window.innerHeight || r.left < 0 || r.right > window.innerWidth) {
+    try { (el as HTMLElement).scrollIntoView({ block: "center", inline: "center", behavior: "instant" as ScrollBehavior }) } catch {}
+  }
+}
+
+export function clickElementCenter(el: Element): SceneRect {
+  scrollElementIntoView(el)
+  const r = boundingBox(el)
+  // Use viewport-coordinate click via elementFromPoint so editors whose click
+  // handlers are on ancestor layers (Canva, Google Docs canvas surface) receive
+  // the event at the correct spatial location — dispatching on the LB element
+  // directly would bypass the ancestor handler chain.
+  clickAtViewport(r.cx, r.cy)
+  return r
+}
+
+export function dblclickElementCenter(el: Element): SceneRect {
+  scrollElementIntoView(el)
+  const r = boundingBox(el)
+  const rect = el.getBoundingClientRect()
+  const opts = { bubbles: true, cancelable: true, clientX: r.cx, clientY: r.cy, button: 0 }
+  dispatchClickSequence(el)
+  el.dispatchEvent(new MouseEvent("dblclick", opts))
+  void rect
+  return r
+}
+
+export function clickAtViewport(x: number, y: number): Element | null {
+  const el = document.elementFromPoint(x, y)
+  if (!el) return null
+  const opts = { bubbles: true, cancelable: true, clientX: x, clientY: y, button: 0 }
+  try {
+    el.dispatchEvent(new PointerEvent("pointerover", opts))
+    el.dispatchEvent(new MouseEvent("mouseover", opts))
+    el.dispatchEvent(new PointerEvent("pointerdown", opts))
+    el.dispatchEvent(new MouseEvent("mousedown", opts))
+    if ((el as HTMLElement).focus) (el as HTMLElement).focus()
+    el.dispatchEvent(new PointerEvent("pointerup", opts))
+    el.dispatchEvent(new MouseEvent("mouseup", opts))
+    el.dispatchEvent(new MouseEvent("click", opts))
+  } catch {}
+  return el
+}
+
+export function focusIframeTextbox(iframe: HTMLIFrameElement): { doc: Document; textbox: HTMLElement } | null {
+  try {
+    const doc = iframe.contentDocument
+    if (!doc) return null
+    const textbox = doc.querySelector<HTMLElement>('[role=textbox]') || doc.querySelector<HTMLElement>('[contenteditable]')
+    if (!textbox) return null
+    try { iframe.focus() } catch {}
+    try { textbox.focus() } catch {}
+    return { doc, textbox }
+  } catch {
+    return null
+  }
+}
+
+export function dispatchKeysIn(target: Element, keys: string): void {
+  dispatchKeySequence(target, keys)
+}
+
+export function findElementById(id: string): Element | null {
+  try {
+    const direct = document.getElementById(id)
+    if (direct) return direct
+  } catch {}
+  try {
+    return document.querySelector(`#${CSS.escape(id)}`)
+  } catch {
+    return null
+  }
+}

--- a/extension/src/content/scene/profiles/canva.ts
+++ b/extension/src/content/scene/profiles/canva.ts
@@ -1,0 +1,89 @@
+import type { SceneProfile, SceneObject, SceneObjectType, SceneSelection } from "../types"
+import { boundingBox, parseTranslate } from "../ops"
+
+const LB_ID = /^LB[A-Za-z0-9_-]{14}$/
+
+function classify(el: Element): SceneObjectType {
+  if (el.querySelector("img")) return "image"
+  if (el.querySelector("svg")) return "shape"
+  const text = (el.textContent || "").trim()
+  if (text.length > 0) return "text"
+  return "unknown"
+}
+
+export const canvaProfile: SceneProfile = {
+  name: "canva",
+
+  detect(): boolean {
+    try {
+      return location.host.endsWith("canva.com") && location.pathname.includes("/design/")
+    } catch {
+      return false
+    }
+  },
+
+  list(opts?: { type?: string }): SceneObject[] {
+    const all = Array.from(document.querySelectorAll('[id^="LB"]'))
+    const out: SceneObject[] = []
+    for (const el of all) {
+      if (!LB_ID.test(el.id)) continue
+      const rect = el.getBoundingClientRect()
+      if (rect.width < 1 || rect.height < 1) continue
+      const style = (el as HTMLElement).style
+      const translate = parseTranslate(style.transform || "")
+      const dw = parseFloat(style.width || "0")
+      const dh = parseFloat(style.height || "0")
+      const type = classify(el)
+      if (opts?.type && opts.type !== type) continue
+      const textContent = type === "text" ? (el.textContent || "").trim().slice(0, 80) : undefined
+      out.push({
+        id: el.id,
+        type,
+        rect: boundingBox(el),
+        doc: translate && dw && dh ? { x: translate.x, y: translate.y, w: dw, h: dh } : undefined,
+        text: textContent
+      })
+    }
+    return out
+  },
+
+  resolve(id: string): Element | null {
+    if (!LB_ID.test(id)) return null
+    return document.getElementById(id)
+  },
+
+  selected(): SceneSelection {
+    const app = document.querySelector('[role="application"]')
+    const label = app?.getAttribute("aria-label") || undefined
+    if (!label) return { has: false }
+    return { has: true, label }
+  },
+
+  zoom(): number {
+    const all = Array.from(document.querySelectorAll('[style*="scale"]')) as HTMLElement[]
+    for (const el of all) {
+      const m = (el.style.transform || "").match(/scale\(([\d.]+)\)/)
+      if (m) {
+        const s = parseFloat(m[1])
+        if (s > 0 && s < 10) return s
+      }
+    }
+    return 1
+  },
+
+  hitTest(x: number, y: number): SceneObject | null {
+    const list = canvaProfile.list!() as SceneObject[]
+    let best: SceneObject | null = null
+    let bestArea = Infinity
+    for (const o of list) {
+      if (x >= o.rect.x && x <= o.rect.x + o.rect.w && y >= o.rect.y && y <= o.rect.y + o.rect.h) {
+        const area = o.rect.w * o.rect.h
+        if (area < bestArea) {
+          bestArea = area
+          best = o
+        }
+      }
+    }
+    return best
+  }
+}

--- a/extension/src/content/scene/profiles/generic.ts
+++ b/extension/src/content/scene/profiles/generic.ts
@@ -1,0 +1,53 @@
+import type { SceneProfile, SceneObject, SceneSelection } from "../types"
+import { boundingBox } from "../ops"
+
+export const genericProfile: SceneProfile = {
+  name: "generic",
+
+  detect(): boolean {
+    return true
+  },
+
+  list(): SceneObject[] {
+    const out: SceneObject[] = []
+    const selectors = [
+      { sel: "[role=application]", type: "group" as const },
+      { sel: "[role=main]", type: "page" as const },
+      { sel: "[role=document]", type: "page" as const }
+    ]
+    for (const { sel, type } of selectors) {
+      const els = Array.from(document.querySelectorAll(sel))
+      for (const el of els) {
+        const rect = el.getBoundingClientRect()
+        if (rect.width < 2 || rect.height < 2) continue
+        const id = el.id || `${sel.replace(/[[\]=]/g, "")}-${out.length}`
+        const text = (el.getAttribute("aria-label") || "").slice(0, 80)
+        out.push({
+          id,
+          type,
+          rect: boundingBox(el),
+          text: text || undefined
+        })
+      }
+    }
+    return out
+  },
+
+  resolve(id: string): Element | null {
+    if (!id) return null
+    try {
+      return document.getElementById(id) || document.querySelector(`[id="${CSS.escape(id)}"]`)
+    } catch {
+      return null
+    }
+  },
+
+  selected(): SceneSelection {
+    const app = document.querySelector("[role=application]")
+    const label = app?.getAttribute("aria-label") || undefined
+    return {
+      has: !!label,
+      label
+    }
+  }
+}

--- a/extension/src/content/scene/profiles/google-docs.ts
+++ b/extension/src/content/scene/profiles/google-docs.ts
@@ -1,0 +1,182 @@
+import type {
+  SceneProfile,
+  SceneObject,
+  SceneSelection,
+  SceneText,
+  SceneRenderResult
+} from "../types"
+import { boundingBox, clickAtViewport } from "../ops"
+
+function findTextEventTarget(): { iframe: HTMLIFrameElement; doc: Document; textbox: HTMLElement } | null {
+  const iframe = document.querySelector<HTMLIFrameElement>(".docs-texteventtarget-iframe")
+  if (!iframe) return null
+  try {
+    const doc = iframe.contentDocument
+    if (!doc) return null
+    const textbox =
+      doc.querySelector<HTMLElement>('[role="textbox"]') ||
+      doc.querySelector<HTMLElement>("[contenteditable]")
+    if (!textbox) return null
+    return { iframe, doc, textbox }
+  } catch {
+    return null
+  }
+}
+
+function kixCanvasTiles(): HTMLCanvasElement[] {
+  return Array.from(document.querySelectorAll<HTMLCanvasElement>(".kix-canvas-tile-content"))
+}
+
+function kixPages(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".kix-page-paginated"))
+}
+
+function kixEmbeds(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".kix-embeddedobjectdragger, .kix-embeddedobjectdragger-embeddedentity"))
+}
+
+export const googleDocsProfile: SceneProfile = {
+  name: "google-docs",
+
+  detect(): boolean {
+    try {
+      return location.host === "docs.google.com" && location.pathname.startsWith("/document/")
+    } catch {
+      return false
+    }
+  },
+
+  list(opts?: { type?: string }): SceneObject[] {
+    const out: SceneObject[] = []
+    if (!opts?.type || opts.type === "page") {
+      const pages = kixPages()
+      pages.forEach((p, i) => {
+        const rect = p.getBoundingClientRect()
+        if (rect.width < 2 || rect.height < 2) return
+        out.push({
+          id: `page-${i}`,
+          type: "page",
+          rect: boundingBox(p),
+          extras: { pageIndex: i }
+        })
+      })
+    }
+    if (!opts?.type || opts.type === "embed") {
+      const embeds = kixEmbeds()
+      embeds.forEach((e, i) => {
+        const rect = e.getBoundingClientRect()
+        if (rect.width < 2 || rect.height < 2) return
+        const aria = e.getAttribute("aria-label") || undefined
+        out.push({
+          id: `embed-${i}`,
+          type: "embed",
+          rect: boundingBox(e),
+          text: aria,
+          extras: { embedIndex: i }
+        })
+      })
+    }
+    return out
+  },
+
+  resolve(id: string): Element | null {
+    const pageMatch = id.match(/^page-(\d+)$/)
+    if (pageMatch) {
+      const idx = parseInt(pageMatch[1])
+      return kixPages()[idx] || null
+    }
+    const embedMatch = id.match(/^embed-(\d+)$/)
+    if (embedMatch) {
+      const idx = parseInt(embedMatch[1])
+      return kixEmbeds()[idx] || null
+    }
+    return null
+  },
+
+  selected(): SceneSelection {
+    const tet = findTextEventTarget()
+    if (!tet) return { has: false }
+    try {
+      const sel = tet.iframe.contentWindow?.getSelection()
+      if (!sel || sel.rangeCount === 0) return { has: false }
+      const range = sel.getRangeAt(0)
+      const text = range.toString()
+      return {
+        has: text.length > 0,
+        text: text.slice(0, 200),
+        label: text ? `selection(${text.length} chars)` : "caret"
+      }
+    } catch {
+      return { has: false }
+    }
+  },
+
+  text(opts?: { withHtml?: boolean }): SceneText | null {
+    const tet = findTextEventTarget()
+    if (!tet) return null
+    const text = (tet.textbox.textContent || "").toString()
+    return {
+      text,
+      html: opts?.withHtml ? tet.textbox.innerHTML : undefined,
+      length: text.length
+    }
+  },
+
+  writeAtCursor(text: string): { success: boolean; error?: string } {
+    const tet = findTextEventTarget()
+    if (!tet) return { success: false, error: "text event target iframe not found" }
+    try {
+      try { tet.iframe.focus() } catch {}
+      try { tet.textbox.focus() } catch {}
+      const iframeDoc = tet.doc as Document & { execCommand?: (c: string, ui: boolean, val?: string) => boolean }
+      let ok = false
+      try {
+        ok = !!iframeDoc.execCommand && iframeDoc.execCommand("insertText", false, text)
+      } catch {}
+      if (!ok) {
+        try {
+          const ev = new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: text })
+          tet.textbox.dispatchEvent(ev)
+          const ev2 = new InputEvent("input", { bubbles: true, cancelable: true, inputType: "insertText", data: text })
+          tet.textbox.dispatchEvent(ev2)
+          ok = true
+        } catch {}
+      }
+      if (!ok) return { success: false, error: "both execCommand and InputEvent dispatch failed" }
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  },
+
+  cursorTo(opts: { x: number; y: number }): { success: boolean; error?: string } {
+    try {
+      clickAtViewport(opts.x, opts.y)
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  },
+
+  async render(id: string): Promise<SceneRenderResult | null> {
+    const pageMatch = id.match(/^page-(\d+)$/)
+    if (!pageMatch) return null
+    const idx = parseInt(pageMatch[1])
+    const page = kixPages()[idx]
+    if (!page) return null
+    const canvas = page.querySelector<HTMLCanvasElement>(".kix-canvas-tile-content")
+    if (!canvas) return null
+    try {
+      const dataUrl = canvas.toDataURL("image/png")
+      return {
+        id,
+        width: canvas.width,
+        height: canvas.height,
+        dataUrl,
+        format: "png"
+      }
+    } catch (err) {
+      throw new Error(`render failed: ${(err as Error).message}`)
+    }
+  }
+}

--- a/extension/src/content/scene/profiles/google-slides.ts
+++ b/extension/src/content/scene/profiles/google-slides.ts
@@ -1,0 +1,176 @@
+import type { SceneProfile, SceneObject, SceneSelection, SceneSlideInfo, SceneRenderResult } from "../types"
+import { boundingBox, clickAtViewport } from "../ops"
+
+const FILMSTRIP_ID = /^filmstrip-slide-(\d+)-(gd[a-z0-9_-]+)$/i
+
+function gatherSlides(): SceneSlideInfo[] {
+  const all = Array.from(document.querySelectorAll<SVGGElement>('g[id^="filmstrip-slide-"]'))
+  const byIndex = new Map<number, SceneSlideInfo>()
+  // Build page-id → index map from punch-filmstrip-thumbnail wrappers so we can
+  // tag the `current` slide by the URL hash's pageId.
+  for (const g of all) {
+    if (g.id.endsWith("-bg")) continue
+    const m = g.id.match(FILMSTRIP_ID)
+    if (!m) continue
+    const index = parseInt(m[1], 10)
+    if (byIndex.has(index)) continue
+    const rect = boundingBox(g as unknown as Element)
+    const img = g.querySelector("image") as SVGImageElement | null
+    const blob = img ? (img.getAttribute("xlink:href") || img.getAttribute("href") || undefined) : undefined
+    const wrapper = g.closest("g.punch-filmstrip-thumbnail") as SVGGElement | null
+    const pageId = wrapper?.getAttribute("data-slide-page-id") || undefined
+    byIndex.set(index, { index, id: g.id, rect, blobUrl: blob, pageId } as SceneSlideInfo & { pageId?: string })
+  }
+  const out = Array.from(byIndex.values()).sort((a, b) => a.index - b.index)
+  const current = currentSlideId()
+  if (current) {
+    for (const s of out) {
+      const sWithPage = s as SceneSlideInfo & { pageId?: string }
+      if (sWithPage.pageId === current) s.current = true
+    }
+  }
+  return out
+}
+
+function currentSlideId(): string | null {
+  // Primary source: URL fragment `#slide=id.<pageId>`
+  try {
+    const h = window.location.hash
+    const m = h.match(/slide=id\.([A-Za-z0-9_]+)/)
+    if (m) {
+      const pageId = m[1]
+      if (pageId === "p") {
+        // Shortcut for slide 0: find the first thumbnail
+        const firstThumb = document.querySelector("g.punch-filmstrip-thumbnail") as SVGGElement | null
+        return firstThumb?.getAttribute("data-slide-page-id") || null
+      }
+      return pageId
+    }
+  } catch {}
+  // Fallback: active editor child
+  const main = document.querySelector('#editor-p') as SVGGElement | null
+  if (!main) return null
+  for (const child of Array.from(main.children)) {
+    const id = (child as Element).id || ""
+    if (id.startsWith("editor-gd")) return id.replace(/^editor-/, "")
+  }
+  return null
+}
+
+export const googleSlidesProfile: SceneProfile = {
+  name: "google-slides",
+
+  detect(): boolean {
+    try {
+      return location.host === "docs.google.com" && location.pathname.startsWith("/presentation/")
+    } catch {
+      return false
+    }
+  },
+
+  list(): SceneObject[] {
+    const slides = gatherSlides()
+    return slides.map((s) => ({
+      id: s.id,
+      type: "slide",
+      rect: s.rect,
+      text: s.blobUrl ? `[blob: ${s.blobUrl.slice(0, 40)}]` : undefined,
+      extras: { slideIndex: s.index, current: !!s.current, blobUrl: s.blobUrl }
+    }))
+  },
+
+  resolve(id: string): Element | null {
+    return document.getElementById(id)
+  },
+
+  selected(): SceneSelection {
+    const app = document.querySelector('[role=application]') as HTMLElement | null
+    const label = app?.getAttribute("aria-label") || undefined
+    const current = currentSlideId()
+    return { has: !!label || !!current, label, id: current || undefined }
+  },
+
+  slides(): SceneSlideInfo[] {
+    return gatherSlides()
+  },
+
+  slideCurrent(): SceneSlideInfo | null {
+    const slides = gatherSlides()
+    return slides.find((s) => s.current) || slides[0] || null
+  },
+
+  slideGoto(index: number): { success: boolean; error?: string } {
+    const slides = gatherSlides()
+    if (index < 0 || index >= slides.length) return { success: false, error: `slide index ${index} out of range (0..${slides.length - 1})` }
+    const target = slides[index]
+    const filmstripGroup = document.getElementById(target.id)
+    if (!filmstripGroup) return { success: false, error: `slide ${target.id} not in DOM` }
+    const thumbWrapper = filmstripGroup.closest("g.punch-filmstrip-thumbnail") as SVGGElement | null
+    if (!thumbWrapper) return { success: false, error: "no punch-filmstrip-thumbnail ancestor" }
+    // The real slide page ID is carried on `data-slide-page-id` on the
+    // .punch-filmstrip-thumbnail wrapper. Use that to build the URL fragment.
+    const pageId = thumbWrapper.getAttribute("data-slide-page-id")
+    if (!pageId) return { success: false, error: "no data-slide-page-id on thumbnail" }
+    // Google Slides' hash format is `#slide=id.<pageId>` where pageId is what we
+    // see on data-slide-page-id (e.g. `gd02e148143_0_12`). For the very first
+    // slide the shortcut `#slide=id.p` is also accepted.
+    const newHash = `#slide=id.${pageId}`
+    try {
+      window.location.hash = newHash
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  },
+
+  notes(slideIndex?: number): string | null {
+    const paragraphs = Array.from(document.querySelectorAll('[id^="speakernotes-i"][id*="paragraph"]'))
+    if (paragraphs.length === 0) {
+      const notesContainer = document.getElementById("speakernotes") || document.getElementById("speakernotes-workspace")
+      if (notesContainer) return (notesContainer.textContent || "").trim() || null
+      return null
+    }
+    const text = paragraphs.map((p) => (p.textContent || "").trim()).filter(Boolean).join("\n")
+    void slideIndex
+    return text || null
+  },
+
+  text(): { text: string; html?: string; length: number } | null {
+    const iframe = document.querySelector<HTMLIFrameElement>(".docs-texteventtarget-iframe")
+    if (!iframe) return null
+    try {
+      const doc = iframe.contentDocument
+      if (!doc) return null
+      const textbox = doc.querySelector<HTMLElement>('[role=textbox]') || doc.querySelector<HTMLElement>('[contenteditable]')
+      if (!textbox) return null
+      const text = (textbox.textContent || "").trim()
+      return { text, length: text.length }
+    } catch {
+      return null
+    }
+  },
+
+  async render(id: string): Promise<SceneRenderResult | null> {
+    const slide = document.getElementById(id) as SVGGElement | null
+    if (!slide) return null
+    const img = slide.querySelector("image") as SVGImageElement | null
+    if (!img) return null
+    const href = img.getAttribute("xlink:href") || img.getAttribute("href")
+    if (!href) return null
+    try {
+      const resp = await fetch(href)
+      const blob = await resp.blob()
+      const bitmap = await createImageBitmap(blob)
+      const canvas = document.createElement("canvas")
+      canvas.width = bitmap.width
+      canvas.height = bitmap.height
+      const ctx = canvas.getContext("2d")
+      if (!ctx) return null
+      ctx.drawImage(bitmap, 0, 0)
+      const dataUrl = canvas.toDataURL("image/png")
+      return { id, width: bitmap.width, height: bitmap.height, dataUrl, format: "png" }
+    } catch {
+      return null
+    }
+  }
+}

--- a/extension/src/content/scene/types.ts
+++ b/extension/src/content/scene/types.ts
@@ -1,0 +1,81 @@
+export type SceneObjectType = "image" | "shape" | "text" | "group" | "page" | "slide" | "embed" | "unknown"
+
+export interface SceneRect {
+  x: number
+  y: number
+  w: number
+  h: number
+  cx: number
+  cy: number
+}
+
+export interface SceneDocCoord {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface SceneObject {
+  id: string
+  type: SceneObjectType
+  rect: SceneRect
+  doc?: SceneDocCoord
+  text?: string
+  extras?: Record<string, unknown>
+}
+
+export interface SceneSelection {
+  has: boolean
+  label?: string
+  id?: string
+  text?: string
+  extras?: Record<string, unknown>
+}
+
+export interface SceneText {
+  text: string
+  html?: string
+  length: number
+}
+
+export interface SceneRenderResult {
+  id: string
+  width: number
+  height: number
+  dataUrl: string
+  format: "png" | "jpeg"
+}
+
+export interface SceneSlideInfo {
+  index: number
+  id: string
+  rect: SceneRect
+  blobUrl?: string
+  current?: boolean
+}
+
+export interface SceneProfile {
+  name: string
+  detect(): boolean
+  list?(opts?: { type?: string }): SceneObject[]
+  resolve?(id: string): Element | null
+  selected?(): SceneSelection
+  zoom?(): number
+  text?(opts?: { withHtml?: boolean }): SceneText | null
+  writeAtCursor?(text: string): { success: boolean; error?: string }
+  cursorTo?(opts: { x: number; y: number }): { success: boolean; error?: string }
+  render?(id: string): Promise<SceneRenderResult | null>
+  slides?(): SceneSlideInfo[]
+  slideCurrent?(): SceneSlideInfo | null
+  slideGoto?(index: number): { success: boolean; error?: string }
+  notes?(slideIndex?: number): string | null
+  hitTest?(x: number, y: number): SceneObject | null
+}
+
+export interface SceneEngineResult<T = unknown> {
+  success: boolean
+  data?: T
+  error?: string
+  profile?: string
+}

--- a/prd/PRD-13.md
+++ b/prd/PRD-13.md
@@ -1,0 +1,452 @@
+# PRD-13: Session Monitor — Capture User Actions, DOM Mutations, and Network Side Effects for Agent Replay
+
+**Goal:** Add a `slop monitor` command surface that records a complete trace of a user's interaction session — every real click, keystroke, form change, navigation, DOM mutation, and network call the page made as a consequence — in a single sparse append-only log that an agent can read back and replay as a batch of `slop` commands. No CDP. No debugger infobanner. No pretty-printed JSON.
+
+**Scope:** New `extension/src/content/monitor.ts` (ISOLATED world capture-phase listeners + MutationObserver + `__slop_net` subscription), new `background/capabilities/monitor.ts` (state, webNavigation wiring, event fan-out), new `cli/commands/monitor.ts` (start / stop / status / tail / export / replay-plan). Reuses the existing `EVENTS_PATH` JSONL stream in the daemon for persistence and the existing `sendToHost({ type: "event", ... })` bridge for transport.
+
+**Non-Negotiable:**
+1. **No CDP.** This PRD must not attach `chrome.debugger`. The whole point of the monitor is to be invisible to the page and to the user (no yellow infobanner, no viewport shift).
+2. **Sparse format.** One event per line. No pretty-printed JSON with 80 spaces of indent. Each event ≤ ~300 bytes in the common case. Agents consume this on a budget.
+3. **Capture-phase, passive.** Listeners use `{ capture: true, passive: true }` so a misbehaving page handler can never stop us from seeing the event, and we never interfere with the page's own handlers.
+4. **Correlated.** Every user action is tagged with a monotonic session-local `seq` and wall-clock `ts`. Every network call fired within N ms of that action is tagged with the same `cause` seq, so an agent can read "click #7 caused /api/search fetch and 3 DOM mutations in 180ms."
+5. **Replayable.** `slop monitor export --as plan` produces a plain text batch of `slop` commands reproducible without the source session — not a JSON dump.
+
+---
+
+## Evidence Sources
+
+| ID | Source | Path | How to access |
+|----|--------|------|---------------|
+| SLOP-CONTENT | content script entry + dispatcher | `extension/src/content.ts` | `read` |
+| SLOP-INJECT | MAIN-world fetch/XHR patch | `extension/src/inject-net.ts` | `read` — emits `__slop_net` CustomEvent |
+| SLOP-NETBUF | net-buffer + `__slop_net` listener | `extension/src/content/net-buffer.ts` | `read` — where content script subscribes today |
+| SLOP-DOMOBS | existing MutationObserver | `extension/src/content/dom-observer.ts` | `read` — sets `domDirty` flag only, doesn't emit |
+| SLOP-REFREG | element ref registry (`e1`, `e2`, ...) | `extension/src/content/ref-registry.ts` | `read` — stable element IDs for replay |
+| SLOP-A11Y | effective role + accessible name | `extension/src/content/a11y-tree.ts` | `read` — `getEffectiveRole`, `getAccessibleName` |
+| SLOP-INPUT | click/key dispatch sequence | `extension/src/content/input-simulation.ts` | `read` — `dispatchClickSequence`, `dispatchKeySequence` |
+| SLOP-TRANSPORT | extension → daemon event bridge | `extension/src/background/transport.ts` | `read` — `sendToHost({ type: "event", event, ...data })` |
+| SLOP-DAEMON | daemon event persistence | `daemon/index.ts` lines 11-24 | `read` — `emitEvent()` → `appendFileSync(EVENTS_PATH, ...)` with 10MB rotation |
+| SLOP-EVENTS-CLI | existing `slop events` command | `cli/commands/meta.ts` case `"events"` | `read` — tail + since filter already work |
+| SLOP-PLATFORM | EVENTS_PATH config | `shared/platform.ts` | `/tmp/slop-browser-events.jsonl`, 10 MB cap |
+| SLOP-ROUTER | action routing | `extension/src/background/router.ts` | `read` — where new monitor actions register |
+| SLOP-MANIFEST | MV3 permissions | `extension/manifest.json` | Already has `webNavigation`, `scripting`, `tabs`, `activeTab`; no new permissions needed |
+| CHR-CS | Chrome content scripts (isolated / MAIN worlds, `run_at`) | `80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/content-scripts.md` | Line 33: "Content scripts live in an isolated world" — line 144: `world` defaults to ISOLATED |
+| CHR-MSG | Chrome messaging | `80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/messaging.md` | Line 12: one-time vs long-lived; line 239: `chrome.runtime.connect` for streaming |
+| CHR-WEBNAV | webNavigation API | `80_Reference/docs/chrome-extensions/docs/extensions/reference/api/webNavigation.md` | Line 48: `onHistoryStateUpdated` fires on `history.pushState`; line 858: handler signature |
+| CHR-SCRIPTING | scripting.executeScript / registerContentScripts | `80_Reference/docs/chrome-extensions/docs/extensions/reference/api/scripting.md` | For on-demand monitor injection instead of always-on |
+| BUN-FILE | `Bun.file().writer()` FileSink | `80_Reference/docs/bun/docs/runtime/file-io.md` lines 157-200 | Incremental writes, buffered, `flush()` + `end()` |
+| BUN-JSONL | `Bun.JSONL.parse()` | `80_Reference/docs/bun/docs/runtime/jsonl.md` lines 5-39 | Built-in JSONL parser for CLI-side replay |
+| DOM-CAPTURE | capture-phase `addEventListener` + `composedPath()` | DOM spec (no local doc) | `{ capture: true }` fires before target's listeners; `composedPath()` crosses shadow roots |
+| DOM-TRUSTED | `Event.isTrusted` | DOM spec (no local doc) | `true` for user-generated events, `false` for `dispatchEvent()` — critical to distinguish a real user click from slop's own click simulation |
+
+---
+
+## The Problem
+
+### What Ron actually wants to do
+
+> "I want to be able to capture exactly where the user is clicking and also what are the subsequent things that happen down the stack when something is clicked... monitor my clicks and also monitor some of those JavaScript changes that happen in the background, just so an agent can repeat this process."
+
+Translated: Ron performs a task in the browser once, manually. slop writes down what he did AND what the page did in response. Later, an agent reads the trace, understands the flow, and replays it as a batch of `slop` commands — including knowing which XHR call produced the data it needs to extract.
+
+This is a **teaching loop**: Ron → slop → agent. Ron demonstrates. Agent learns. Agent repeats.
+
+### Why the pieces we already have don't cover it
+
+| Piece we have | What it does | What's missing |
+|---------------|--------------|----------------|
+| `inject-net.ts` | Captures fetch/XHR passively | No correlation with user actions. A log of 200 XHRs with no "which click caused which call" is useless for replay. |
+| `net-buffer.ts` | Buffers 500 net entries in content script | Buffer lives in-tab, is flushed on navigation, never written to disk. A 30-minute session is lost the moment the tab closes. |
+| `dom-observer.ts` | MutationObserver sets `domDirty` flag | Doesn't emit events, doesn't remember what changed, doesn't stream. Only answers "did anything change since last tree read?" |
+| `snapshot-diff.ts` | Diffs two refRegistry snapshots | Manual — you must call `cacheSnapshot()` before and `computeSnapshotDiff()` after. No streaming, no correlation to actions. |
+| `input-simulation.ts` | Dispatches synthetic clicks / keys for slop's own commands | Only the *outbound* direction. Does not observe user input at all. |
+| `slop events` CLI | Tails the daemon event log | Only shows slop's own request/response cycle (`request_received`, `request_complete`) — not user clicks, not page DOM, not page network. |
+| `chrome.debugger` / CDP | Could in principle dispatch Input events from DevTools protocol | Shows yellow infobanner, shifts viewport [SLOP-CONTENT: comments about `chrome.debugger` infobanner], detected by anti-bot checks. Non-negotiable: **no CDP**. |
+
+We have the low-level primitives — MutationObserver, `__slop_net`, ref registry, a11y tree, event log — but there is **no component that ties real-user input to DOM mutations to network calls into a single correlated stream, and no component that writes that stream anywhere an agent can read it later**.
+
+That component is this PRD.
+
+---
+
+## Architecture
+
+### Overview
+
+```
+┌───────────────────────── Chrome Tab ─────────────────────────┐
+│                                                                │
+│  MAIN world  (inject-net.ts — already exists)                  │
+│  ─────────────────────────────────────────────                 │
+│  window.fetch, XHR.prototype monkey-patches                    │
+│              │ CustomEvent('__slop_net', detail)               │
+│              ▼                                                 │
+│  ISOLATED world  (content.ts + new content/monitor.ts)         │
+│  ─────────────────────────────────────────────                 │
+│  document.addEventListener(                                    │
+│    'click' 'input' 'change' 'submit' 'keydown' 'scroll',       │
+│    { capture: true, passive: true }                            │
+│  )                                                             │
+│  MutationObserver(document.documentElement, deep)              │
+│  __slop_net listener (from net-buffer, reused)                 │
+│              │                                                 │
+│              ▼                                                 │
+│  Monitor state                                                 │
+│    seq counter                                                 │
+│    cause stack (last 3 user actions within 500ms)              │
+│    mutation batcher (coalesce @ 50ms)                          │
+│    event serializer (sparse wire format)                       │
+│              │ chrome.runtime.sendMessage({ type: 'mon_evt' }) │
+└──────────────┼─────────────────────────────────────────────────┘
+               ▼
+┌──────────── Background Service Worker ─────────────────────────┐
+│  router.ts dispatches to background/capabilities/monitor.ts    │
+│    session state: { id, tabId, startedAt, paused }             │
+│    webNavigation listeners (history.pushState / onCommitted)   │
+│    sendToHost({ type: 'event', event: 'mon_*', ...data })      │
+└──────────────┼─────────────────────────────────────────────────┘
+               ▼ native messaging / websocket
+┌──────────── daemon/index.ts (Bun) ─────────────────────────────┐
+│  handleNativeMessage → emitEvent('mon_*', ...)                 │
+│  → appendFileSync(EVENTS_PATH, line + '\n')                    │
+│  → rotates at 10 MB                                            │
+└──────────────┼─────────────────────────────────────────────────┘
+               ▼
+           /tmp/slop-browser-events.jsonl
+               ▲
+┌──────────── slop CLI ──────────────────────────────────────────┐
+│  slop monitor start  → action: { type: 'monitor_start' }       │
+│  slop monitor stop   → action: { type: 'monitor_stop' }        │
+│  slop monitor status → action: { type: 'monitor_status' }      │
+│  slop monitor tail   → reads EVENTS_PATH directly, filters     │
+│  slop monitor export → Bun.JSONL.parse + sparse render         │
+│  slop monitor plan   → emit batch of 'slop <cmd>' lines        │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Why this layout
+
+- **Capture-phase listeners in ISOLATED world** instead of MAIN world: we only need to OBSERVE, not to intercept. ISOLATED is already where `content.ts` and `net-buffer.ts` live, so we inherit the existing `__slop_net` subscription without crossing worlds. Capture phase + `passive: true` means page handlers can't `stopPropagation()` us and we can't block page behavior [DOM-CAPTURE].
+- **MutationObserver on `document.documentElement`** instead of `document.body`: catches attribute changes on `<html>` (common in SPA theme toggles and `lang` changes) and the body-swap case some frameworks do on route transitions. Subtree + attributes + childList + characterData.
+- **`chrome.runtime.sendMessage` per event** is fire-and-forget — we don't need a port because we never wait for an ack. If the service worker is asleep, MV3 wakes it [CHR-MSG]. If bursts become a problem, Phase 4 adds a batched port.
+- **Daemon reuses `emitEvent()`**: no new transport. Events land in the existing `/tmp/slop-browser-events.jsonl` [SLOP-DAEMON lines 11-24], which already rotates at 10 MB [SLOP-PLATFORM: `EVENTS_MAX_SIZE = 10 * 1024 * 1024`], and `slop events` already tails it [SLOP-EVENTS-CLI]. The monitor is a new *consumer schema* on an existing pipe.
+- **webNavigation.onHistoryStateUpdated** catches SPA navigation without CDP and without monkey-patching `history.pushState` [CHR-WEBNAV line 48]. The permission is already granted [SLOP-MANIFEST].
+
+### Session lifecycle
+
+1. `slop monitor start` → CLI sends `monitor_start` to background.
+2. Background records `{ sessionId: uuid, tabId, startedAt: Date.now(), instruction?: string }`, tells the content script to arm listeners, and registers the webNavigation listener for that `tabId`.
+3. Background emits `mon_start` event with the session record.
+4. User interacts with the page. Content script streams `mon_*` events.
+5. `slop monitor stop` → background unregisters listeners, tells content script to disarm, emits `mon_stop` with `endedAt` + counts.
+6. Sessions are delimited in the event log by `mon_start` / `mon_stop` pairs containing `sessionId`. A single `EVENTS_PATH` holds multiple sessions historically — the CLI filters by `sessionId`.
+
+### Optional instruction priming
+
+Per Ron's ask — *"especially if a user gives the instruction beforehand"*:
+
+```
+slop monitor start --instruction "search for bun docs, open the first result, copy the first paragraph"
+```
+
+The instruction string is attached to `mon_start`. `slop monitor export` prints it as the first line of the export. An agent reading the trace has both the *intent* (what Ron wanted to do) and the *observation* (what Ron actually did). This makes the replay much more robust — the agent can tell whether a particular click was essential or an accidental misclick.
+
+---
+
+## Sparse Event Format
+
+### Wire format (one JSON object per line, no pretty-printing)
+
+Every event has the same three header fields and then a small number of type-specific fields. Field names are kept short (2-4 chars) so the common case stays under 300 bytes.
+
+```
+{"t":1775409372123,"s":0,"k":"mon_start","sid":"7f3e...","tid":413782019,"url":"https://example.com/","ins":"search for bun docs"}
+{"t":1775409374001,"s":1,"k":"click","sid":"7f3e...","ref":"e42","r":"button","n":"Search","x":412,"y":187,"tr":true}
+{"t":1775409374015,"s":2,"k":"input","sid":"7f3e...","ref":"e17","r":"textbox","n":"Query","v":"bun docs","ic":true}
+{"t":1775409374062,"s":3,"k":"mut","sid":"7f3e...","c":1,"add":4,"rem":1,"attr":2,"cause":1}
+{"t":1775409374128,"s":4,"k":"fetch","sid":"7f3e...","u":"/api/search?q=bun+docs","m":"GET","st":200,"bz":2417,"cause":1}
+{"t":1775409374210,"s":5,"k":"nav","sid":"7f3e...","u":"https://example.com/search?q=bun+docs","typ":"history","cause":1}
+{"t":1775409376801,"s":6,"k":"mon_stop","sid":"7f3e...","evt":24,"mut":8,"net":3,"dur":4678}
+```
+
+### Field dictionary
+
+| Field | Meaning | Types |
+|-------|---------|-------|
+| `t` | Wall-clock timestamp (ms since epoch) | all |
+| `s` | Monotonic seq within session | all |
+| `k` | Event kind | all — one of `mon_start`, `mon_stop`, `mon_pause`, `mon_resume`, `click`, `dblclick`, `rclick`, `input`, `change`, `submit`, `key`, `scroll`, `focus`, `blur`, `copy`, `paste`, `mut`, `fetch`, `xhr`, `nav`, `reload`, `error` |
+| `sid` | Session ID | all |
+| `tid` | Tab ID | `mon_start`, `nav` |
+| `url` | URL | `mon_start`, `nav`, `fetch`, `xhr` |
+| `ins` | Instruction text (optional) | `mon_start` |
+| `ref` | Element ref (`e42`) from ref-registry, assigned on demand | `click`, `input`, `change`, `submit`, `focus`, `blur`, `key` |
+| `r` | Effective ARIA role (from `a11y-tree.getEffectiveRole`) | user actions on elements |
+| `n` | Accessible name (from `a11y-tree.getAccessibleName`), truncated to 80 chars | user actions on elements |
+| `tg` | Tag name (lowercase), only when role doesn't cover it | user actions |
+| `x`, `y` | Viewport click coords | `click`, `dblclick`, `rclick` |
+| `sel` | CSS selector fallback when `ref` isn't sufficient | user actions |
+| `v` | Input value, truncated to 120 chars; passwords masked to `***N***` where N is length | `input`, `change` |
+| `ic` | `composed` — did event cross a shadow root? | user actions |
+| `tr` | `isTrusted` — true for real user events, false if slop's own `dispatchClickSequence` caused it | user actions |
+| `kc` | Key combo (`Enter`, `Control+A`) | `key` |
+| `sx`, `sy` | Scroll deltas | `scroll` (throttled @ 100ms) |
+| `c` | Mutation batch count (how many mutations were collapsed into this `mut` event) | `mut` |
+| `add`, `rem`, `attr`, `txt` | Mutations of each kind inside batch | `mut` |
+| `tgts` | Up to 5 target refs affected by mutation batch | `mut` |
+| `u` | URL (request URL for net, destination URL for nav) | `fetch`, `xhr`, `nav` |
+| `m` | HTTP method | `fetch`, `xhr` |
+| `st` | HTTP status | `fetch`, `xhr` |
+| `bz` | Response body size in bytes | `fetch`, `xhr` |
+| `ct` | Response content-type (first 40 chars) | `fetch`, `xhr` |
+| `typ` | Navigation sub-type: `hard`, `history`, `reference` | `nav` |
+| `cause` | `s` of the user action this event is attributed to | `mut`, `fetch`, `xhr`, `nav` |
+| `evt`, `mut`, `net`, `dur` | Session totals | `mon_stop` |
+
+### Causality rule
+
+When a `mut`, `fetch`, `xhr`, or `nav` event arrives, the content script looks up the **most recent user-action seq within 500ms** and writes it as `cause`. If no user action was within the window, `cause` is omitted — the side effect was autonomous (polling, timer, etc.). 500ms covers the synchronous handler chain (~0-5 ms), a short awaited step, and a network round-trip that resolves before the page re-paints.
+
+### Response bodies are NOT streamed
+
+The wire format carries only `bz` (size) and `ct` (content-type). The actual response body is already in the `net-buffer` ring buffer (up to 500 entries) and is retrievable via the existing `slop net log --filter <url>` mechanism. Storing bodies twice would blow up the event log. On `slop monitor export`, the exporter can optionally merge body data back in from the net buffer for the last 500 requests — see Phase 5.
+
+### Why short field names
+
+A 30-minute recording of an SPA session can easily produce 2,000 events. At 300 bytes/event that's 600 KB — within the 10 MB rotation cap but comfortable. If we used `{"timestamp":...,"sequence":...,"kind":"click","ref":"e42","role":"button","accessibleName":"Search",...}` we'd triple the line size. Agents tokenize JSON key names just like values. Shorter keys = more events fit in the agent's context window.
+
+---
+
+## CLI Surface
+
+```
+slop monitor start [--instruction "<text>"] [--tab <id>]
+slop monitor stop
+slop monitor pause
+slop monitor resume
+slop monitor status
+
+slop monitor tail                        # live tail of current session (k != mon_*)
+slop monitor tail --raw                  # no pretty rendering
+slop monitor list                        # list sessions seen in EVENTS_PATH
+slop monitor export <sessionId>          # pretty text rendering of a session
+slop monitor export <sessionId> --json   # raw JSONL for that session
+slop monitor export <sessionId> --plan   # emit 'slop <cmd>' replay script
+slop monitor export <sessionId> --with-bodies
+                                         # merge net-buffer bodies (if still in ring)
+```
+
+### Pretty text rendering (not --raw)
+
+```
+session 7f3e2c1a  started 2026-04-07 12:44:32  tab 413782019  https://example.com/
+  instruction: search for bun docs, open first result, copy first paragraph
+
+  [+0.000]  start
+  [+1.878]  click     e42  button  "Search"           (412,187)  trusted
+  [+1.892]  input     e17  textbox "Query"            v="bun docs"
+  [+1.939]  mut       +4 -1 attr:2                    (cause: click#1)
+  [+2.005]  fetch     GET /api/search?q=bun+docs 200  2.4 kB     (cause: click#1)
+  [+2.087]  nav       history → /search?q=bun+docs    (cause: click#1)
+  [+2.312]  mut       +12 -3 attr:5                   (cause: click#1)
+  [+4.678]  stop      24 evt  8 mut  3 net  4.7 s
+```
+
+Columns are right-aligned so a scanning eye lines up causes with effects. `[+1.878]` is seconds since session start.
+
+### Replay plan output (--plan)
+
+```
+# Replay plan for session 7f3e2c1a
+# Instruction: search for bun docs, open first result, copy first paragraph
+# Generated from /tmp/slop-browser-events.jsonl at 2026-04-07T13:02:11Z
+
+slop tab new "https://example.com/"
+slop wait-stable
+slop find "Search" --role button
+slop click e42
+slop wait-stable
+slop find "Query" --role textbox
+slop type e17 "bun docs"
+slop keys Enter
+slop wait-stable
+slop net log --filter /api/search --limit 1
+slop extract-text e99
+```
+
+Notes on the plan generator:
+1. It uses the original `ref` IDs only as hints — the replay actually emits `slop find "<name>" --role <role>` because refs don't survive navigation. Role + accessible name is the stable identifier.
+2. If a `fetch`/`xhr` was correlated to the click and the response body is still in the net buffer, the plan emits `slop net log --filter <path>` afterward so the agent can read what the page learned.
+3. Mutation events with `cause` become implicit `slop wait-stable` markers — the replay plan assumes the agent waits after each action until mutations settle.
+4. Autonomous events (no `cause`) are logged as comments only: `# autonomous: fetch /api/tick (polling)`.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Content script monitor (P0)
+
+**Files:** `extension/src/content/monitor.ts` (new), `extension/src/content.ts` (modified to import and register)
+
+- [x] 1.1: Create `content/monitor.ts` with module-level state: `armed`, `sessionId`, `startedAt`, `seq`, `recentUserActions: Array<{seq, t}>` (cap 16), `mutationBatch: []`, `mutationFlushTimer: null`.
+- [x] 1.2: Export `arm(sessionId: string, startedAt: number)` — sets `armed=true`, resets `seq=0`, attaches listeners.
+- [x] 1.3: Export `disarm()` — removes all listeners, flushes any pending mutation batch, sets `armed=false`.
+- [x] 1.4: Attach capture-phase listeners to `document` for: `click`, `dblclick`, `contextmenu`, `input`, `change`, `submit`, `keydown`, `focus`, `blur`, `copy`, `paste`, `scroll`. Options: `{ capture: true, passive: true }`.
+- [x] 1.5: Each listener: build a compact event object using `composedPath()[0]` as the target (handles shadow DOM), resolve `ref` via `getOrAssignRef`, pull `r`, `n` from `getEffectiveRole` / `getAccessibleName`, include `tr: event.isTrusted`. Scroll events throttle to one per 100ms (deltas accumulated).
+- [x] 1.6: Password masking: if target is `input[type=password]`, emit `v: "***" + length + "***"` not raw text.
+- [x] 1.7: Value truncation: any `v` field is `.slice(0, 120)` + `"…"` when longer.
+- [x] 1.8: Each user-action emit also pushes `{seq, t}` onto `recentUserActions` (cap at 16, drop oldest).
+- [x] 1.9: MutationObserver on `document.documentElement` with `{ childList: true, subtree: true, attributes: true, characterData: true }`. On each batch callback: increment counters (add/rem/attr/txt), collect up to 5 affected refs via `getOrAssignRef`, set a 50ms debounce timer to emit a single `mut` event.
+- [x] 1.10: `mut` emit: look up `cause` by walking `recentUserActions` backward for entries within 500ms; omit `cause` if none. Emit event and reset batch.
+- [x] 1.11: Subscribe to `__slop_net` (reuse pattern from `net-buffer.ts`, but a separate listener so it works even if net-buffer is disabled). On each entry: look up `cause` same way, emit `fetch` or `xhr` event with `bz = body.length`, `ct = headers['content-type']?.slice(0,40)`.
+- [x] 1.12: Handle message `monitor_arm { sessionId, startedAt }` → call `arm`, reply `{ success: true }`.
+- [x] 1.13: Handle message `monitor_disarm` → call `disarm`, reply with `{ evt, mut, net }` counts.
+- [x] 1.14: All emits go through a single `emit(obj)` helper that does `chrome.runtime.sendMessage({ type: "mon_evt", obj })` — no formatting here, background serializes.
+- [x] 1.15: Emitter must never throw. Wrap every field lookup in try/catch. A broken event is dropped, never crashes the monitor.
+- [x] 1.16: Import `content/monitor.ts` side-effect from `content.ts` so it's in every frame.
+
+**Acceptance criteria:**
+- [x] Real user click on a page produces one `click` event with `tr: true`. *(verified by code: capture-phase listener reads `e.isTrusted`; live verification per `Notes/monitor.md` smoke test)*
+- [x] slop's own `dispatchClickSequence` produces a `click` event with `tr: false`. *(verified by code; the `buildPlan` unit test exercises the `tr:false` filter end-to-end)*
+- [x] Typing into a password field never emits the raw value — only masked length. *(verified by `buildPlan emits TODO for masked password inputs` unit test plus the `isPasswordLike` + `maskedValue` content-script helpers)*
+- [x] 50 consecutive `attributes` mutations collapse into a single `mut` event with `attr: 50` and up to 5 target refs. *(verified by code: 50ms debounce + per-batch `attr` counter + `tgts` slice 0..5)*
+- [x] A fetch that fires 80 ms after a click carries `cause: <click_seq>`. *(verified by `findCause` walking `recentUserActions` ring within 500ms; `buildPlan` test asserts cause-tagged plans)*
+- [x] A polling fetch with no preceding user action carries no `cause` field. *(verified by code: cause is omitted when no recent action; plan generator emits `# autonomous` comment)*
+- [x] Scroll events throttle to one per 100ms. *(verified by code: `handleScroll` debounce timer + accumulated `sx`/`sy` deltas)*
+- [x] Disarming flushes any pending mutation batch and stops all listeners. *(verified by code: `disarm()` calls `flushMutationBatch()` and detaches every listener)*
+
+### Phase 2: Background capability + webNavigation + session state (P0)
+
+**Files:** `extension/src/background/capabilities/monitor.ts` (new), `extension/src/background/router.ts` (register), `extension/src/background/transport.ts` (no change — reuse `sendToHost` path)
+
+- [x] 2.1: Create `background/capabilities/monitor.ts` with module-level `sessions: Map<sessionId, { tabId, startedAt, instruction?, counts: { evt, mut, net, nav }, seq, paused, url }>` and `activeSessionByTab: Map<tabId, sessionId>`.
+- [x] 2.2: Handle `monitor_start` action: generate `sessionId = crypto.randomUUID()`, read tab URL, record session, emit `mon_start` via `sendToHost({ type: "event", event: "mon_start", sid, tid, url, ins: instruction, t, s })`, then send `monitor_arm` to content script.
+- [x] 2.3: Handle `monitor_stop` action: look up session by tab, send `monitor_disarm` to content script, emit `mon_stop` with counts and `dur`, delete session.
+- [x] 2.4: Handle `monitor_status` action: returns `{ active, sessions[] }` with per-session counts, url, instruction, ageMs; supports per-tab lookup via `action.tabId`.
+- [x] 2.5: Handle `monitor_pause` / `monitor_resume` actions: update `paused` flag on session, emit `mon_pause` / `mon_resume` events, re-arm content script on resume.
+- [x] 2.6: `chrome.webNavigation.onHistoryStateUpdated` listener registered once; emits `nav` event with `typ: "history"`, `u`, `tt`, `tq` for active session tabs only (frameId === 0).
+- [x] 2.7: `chrome.webNavigation.onCommitted` listener registered once; emits `nav` event with `typ: "hard"` (or `"reload"` when `transitionType === "reload"`), plus reference-fragment updates as `typ: "reference"`.
+- [x] 2.8: `chrome.webNavigation.onCompleted` fires after hard navigation; background re-sends `monitor_arm` to the tab so the freshly-injected content script re-arms. Background tracks the per-session `seq` counter so it survives navigation (global monotonic within session).
+- [x] 2.9: `chrome.runtime.onMessage` listener registered via `registerMonitorListeners()` handles `mon_evt` from content scripts: uses `sender.tab.id` + `sender.frameId`, looks up active session, strips `k`, calls `emitMonEvent(session, kind, payload)` which adds `sid`, `s`, `t` and forwards via `sendToHost({ type: "event", event: kind, ... })`.
+- [x] 2.10: Register monitor action types in `background/router.ts` `MONITOR_ACTIONS` set: `monitor_start`, `monitor_stop`, `monitor_status`, `monitor_pause`, `monitor_resume`, plus added `monitor_status` to `needsTab` no-tab list in `message-dispatch.ts`.
+
+**Acceptance criteria:**
+- [x] `monitor_start` returns `{ sessionId }` and the content script is armed. *(verified by code: handler returns `data: { sessionId, tabId, startedAt, url, instruction }`; `sendArmToTab` follows)*
+- [x] `monitor_stop` returns `{ sessionId, evt, mut, net, dur }` and the content script is disarmed. *(verified by code: handler returns full counts and dur; `sendDisarmToTab` follows)*
+- [x] A hard navigation during an active session results in events continuing to land in the same `sessionId`. *(verified by code: `chrome.webNavigation.onCompleted` re-fires `monitor_arm` with the original sessionId)*
+- [x] `history.pushState` in the page produces a `nav` event with `typ: "history"`. *(verified by code: `onHistoryStateUpdated` emits `typ: "history"`)*
+- [x] Closing the tab implicitly stops the session — background's `chrome.tabs.onRemoved` emits `mon_stop` with reason `tab_closed`. *(verified by code: `chrome.tabs.onRemoved` listener inside `registerWebNavListenersOnce` emits `mon_stop` with `reason: "tab_closed"`)*
+
+### Phase 3: Daemon passthrough (P0 — minimal change)
+
+**Files:** `daemon/index.ts` (verify, no logic change)
+
+- [x] 3.1: Verify `handleNativeMessage` with `{ type: "event", event, ...data }` already calls `emitEvent(event, data)` [SLOP-DAEMON lines 90-93]. No change needed.
+- [x] 3.2: Verify `EVENTS_MAX_SIZE = 10 MB` rotation works for the heavier event volume [SLOP-PLATFORM].
+- [x] 3.3: Consider (but don't require) swapping the current `appendFileSync(EVENTS_PATH, ...)` to a persistent `Bun.file(EVENTS_PATH).writer()` FileSink for higher throughput [BUN-FILE lines 157-200]. **Deferred** — current append rate is fine for v1.
+- [x] 3.X: **Patch the daemon ws handler** to route `{ type: "event" }` messages from the extension ws channel into `handleNativeMessage`. Pre-patch, the ws path only handled `"extension"`, `"keepalive"`, and `id+result` pairs — `type:"event"` messages would have fallen through to the action-request branch and been dropped. Three-line addition mirrors the stdin path.
+
+**Acceptance criteria:**
+- [x] Daemon writes monitor events to `/tmp/slop-browser-events.jsonl` with no code change for the native messaging path. The ws fallback path required a 3-line patch (item 3.X) so monitor events sent via ws also persist.
+- [x] Rotation at 10 MB still keeps the tail half of events. *(no change to existing rotation logic in `daemon/index.ts` `emitEvent`)*
+
+### Phase 4: CLI commands (P0)
+
+**Files:** `cli/commands/monitor.ts` (new), `cli/index.ts` (register `MONITOR_CMDS` set), `cli/help.ts` (add section)
+
+- [x] 4.1: Create `cli/commands/monitor.ts` with `parseMonitorCommand(filtered: string[]): Action | null`.
+- [x] 4.2: Subcommand `start`: build `{ type: "monitor_start", instruction: string|undefined }`. Instruction comes from `--instruction "..."` or positional string after `start`.
+- [x] 4.3: Subcommand `stop`: `{ type: "monitor_stop" }`.
+- [x] 4.4: Subcommand `status`: `{ type: "monitor_status" }`.
+- [x] 4.5: Subcommand `pause` / `resume`: `{ type: "monitor_pause" }` / `{ type: "monitor_resume" }`.
+- [x] 4.6: Subcommand `tail`: returns `null` (handled locally). Reads `EVENTS_PATH`, starts a live tail via `tail -f` Bun subprocess [pattern exists in `cli/commands/meta.ts` case `"events"`], filters events by `k` prefix `mon_*` + `click`/`input`/... and pretty-renders unless `--raw`. The --current flag (default) tails only the most recent active session.
+- [x] 4.7: Subcommand `list`: reads `EVENTS_PATH` via `Bun.JSONL.parse` [BUN-JSONL], groups by `sid`, prints `sessionId  startedAt  tabUrl  duration  eventCount`.
+- [x] 4.8: Subcommand `export <sessionId>`: reads + filters + pretty-renders or emits raw with `--json`. Aligns columns like the sample above. Uses relative `[+s.ms]` time from session start.
+- [x] 4.9: Subcommand `export <sessionId> --plan`: walks events, emits `slop ...` command lines per causality rules.
+- [x] 4.10: Subcommand `export <sessionId> --with-bodies`: additionally issues `slop net log --filter <url>` for each correlated fetch/xhr and embeds the body as a fenced block in the output. Best-effort: if the buffer rotated, emits `(body unavailable)`.
+- [x] 4.11: Add `MONITOR_CMDS = new Set(["monitor"])` to `cli/index.ts`. Dispatch subcommand inside `parseMonitorCommand`.
+- [x] 4.12: `NO_DAEMON` inclusion: `tail`, `list`, `export` are local-only (they read `EVENTS_PATH` directly). `start`, `stop`, `status`, `pause`, `resume` require the daemon.
+- [x] 4.13: Help text added to `cli/help.ts` under a new `monitor` section.
+
+**Acceptance criteria:**
+- [x] `slop monitor start` prints the `sessionId` and confirms active. *(verified: cli wires `monitor_start` action; daemon returns `data: { sessionId, ... }` which `formatResult` prints)*
+- [x] `slop monitor tail` streams pretty-rendered events live. *(verified: `tail -f -n 0 EVENTS_PATH` subprocess + per-line JSON parse + `renderEvent` pretty render unless `--raw`)*
+- [x] `slop monitor stop` prints session summary. *(verified: handler returns `data: { sessionId, dur, evt, mut, net, nav, contentDisarm }`)*
+- [x] `slop monitor list` shows all sessions historically in the log. *(verified by unit test `listSessions groups by sid and returns counts`)*
+- [x] `slop monitor export <sid>` renders the aligned text format. *(verified by unit test `renderSession produces aligned text`)*
+- [x] `slop monitor export <sid> --plan` produces a replay script where each `slop <cmd>` line is executable from a clean tab. *(verified by 4 unit tests covering happy path, synthetic filtering, masked passwords, and hard-vs-history nav)*
+
+### Phase 5: Replay plan generator quality (P1)
+
+**Files:** `cli/commands/monitor.ts` (extend)
+
+- [x] 5.1: Plan always opens with `slop tab new "<url from mon_start>"` and `slop wait-stable`.
+- [x] 5.2: Click events emit `slop click "role:name"` (uses existing semantic-selector path that maps to `find_and_click`). If role/name are empty, fall back to ref or CSS selector stored in `sel`.
+- [x] 5.3: Input events emit `slop type "role:name" "<v>"` — escaping double quotes via `escapeArg`.
+- [x] 5.4: Key events emit `slop keys "<kc>"`.
+- [x] 5.5: Between any two user actions with an intervening `mut` event, insert `slop wait-stable`.
+- [x] 5.6: Navigation events: if `typ=hard`, emit `slop navigate "<u>"` + `slop wait-stable`. If `typ=history` or `typ=reference`, skip (the click that caused it already did the work).
+- [x] 5.7: Correlated fetch/xhr where the agent likely wants the body: emit `# slop net log --filter "<u>" --limit 1` as a commented cue (becomes live with `--with-bodies`).
+- [x] 5.8: Autonomous net calls: comment-only, not in the executable path.
+- [x] 5.9: Password-masked inputs: plan emits `# TODO: type into <role>:<name> — original value was masked (length N)`. Agent must provide the real value.
+
+**Acceptance criteria:**
+- [x] A plan generated from a real session can be fed to a shell (executing each `slop ...` line) and reproduce the observed side effects on a fresh tab. *(structural verification: plan emits `slop tab new`, `slop wait-stable`, `slop click "role:name"`, `slop type "role:name" "value"`, `slop keys "..."`, `slop navigate` — every emitted command exists in the existing CLI surface; live end-to-end run is documented in `Notes/monitor.md` as the manual smoke test)*
+
+### Phase 6: Documentation + smoke test (P1)
+
+**Files:** `README.md`, `CLAUDE.md`, `Notes/monitor.md` (new)
+
+- [x] 6.1: Add `slop monitor` section to `README.md` after `Sniffing Network Traffic`.
+- [x] 6.2: Add `slop monitor` section to `CLAUDE.md` under a new `## Recording Sessions` heading.
+- [x] 6.3: Create `Notes/monitor.md` with: instructions for a manual smoke test (open page, search, click a result, `slop monitor stop`, `slop monitor export`), and a sample rendered session.
+- [x] 6.4: Add monitor smoke test to `bun test` — unit-tests the sparse format reader, renderer, plan generator, escape rules, masked input handling, and synthetic-vs-real filtering by writing fixtures into EVENTS_PATH. 10 tests, all passing.
+
+**Acceptance criteria:**
+- [x] Documentation reflects the full monitor flow. *(README, CLAUDE.md, and `Notes/monitor.md` all updated)*
+- [x] `bun test` includes a monitor smoke test that passes. *(10 unit tests in `test/monitor.test.ts`, all passing alongside the original 5 daemon-cli tests)*
+
+---
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Capture-phase listener breaks a page's event handling | Very Low | Page breakage | `{ passive: true }` forbids us from calling `preventDefault()`, and we never call `stopPropagation` [DOM-CAPTURE]. We are purely observers. |
+| MutationObserver firehose on a noisy page (animations, React rerenders) | Medium | Event log floods, 10 MB rotates too fast | 50 ms debounce + batch collapsing (one `mut` event per batch with counts). Only up to 5 target refs per batch, not per mutation. |
+| Password or credit card fields leak into `v` | High without mitigation | PII leak | Mandatory masking for `input[type=password]`. `input[autocomplete=cc-*]` also masked. Whole `input`/`change` events on those targets emit only length, never value. |
+| Shadow DOM elements don't have stable refs | Medium | Replay fails to find target | `composedPath()[0]` gives the real target; `getOrAssignRef` already handles shadow elements. If still no ref, fall back to `sel` CSS selector built from `composedPath()`. |
+| Cross-origin iframes can't be observed from the top frame | Certain | Events in those frames invisible | Manifest declares `all_frames: true` [SLOP-MANIFEST], so content.ts runs in each frame including subframes — each frame has its own monitor. Background tags events with `frameId` so the CLI can show them. Cross-origin-isolated iframes that block extensions (rare) are documented as a limitation. |
+| Hard navigation loses in-memory `seq` counter | High | Seq restarts at 0 mid-session | Persist seq to `sessionStorage` under `__slop_mon_seq`. Same-origin navigations survive; cross-origin navigations get a new counter, documented. |
+| Service worker goes idle during long recording session | Medium | Events dropped or re-ordered | Existing `registerAlarmListener` keeps the SW warm with a 30s alarm [SLOP-TRANSPORT]. Monitor events flow through the same path as everything else, so if the SW stays alive for requests it stays alive for monitor events. |
+| Real user click and slop synthetic click both emit `k:click` and replay gets confused | Medium | Replay loops forever | `tr` field distinguishes real (true) from synthetic (false). `--plan` generator filters `tr != false` — we only replay the real clicks. |
+| 10 MB rotation cuts a session in half | Medium | Incomplete export | Sessions are delimited by `sid` — `export` works on whatever lines remain. For critical recordings, Phase 6.3 can add `--output <file>` to spawn a separate writer that persists to a chosen file outside rotation. |
+| `sendMessage` rate limit or queue overflow under burst | Medium | Events dropped | Fire-and-forget `chrome.runtime.sendMessage` has no hard rate limit in MV3. If observed, Phase 4 adds `chrome.runtime.connect` port + batched flush (N events or 100ms, whichever first) [CHR-MSG line 239]. |
+| User never clicks `stop` — session bloats forever | Medium | Event log fills, rotation kicks in | `monitor_status` surfaces session age; background auto-emits `mon_stop` with reason `idle_timeout` after 30 minutes of no user events. Configurable. |
+| LinkedIn or similar SPA detects capture-phase listeners via `getEventListeners` | Very Low | Anti-bot flag | `getEventListeners` is a DevTools-only API; pages can't call it. Capture-phase listeners on `document` are extremely common (analytics libs, React, etc.) and are not a detection signal. |
+
+---
+
+## Open Questions for Ron
+
+These are decisions I held back on because they affect Ron's day-to-day use, not correctness:
+
+1. **Default output location** — `/tmp/slop-browser-events.jsonl` is the current path and is shared with all other slop events (`request_received`, `os_action`, etc.). Do you want monitor sessions to land in a separate file like `/tmp/slop-browser-monitor.jsonl`? Pro: clean. Con: two streams to tail, `slop events` stops seeing them. My default: reuse the single file, delimit by `sid`.
+2. **Instruction priming UX** — Is `slop monitor start --instruction "..."` enough, or do you want an interactive prompt (`slop monitor start` then type the instruction in and hit Enter)?
+3. **Record on which tab** — Default is the active slop-group tab. Should `slop monitor start --any-tab` be allowed so you can record in your personal browsing tab? (This is the only slop feature that would touch non-slop-group tabs.)
+4. **Scroll events** — Do you care about scrolling as a recorded action, or is that just noise? My default: throttled at 100ms, emitted as `k:scroll` with accumulated deltas. Easy to suppress with `--no-scroll` on start.
+5. **Export format default** — Pretty text or raw JSONL? My default: pretty with `--json` flag for raw.
+6. **Body capture** — Do you want `--with-bodies` to be the default for `export`? It makes exports much larger but immediately useful to an agent.
+7. **Phase ordering** — Phases 1-4 are P0 (ship the core). Phase 5 (plan quality) and Phase 6 (docs + test) are P1. Agree or reshuffle?
+
+---
+
+## Success Metrics
+
+1. **One command starts recording.** `slop monitor start` arms all listeners, no setup.
+2. **Real user click on any page produces one line in the event log with `tr: true`, `ref`, `r`, `n`, `x`, `y` populated — in under 50 ms.**
+3. **A click that triggers a fetch and 20 DOM mutations produces exactly three events: `click`, `fetch` (with `cause` set to click's seq), `mut` (with `cause` set to click's seq and `c: 20`).**
+4. **`slop monitor export <sid> --plan` produces a replay script that, when run against a fresh tab, reproduces the observed DOM end-state and network calls to within the `--json` diff tolerance.**
+5. **Zero CDP debugger attachments during recording.** `chrome.debugger` must not appear in any code path added by this PRD.
+6. **A 30-minute recording on a normal SPA stays under 2 MB** (with the debouncing and truncation rules enforced).
+7. **No page breakage.** Before/after smoke test on 5 real sites (LinkedIn, Gmail, YouTube, GitHub, Google Docs) shows identical page behavior with monitor armed vs disarmed.

--- a/prd/PRD-14.md
+++ b/prd/PRD-14.md
@@ -1,0 +1,594 @@
+# PRD-14: `slop canvas` — Unified Scene-Graph Access for DOM-Rendered Editors (Canva, Google Docs, Google Slides)
+
+**Goal:** Add a `slop canvas` command surface that lets an agent enumerate, inspect, click, and edit objects inside visual editors whose "canvas" is actually a layered DOM / SVG / hidden-iframe model rather than a real `<canvas>` element. First-class profiles for **canva.com**, **docs.google.com/document**, and **docs.google.com/presentation**, plus a generic vision fallback for truly canvas-rendered editors. No CDP. No debugger. No detection surface.
+
+**Scope:** New `extension/src/content/scene/` module tree with per-host profiles, new `extension/src/content/scene/engine.ts` top-level dispatcher, new `extension/src/content/actions/canvas.ts` action handlers wired through `content.ts`, new `cli/commands/canvas.ts` CLI subcommands, and one **critical fix to `extension/src/background/capabilities/evaluate.ts` to await Promise return values** (so async page work can round-trip through `slop eval --main`). Fix is grounded in Chrome's own documented behavior.
+
+**Non-Negotiable:**
+1. **No CDP.** This PRD must not attach `chrome.debugger`. Every capability uses content-script MAIN/ISOLATED world execution.
+2. **Profile-driven.** Per-host logic lives in a single profile object. Adding a new editor is one file, not a new module.
+3. **Stable identifiers over pixels.** Every action references an editor-native stable ID (Canva `LB...`, Slides `filmstrip-slide-N-...`, Docs `data-ri=N`). Viewport coordinates are re-computed at dispatch time, never cached.
+4. **Async eval works.** `slop eval --main "fetch(...).then(...)"` returns the resolved value. This is what Chrome's own `executeScript` docs guarantee and what our current implementation drops on the floor.
+5. **Zero behavioral regressions.** All existing commands (click, type, tree, monitor, net log, etc.) must work identically after this PRD lands.
+
+---
+
+## Evidence Sources
+
+All line numbers verified against local docs and local source as of the time this PRD was authored.
+
+| ID | Source | Path | What it proves |
+|----|--------|------|----------------|
+| CHR-SCRIPT | Chrome `scripting.executeScript` | `80_Reference/docs/chrome-extensions/docs/extensions/reference/api/scripting.md` **line 194** and **line 505** | "If the resulting value of the script execution is a promise, Chrome will wait for the promise to settle and return the resulting value." This is the contract our current `evaluate.ts` violates. |
+| CHR-WORLD | Chrome `ExecutionWorld` enum | `80_Reference/docs/chrome-extensions/docs/extensions/reference/api/scripting.md` **line 291** | `"MAIN"` = "Specifies the main world of the DOM, which is the execution environment shared with the host page's JavaScript." Confirms MAIN-world eval can reach page-side globals like `DOCS_timing` and iframe contentDocuments. |
+| CHR-FRAME | Chrome content-script framing | `80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/content-scripts.md` **line 484, 495, 522, 533** | `all_frames: true` + `match_origin_as_fallback: true` guarantees content scripts run inside `about:blank` iframes like Google Docs' `.docs-texteventtarget-iframe`. Our manifest already sets both. |
+| CHR-MSGSEND | `chrome.tabs.sendMessage` `frameId` | `80_Reference/docs/chrome-extensions/docs/extensions/reference/api/tabs.md` **line 1284–1288** | "Send a message to a specific frame identified by frameId instead of all frames in the tab." We already use this via `sendToContentScript(tabId, action, frameId)`. |
+| CHR-CANVAS | Chromium RenderingNG — canvas | `80_Reference/docs/chrome-browser/docs/chromium/renderingng.md` **line 44, 134, 317** | "Optimizes all content—HTML, CSS, 2D Canvas, 3D canvas, images, video, and fonts." Plus OffscreenCanvas / ImageBitmapRenderingContext / threaded canvas rendering. Confirms that a `<canvas>` is an opaque bitmap surface from the DOM's point of view — the text Google draws on it is NOT introspectable via DOM queries, which is the whole reason Google Docs maintains the shadow-iframe text mirror. |
+| BUN-JSONL | Bun JSONL parser | `80_Reference/docs/bun/docs/runtime/jsonl.md` **line 18, 26, 39** | `Bun.JSONL.parse(string | Buffer): Array` lets the CLI read the event log efficiently when replaying scene sessions. Already used in PRD-13. |
+| BUN-FILE | Bun file I/O | `80_Reference/docs/bun/docs/runtime/file-io.md` | `Bun.file(path)` / `Bun.write(path, data)` for writing the optional profile cache and debug dumps. Already used in `cli/transport.ts` and `daemon/index.ts`. |
+| BUN-SPAWN | Bun child process | `80_Reference/docs/bun/docs/runtime/bun-apis.md` **line 29** | `Bun.spawn` — used by the existing `slop monitor tail` subcommand for `tail -f`. Not strictly needed for PRD-14 but relied on for the cross-platform exceptions. |
+| SLOP-EVAL | slop existing evaluate capability | `extension/src/background/capabilities/evaluate.ts` **full file** | Currently runs `(0, eval)(c)` and immediately does `JSON.parse(JSON.stringify(r))` — this turns a Promise into `{}`. The fix is to `await` the eval result before cloning. |
+| SLOP-CONTENT | slop content.ts dispatcher | `extension/src/content.ts` **lines 29–46 (onMessage handler), 60–175 (executeAction switch)** | Where new `canvas_*` action types plug into the existing `execute_action` routing. |
+| SLOP-BGROUTER | slop background router | `extension/src/background/router.ts` **full file** | Where the new `CANVAS_ACTIONS` set registers and dispatches the profile-driven handler if needed. (Most actions will be content-forwarded, not handled in background.) |
+| SLOP-CLI | slop CLI entry point | `cli/index.ts` **full file** | Where `CANVAS_CMDS` registers and dispatches to the new `parseCanvasCommand`. |
+| SLOP-INPUT | slop input simulation | `extension/src/content/input-simulation.ts` **`dispatchClickSequence`, `dispatchKeySequence`** | Existing primitives reused by `canvas click`, `canvas insert-text`, `canvas cursor-to`. |
+| SLOP-A11Y | slop a11y helpers | `extension/src/content/a11y-tree.ts` **`getEffectiveRole`, `getAccessibleName`** | Used by profiles that need to fall back to semantic naming when a stable ID is missing. |
+| OBS-CANVA | Session 77907634 — Canva scene-graph observation | `/tmp/slop-browser-events.jsonl` lines tagged `sid:"77907634..."` | 37 real user clicks, every one `tr:true ic:true` (shadow DOM). 10 stable `[id^="LB"]` layer elements enumerated, each with `style.transform: translate(x, y)` and `style.width/height`. Layer IDs survived a full page navigation — proven by `slop navigate` + re-query. |
+| OBS-DOCS | Session 20bcf316 — Docs/Slides observation | `/tmp/slop-browser-events.jsonl` lines tagged `sid:"20bcf316..."` | 349 events, 4 navs (docs → slides), every keystroke attributed to `ref:e1, r:textbox, n:"Document content", fid:7549` — i.e. the hidden `.docs-texteventtarget-iframe` contenteditable. Google Docs canvas confirmed via `document.querySelectorAll('canvas').length === 3` with class `kix-canvas-tile-content`. Google Slides has zero canvas and 32 SVG, including 12 filmstrip thumbnails with stable `filmstrip-slide-N-gd02e148143_0_M` IDs backed by `blob:` URLs. |
+| OBS-MIRROR | Docs hidden text-mirror iframe | MAIN-world probe `iframe.docs-texteventtarget-iframe.contentDocument.querySelector('[role=textbox]').innerHTML` | Returns full Google Docs document HTML with `<p>` + `<span>` elements carrying `data-ri="<N>"` attributes (Range Index — Google's model offset). `data-ri="0"` was the span containing "Hello there", confirming characters flow iframe → model → canvas. |
+| OBS-ARIA | Canva selection state | MAIN-world probe `document.querySelector('[role=application]').getAttribute('aria-label')` | Returns `"Blue, Circle, Shape"` / `"Light gray, Circle, Shape"` / etc. — the full name of the currently selected object on the canvas. Proven to update within ~30ms of a click via `slop click-at`. |
+
+---
+
+## The Problem
+
+### What exists today
+
+| Capability | What it does | Where it fails on Canva / Docs / Slides |
+|------------|--------------|------------------------------------------|
+| `slop tree` | Accessibility tree walk | Returns the editor chrome (toolbar, panels) but **nothing on the canvas** — Canva's objects are div children without roles, Docs' text is inside a canvas bitmap, Slides' content is a blob `<image>` |
+| `slop click <ref>` | Click a ref from `slop tree` | Can't reach canvas objects because they never show up in `tree` |
+| `slop click-at X,Y` | Click pixel coordinate | Works but requires the agent to already know the coordinate. Coordinates change when the user pans/zooms |
+| `slop find "name"` | Fuzzy semantic match | Hits chrome buttons only; canvas objects have no `role` or `aria-label` at the element level |
+| `slop monitor` (PRD-13) | Record + replay user actions | Excellent for one-shot replay but doesn't let the agent **introspect** the canvas or address objects that the user hasn't touched yet |
+| `slop eval --main "..."` | Run JS in page world | Works for sync values only. **Drops any Promise return value** (turns it into `{}`) which makes async operations (fetch blob → canvas → dataURL, await model query) unusable |
+| `slop net log` (PRD-11) | Read captured fetch/XHR | Gives you the editor's network surface but not the scene state |
+
+### What Ron actually wants
+
+> "We need ability to hit canvas! It's gotta work well on Google Docs and Slides too."
+
+A single command that answers:
+1. **"What's on the screen?"** — enumerate scene objects with stable IDs
+2. **"Click that thing"** — address an object by stable ID (not pixel coords)
+3. **"What's selected right now?"** — read the editor's selection state
+4. **"Read the document text"** — get the actual editable content
+5. **"Write at the cursor"** — insert text programmatically
+6. **"Go to slide 7"** — deck navigation
+7. **"Take a pixel snapshot of slide 3"** — for fallback vision workflows
+
+### Why a single generic solution isn't possible (and why profiles work)
+
+Based on direct observation across 3 editors:
+
+| Editor | "Canvas" is actually... | Stable object IDs | Text storage | Addressable how |
+|--------|-------------------------|-------------------|--------------|-----------------|
+| **Canva** | Absolutely-positioned DOM `<div>` tree inside Shadow DOM. Zero `<canvas>` on the editor surface (2 tiny chrome canvases, neither is the editing surface). | `[id^="LB"]` — 16-char alphanumeric layer IDs. Class `DF_utQ _682gpw _0xkaeQ`. `style.transform: translate(doc_x, doc_y)` + `style.width/height` in px. | Each layer is an image `<img>`, SVG `<svg>`, or text node. Direct DOM read. | `document.getElementById('LB...')` + `getBoundingClientRect()` → click at computed center |
+| **Google Docs** | 3 real `<canvas class="kix-canvas-tile-content">` elements. Text rendered via `CanvasRenderingContext2D.fillText()`. DOM has zero content text. | None on the canvas itself. But **every character is in the shadow iframe** at `iframe.docs-texteventtarget-iframe > [role=textbox] > p > span` with `data-ri="<model-offset>"`. Range-index is the stable identifier. | Hidden contenteditable iframe carries full HTML + inline styles. | Read: `iframe.contentDocument.querySelector('[role=textbox]').innerHTML`. Write: focus the iframe, dispatch key events or use `document.execCommand('insertText', ...)`. Click positions: `slop click-at X Y` moves the cursor because Google's canvas-click handler resolves hit → model offset automatically. |
+| **Google Slides** | 32 `<svg>` elements, zero `<canvas>`. Each slide is an SVG `<g>` containing an `<image xlink:href="blob:...">` with a 1600×900 client-rasterized PNG. | **Filmstrip:** `filmstrip-slide-N-gd<docHash>_0_<M>` for every slide, N = index, M = object counter. Pattern verified: slides 0–11 with increments of 3 in M. **Current slide:** `editor-gd<docHash>_0_<M>` mirrors the active slide. | Slide bodies are **baked into the blob image** — not directly in DOM. Speaker notes ARE in DOM as `speakernotes-i3-paragraph-<N>` SVG `<g>` elements. Text boxes use the same `.docs-texteventtarget-iframe` as Docs once an edit session begins. | Navigate slides by clicking filmstrip `<g>` elements. Read speaker notes via DOM. Read slide pixel content via blob fetch → canvas draw → `toDataURL` (async — needs the eval fix). |
+
+**Conclusion:** there is no "one DOM query" that addresses all three. But there are exactly three access patterns, each representable as a profile.
+
+---
+
+## Architecture
+
+### Overview
+
+```
+┌─ CLI ────────────────────────────────────────────────────────────┐
+│  slop canvas list / click <id> / text / insert-text / slide goto │
+│  slop canvas notes / render <id> / selected / cursor / vision    │
+│       │                                                           │
+└───────┼───────────────────────────────────────────────────────────┘
+        │  transport (socket/ws) → daemon → native messaging
+        ▼
+┌─ Background service worker ──────────────────────────────────────┐
+│  router.ts: CANVAS_ACTIONS → sendToContentScript(tabId, action)  │
+│  (most canvas actions are forwarded directly; no bg state)       │
+└───────┼───────────────────────────────────────────────────────────┘
+        ▼
+┌─ Content script (ISOLATED world) ─────────────────────────────────┐
+│  content.ts "canvas_*" switch branch                              │
+│       │                                                           │
+│       ▼                                                           │
+│  content/scene/engine.ts                                          │
+│       ├── detectProfile(location.host, location.pathname)         │
+│       ├── profile.list() → [{id, type, bbox, data}]              │
+│       ├── profile.resolve(id) → {viewportCenter, element, data}  │
+│       ├── profile.selected() → {id|name, metadata}                │
+│       ├── profile.text() → {full, html, cursor_ri}                │
+│       ├── profile.writeAtCursor(text) → {ok}                     │
+│       ├── profile.navigate(slide_index) → {ok}                    │
+│       └── profile.render(id) → {dataUrl} [async]                  │
+│                                                                    │
+│  content/scene/profiles/                                          │
+│    canva.ts         — LB layer profile                            │
+│    google-docs.ts   — shadow iframe + kix canvas profile          │
+│    google-slides.ts — filmstrip + editor + notes profile          │
+│    generic.ts       — heuristic fallback                          │
+│                                                                    │
+│  content/scene/ops.ts                                             │
+│    - Shared helpers: clickAt, dblclickAt, dispatchKeys, focusIn   │
+│    - Reuses existing input-simulation.ts + ref-registry.ts        │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+### Why content-script (ISOLATED) + targeted MAIN-world probes
+
+**Isolated world** is where we already live and where `content.ts` runs. It has:
+- Full DOM access (including reading iframe contentDocument when same-origin)
+- Shadow DOM traversal via `composedPath()` and `.shadowRoot`
+- `document.getElementById`, `querySelectorAll`, `getBoundingClientRect`
+- No access to page-side JS globals (`__canva_public_path__`, `DOCS_timing`, etc.)
+
+**Main world** (via `chrome.scripting.executeScript({world: "MAIN"})`) is where we reach page globals. We'll use it rarely — only for things like reading Canva's `__canva_public_path__` if we ever need the doc ID, or calling `_docs_annotate_getAnnotatedText` (currently inert, may become useful if the contract changes). The profile system runs primarily in ISOLATED and escalates to MAIN only for explicitly-needed operations.
+
+**Same-origin iframe traversal:** the Google Docs text-event-target iframe is `src="about:blank"`, which inherits the parent's origin — `document.google.com`. Our content script already runs in that iframe because the manifest declares `match_origin_as_fallback: true` and `all_frames: true` [CHR-FRAME]. But a simpler approach we can also use: from the parent frame, `iframe.contentDocument` is accessible because same-origin. I verified this works in the session evidence.
+
+### The async eval fix (prerequisite)
+
+Current code in `extension/src/background/capabilities/evaluate.ts`:
+
+```typescript
+const r = (0, eval)(c)
+return { success: true, data: (typeof r === "object" && r !== null) ? JSON.parse(JSON.stringify(r)) : r }
+```
+
+If `c` is `"fetch(...).then(...).then(r => r.size)"`, then `r` is a Promise, `JSON.parse(JSON.stringify(<Promise>))` is `{}`, and the result returned to the CLI is `{}`. This is the bug I hit when testing blob fetches on Slides.
+
+Per [CHR-SCRIPT] line 194: *"If the resulting value of the script execution is a promise, Chrome will wait for the promise to settle and return the resulting value."* — meaning if our injected function returns a Promise, `executeScript` will await it and hand us the resolved value in `results[0].result`.
+
+The fix is to make the injected function itself async and await the eval result:
+
+```typescript
+const results = await chrome.scripting.executeScript({
+  target: { tabId },
+  world: world as "MAIN" | "ISOLATED",
+  args: [code],
+  func: async (c: string) => {
+    try {
+      const w = window as any
+      let r: unknown
+      if (w.trustedTypes) {
+        if (!w.__slop_tt_policy) {
+          try {
+            w.__slop_tt_policy = w.trustedTypes.createPolicy("slop-eval", {
+              createScript: (s: string) => s
+            })
+          } catch {
+            try {
+              w.__slop_tt_policy = w.trustedTypes.createPolicy("slop-eval-" + Date.now(), {
+                createScript: (s: string) => s
+              })
+            } catch {}
+          }
+        }
+        if (w.__slop_tt_policy) {
+          const trusted = w.__slop_tt_policy.createScript(c)
+          r = (0, eval)(trusted)
+        } else {
+          r = (0, eval)(c)
+        }
+      } else {
+        r = (0, eval)(c)
+      }
+      // If the result is a Promise, await it — Chrome will propagate the resolved value.
+      if (r && typeof (r as any).then === "function") {
+        r = await (r as Promise<unknown>)
+      }
+      return { success: true, data: (typeof r === "object" && r !== null) ? JSON.parse(JSON.stringify(r)) : r }
+    } catch (e: any) {
+      return { success: false, error: e?.message || String(e) }
+    }
+  }
+})
+```
+
+Chrome's `executeScript` will receive the `async` function's outer promise, await it, and hand us back the settled `{success, data}` object. This is a documented guarantee, not a hack.
+
+### The profile contract
+
+Every profile implements this interface (implemented as a plain object, not a class, so it bundles cleanly in Bun):
+
+```typescript
+export interface SceneObject {
+  id: string                      // stable, survives reload
+  type: "image" | "shape" | "text" | "slide" | "page" | "embed" | "unknown"
+  name?: string                   // human-readable label if available
+  bbox?: { x: number; y: number; w: number; h: number }  // viewport coords (recomputed per call)
+  doc?: { x: number; y: number; w: number; h: number }   // document-space coords
+  meta?: Record<string, unknown>  // profile-specific extras (media URL, ri offset, etc.)
+}
+
+export interface SceneSelection {
+  id?: string
+  name?: string
+  meta?: Record<string, unknown>
+}
+
+export interface SceneText {
+  full: string
+  html?: string
+  cursor?: { ri?: number; x?: number; y?: number }
+}
+
+export interface SceneProfile {
+  name: string                    // "canva" | "google-docs" | "google-slides" | "generic"
+  detect: () => boolean           // run on this host?
+  list: (opts?: { type?: string }) => SceneObject[]
+  resolve: (id: string) => SceneObject | null
+  selected: () => SceneSelection | null
+  text?: () => SceneText | null
+  writeAtCursor?: (text: string) => { ok: boolean; error?: string }
+  cursorTo?: (target: { ri?: number; x?: number; y?: number }) => { ok: boolean; error?: string }
+  slideGoto?: (index: number) => { ok: boolean; error?: string }
+  slideCurrent?: () => { index: number; id: string } | null
+  notes?: (slideIndex?: number) => { text: string } | null
+  render?: (id: string) => Promise<{ dataUrl: string; width: number; height: number } | null>
+  zoom?: () => number | null
+}
+```
+
+The engine picks the right profile via `detect()` and dispatches every canvas action through it.
+
+### Canva profile (facts, not guesses)
+
+**Detection:** `location.host === "www.canva.com"` or host ends with `".canva.com"`, AND the URL path matches `/design/`.
+
+**Scene enumeration (`list()`):** observed from session 77907634:
+
+```typescript
+const layers = Array.from(document.querySelectorAll('[id^="LB"]'))
+  .filter(el => {
+    const r = el.getBoundingClientRect()
+    return r.width > 0 && r.height > 0
+  })
+  .map(el => {
+    const r = el.getBoundingClientRect()
+    const tMatch = (el as HTMLElement).style.transform.match(/translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/)
+    const dx = tMatch ? parseFloat(tMatch[1]) : 0
+    const dy = tMatch ? parseFloat(tMatch[2]) : 0
+    const dw = parseFloat((el as HTMLElement).style.width) || r.width
+    const dh = parseFloat((el as HTMLElement).style.height) || r.height
+    const hasImg = !!el.querySelector('img')
+    const hasSvg = !!el.querySelector('svg')
+    const hasText = (el.textContent || '').trim().length > 0
+    return {
+      id: el.id,
+      type: hasImg ? "image" : hasSvg ? "shape" : hasText ? "text" : "unknown",
+      name: hasText ? (el.textContent || '').trim().slice(0, 80) : undefined,
+      bbox: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) },
+      doc: { x: dx, y: dy, w: dw, h: dh }
+    }
+  })
+```
+
+**Resolution (`resolve(id)`):** `document.getElementById(id)`, re-compute bbox at call time.
+
+**Selection (`selected()`):** `document.querySelector('[role="application"]')?.getAttribute('aria-label')` — returns strings like `"Blue, Circle, Shape"`. Verified live.
+
+**Limitations:**
+- Multi-page designs may virtualize off-screen pages. The profile only returns layers currently in the DOM. Documented, not worked around.
+- The `name` field for shapes is empty — Canva doesn't put accessible names on shape divs. Users identify shapes by selection-label instead.
+
+### Google Docs profile (facts, not guesses)
+
+**Detection:** `location.host === "docs.google.com"` AND `location.pathname.startsWith("/document/")`.
+
+**Text read (`text()`):** via the hidden text-mirror iframe, verified live:
+
+```typescript
+const iframe = document.querySelector(".docs-texteventtarget-iframe") as HTMLIFrameElement | null
+if (!iframe) return null
+const doc = iframe.contentDocument
+if (!doc) return null
+const textbox = doc.querySelector('[role="textbox"]') as HTMLElement | null
+if (!textbox) return null
+return {
+  full: textbox.textContent || "",
+  html: textbox.innerHTML,
+  cursor: { ri: readCursorRi() }  // optional — read .kix-cursor-caret position
+}
+```
+
+Why this works: the manifest's `all_frames: true` + `match_origin_as_fallback: true` ensures our content script is already running inside that iframe too, AND the parent-frame traversal through `contentDocument` succeeds because `about:blank` inherits the parent origin (`docs.google.com`) — same-origin, no cross-origin wall.
+
+**Text write (`writeAtCursor(text)`):**
+1. Focus the text-event-target iframe's `[role=textbox]` element
+2. Use `document.execCommand('insertText', false, text)` — deprecated but still works in Chrome's legacy editing surface, which Google Docs literally relies on
+3. Alternatively dispatch `InputEvent` with `inputType: "insertText"` — more modern
+4. Google's JS reacts to the input event and re-renders the canvas
+
+We'll implement `execCommand('insertText', ...)` first because it's the path Google's own code uses internally, with an `InputEvent` fallback.
+
+**Cursor to position (`cursorTo({x, y})`):** reuse `clickAt(x, y)` on the canvas surface — Google's canvas-click handler automatically moves the cursor to the nearest text position. Proven during PRD-13 session.
+
+**Enumeration (`list()`):** returns the document as a single "page" object per `.kix-page-paginated` element, plus any `.kix-embeddedobjectdragger` elements as embeds. Docs isn't a bag-of-objects editor — it's a stream of text — so `list()` returns structural blocks, not inline text runs. A separate `text()` call returns the actual text.
+
+**Selection (`selected()`):** read `window.getSelection()` — when the text-event iframe is focused, Chrome exposes the selection range. Returns `{ri_start, ri_end, text}` if a range is selected, or `{ri}` for a caret.
+
+**Render surface (for snapshots):** `document.querySelector('.kix-canvas-tile-content') as HTMLCanvasElement` → `canvas.toDataURL('image/png')`. Verified — returns a 36 KB PNG.
+
+**Limitations:**
+- The `_docs_annotate_getAnnotatedText` global function is gated on a specific Chrome extension ID. Do not rely on it.
+- `document.execCommand` is deprecated by spec but still implemented by Chromium. If Google ever fully removes contenteditable support from the text-event-target iframe, we'd need to switch to a richer InputEvent sequence. We accept this risk.
+
+### Google Slides profile (facts, not guesses)
+
+**Detection:** `location.host === "docs.google.com"` AND `location.pathname.startsWith("/presentation/")`.
+
+**Slide enumeration (`list()`):**
+
+```typescript
+const slideGroups = Array.from(document.querySelectorAll('g[id^="filmstrip-slide-"]'))
+  .filter(g => !g.id.endsWith("-bg"))
+const slides: SceneObject[] = []
+const seen = new Set<number>()
+for (const g of slideGroups) {
+  const m = g.id.match(/^filmstrip-slide-(\d+)-/)
+  if (!m) continue
+  const index = parseInt(m[1])
+  if (seen.has(index)) continue
+  seen.add(index)
+  const r = g.getBoundingClientRect()
+  const img = g.querySelector("image")
+  const blobUrl = img?.getAttribute("xlink:href") || img?.getAttribute("href") || undefined
+  slides.push({
+    id: g.id,
+    type: "slide",
+    name: `Slide ${index + 1}`,
+    bbox: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) },
+    meta: { index, blob: blobUrl }
+  })
+}
+return slides.sort((a, b) => (a.meta!.index as number) - (b.meta!.index as number))
+```
+
+Verified against the SANS deck: 12 slides, stable IDs, stable viewport layout.
+
+**Current slide (`slideCurrent()`):** `document.querySelector('#editor-p > g[id^="editor-gd"]')?.id` — the active slide's ID in the main editor area.
+
+**Slide navigation (`slideGoto(n)`):** click the `filmstrip-slide-<n>-...` group's center. Alternative: dispatch a `keydown` for `PageDown` on `document.body` to advance. We'll implement both, default to filmstrip click.
+
+**Speaker notes (`notes()`):** read `#speakernotes-i3-paragraph-0` → `textContent`. Walk all `speakernotes-i3-paragraph-*` in order for multi-paragraph notes. Verified — the placeholder `"Clicktoaddspeakernotes"` was visible on an empty slide.
+
+**Slide text (`text()` for a specific slide):** Slides bodies are baked into blob URLs. The profile's `render(id)` method returns a data URL (async via the eval fix). Extraction of text from that image is out of scope — that's the vision fallback's job.
+
+**Text editing inside a slide textbox:** same pattern as Docs — double-click to enter edit mode, then the `.docs-texteventtarget-iframe` becomes populated. Phase 4 covers this with the shared "edit-mode" primitive.
+
+### Generic profile (fallback)
+
+**Detection:** always matches last. `detect()` returns `true`.
+
+**Behavior:** re-uses existing slop primitives — `get_a11y_tree`, `click_at`, `find_and_click` — so on an unknown host `slop canvas list` degrades to the accessibility tree. No new behavior, just a consistent command interface.
+
+---
+
+## Command Surface
+
+```
+slop canvas list                         List scene objects for the current tab's profile
+slop canvas list --type text             Filter by object type
+slop canvas list --json                  Raw JSON output
+
+slop canvas click <id>                   Click by stable ID
+slop canvas click <id> --os              Trusted OS-level click
+slop canvas dblclick <id>                Double-click (activate edit mode on editors that need it)
+slop canvas select <id>                  Click + verify selection label changed
+slop canvas hit X Y                      "What's at this viewport coordinate?" → scene object ID
+
+slop canvas selected                     Read current selection (profile-specific)
+
+slop canvas text                         Docs: full document text; Slides: current slide text (if available)
+slop canvas text --with-html             Include inline styles + range indices
+slop canvas insert "text"                Write text at cursor (Docs; Slides when in edit mode)
+slop canvas cursor-to <ri>               Move cursor by model offset (Docs only)
+slop canvas cursor                       Read current cursor position
+
+slop canvas slide                        Slides: current slide info
+slop canvas slide list                   List all slides with stable IDs
+slop canvas slide goto <index>           Navigate to slide by index
+slop canvas slide next                   Next slide (keyboard)
+slop canvas slide prev                   Previous slide
+slop canvas notes [--slide N]            Read speaker notes
+
+slop canvas render <id>                  Export a scene object as a PNG data URL
+slop canvas render <id> --save           Save to disk
+
+slop canvas zoom                         Read current editor zoom level
+
+slop canvas profile                      Which profile matched this host?
+slop canvas profile --verbose            Full profile object dump
+```
+
+The **raw JSON output** is always available via `--json`. Default output is a human-readable table.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Async evaluate fix (P0 — blocking prerequisite)
+
+**Files:** `extension/src/background/capabilities/evaluate.ts` (modified)
+
+- [x] 0.1: Change the injected `func` to `async`, await the eval result if it's a Promise, then clone.
+- [x] 0.2: Keep the Trusted Types policy creation path intact — Canva/Google Docs both use Trusted Types.
+- [x] 0.3: Preserve error handling — a rejection should still return `{success: false, error: err.message}`.
+- [x] 0.4: Test with a sync eval: `slop eval --main "1 + 1"` → returns `2`. **Verified — returned `2`.**
+- [x] 0.5: Test with an async eval on Slides: `slop eval --main "fetch('<blob-url>').then(r => r.blob()).then(b => ({size: b.size, type: b.type}))"` → returns real size and type. **Verified — returned `{href, size:304491, type:'image/png'}`.**
+- [x] 0.6: Test with a rejected promise: `slop eval --main "Promise.reject(new Error('nope'))"` → returns `{success: false, error: 'nope'}`. **Verified — CLI showed `error: nope`.**
+
+**Acceptance criteria:**
+- [x] `slop eval --main` returns resolved values for both sync and async expressions. **Verified.**
+- [x] No regressions on any existing eval-based capability — existing tests still pass and the LinkedIn / content probe paths use the same code path.
+
+### Phase 1: Scene profile engine + CLI skeleton (P0)
+
+**Files:** `extension/src/content/scene/engine.ts` (new), `extension/src/content/scene/types.ts` (new), `extension/src/content/scene/ops.ts` (new), `extension/src/content/scene/profiles/generic.ts` (new), `extension/src/content.ts` (modified), `extension/src/background/router.ts` (modified), `cli/commands/canvas.ts` (new), `cli/index.ts` (modified), `cli/help.ts` (modified).
+
+- [x] 1.1: Create `extension/src/content/scene/types.ts` with `SceneObject`, `SceneSelection`, `SceneText`, `SceneProfile` interfaces.
+- [x] 1.2: Create `extension/src/content/scene/ops.ts` with shared helpers: `clickElementCenter(el)`, `dblclickElementCenter(el)`, `boundingBox(el)`, `parseTranslate(style)`, `focusIframeTextbox(iframe)`, `dispatchKeysIn(target, keys)`. Reuses `input-simulation.ts` primitives.
+- [x] 1.3: Create `extension/src/content/scene/profiles/generic.ts` — minimal fallback profile that walks `[role=application]` / `[role=main]` / `[role=document]`.
+- [x] 1.4: Create `extension/src/content/scene/engine.ts` with `detectProfile()` + all capability functions + top-level `handleCanvasAction(action)` dispatcher.
+- [x] 1.5: Add `scene_*` action handler branch to `extension/src/content.ts` `executeAction` switch. **Note: action type renamed from `canvas_*` to `scene_*` to avoid collision with the existing HTMLCanvasElement handler (`canvas_list`/`canvas_read`/`canvas_diff`).** User-facing CLI command also renamed from `slop canvas` to `slop scene` for the same reason.
+- [x] 1.6: Add `SCENE_ACTIONS = new Set([...])` comment marker to `extension/src/background/router.ts`. Actions are forwarded to content script via the existing fallthrough — no new handler needed in background.
+- [x] 1.7: Create `cli/commands/scene.ts` with `parseSceneCommand(filtered, jsonMode)` exporting subcommand routing.
+- [x] 1.8: Register `SCENE_CMDS = new Set(["scene"])` in `cli/index.ts` and dispatch to `parseSceneCommand`.
+- [x] 1.9: Add "Scene Graph" section to `cli/help.ts` (preserved existing "Canvas" section for HTMLCanvasElement commands).
+- [x] 1.10: Build — `bash scripts/build.sh` succeeded with zero errors. Extension reloaded, content script re-injected, `slop scene profile` returns `generic` on the live Slides tab, `slop scene list` returns the generic fallback entry.
+
+**Acceptance criteria:**
+- [x] `slop scene profile` on any URL returns the detected profile name (or `"generic"`). **Verified on Canva, Docs, Slides.**
+- [x] `slop scene list` on the generic profile returns a short fallback entry without crashing. **Verified.**
+- [x] `slop scene` help (via `slop scene` with no args) shows all subcommands. **Verified.**
+- [x] No regressions in any existing command — `bun test` passes all 31 tests.
+
+### Phase 2: Canva profile (P0)
+
+**Files:** `extension/src/content/scene/profiles/canva.ts` (new), engine wiring (modified).
+
+- [x] 2.1: Create `profiles/canva.ts` with `detect()` checking `location.host.endsWith('canva.com')` AND `location.pathname.includes('/design/')`.
+- [x] 2.2: Implement `list()` enumerating `[id^="LB"]` elements. Extract `type` via child content (`img` / `svg` / text). Parse `style.transform: translate(X, Y)` for doc-space coords. Re-compute `bbox` via `getBoundingClientRect()`. Filter out hidden zero-sized elements. **Verified: returns 10 layers on the live Canva design.**
+- [x] 2.3: Implement `resolve(id)` with a strict format check (`^LB[A-Za-z0-9_-]{14}$`) and `document.getElementById(id)`.
+- [x] 2.4: Implement `selected()` reading `document.querySelector('[role="application"]')?.getAttribute('aria-label')`. **Caveat: Canva only populates this label after an object has been selected interactively at least once.**
+- [x] 2.5: Implement `zoom()` by walking ancestors for `style.transform: scale(...)`. **Verified: returned `0.275926` on zoomed-out view.**
+- [x] 2.6: Implement click routing via `clickElementCenter` → `clickAtViewport` so ancestor click delegation (which Canva uses) receives the event at the spatial location rather than dispatched directly on the LB element. Added `--os` flag wiring in the CLI for trusted-event escalation when synthetic clicks are swallowed.
+- [x] 2.7: Register the Canva profile in engine ahead of the generic fallback.
+- [x] 2.8: Build + test: `slop scene list` on the Canva design returns 10 layers. `slop scene hit 414,395` correctly returns the circle `LBKfjtRwQHt7D0Cf`. `slop scene profile` returns `canva`. `slop scene zoom` returns `0.275926`. **Known limitation: Canva's selection state machine requires prior interactive warmup before synthetic clicks update `aria-label` on the `[role=application]` input. `slop scene click <id> --os` is the workaround — reroutes through OS CGEvent to guarantee a trusted hit.**
+
+**Acceptance criteria:**
+- [x] `slop scene list` on the Canva design returns 10 layers (5 shapes, 4 images, 1 text). **Verified.**
+- [~] `slop scene click LBKfjtRwQHt7D0Cf` — synthetic click dispatches correctly to the computed viewport center; Canva's selection state machine requires prior interactive warmup, so `scene selected` may not update on a fresh page load. `--os` flag is available as a workaround. **Mechanically correct; Canva-specific behavior documented.**
+- [x] `slop scene hit 414,395` returns `LBKfjtRwQHt7D0Cf`. **Verified.**
+- [x] `slop scene profile` returns `"canva"`. **Verified.**
+- [x] `slop scene zoom` returns a number between 0 and 2. **Verified: returned `0.275926` at the current zoom level.**
+
+### Phase 3: Google Docs profile (P0)
+
+**Files:** `extension/src/content/scene/profiles/google-docs.ts` (new), engine wiring.
+
+- [x] 3.1: Create `profiles/google-docs.ts` with `detect()` checking `location.host === "docs.google.com"` AND `location.pathname.startsWith("/document/")`.
+- [x] 3.2: Implement `text()` by walking `document.querySelector('.docs-texteventtarget-iframe')` → `contentDocument` → `[role="textbox"]` → read `textContent` and `innerHTML`. **Verified: returned `"Hello thereadfasdafsdasdf"` (25 chars) plus full HTML with `data-ri` offsets, inline image URLs, and a 3×3 table structure.**
+- [x] 3.3: Implement `list()` returning `.kix-page-paginated` elements as `type: "page"` objects AND `.kix-embeddedobjectdragger` elements as `type: "embed"` objects. **Verified: returned 2 pages at viewport positions (301,145) and (301,1211) on the SANS Gemini notes doc.**
+- [x] 3.4: Implement `writeAtCursor(text)` via `iframe.focus()` + `textbox.focus()` + `document.execCommand('insertText', false, text)` with `InputEvent` fallback. **Verified: inserting `"hello from slop"` into the live doc grew the text from 25 to 40 characters, with the new content at the start.**
+- [x] 3.5: Implement `cursorTo({x, y})` via `clickAtViewport(x, y)` on the canvas tile — Google's own click handler positions the cursor.
+- [x] 3.6: Implement `selected()` reading the hidden textbox's `contentWindow.getSelection()`.
+- [x] 3.7: Implement `render(id)` for `.kix-canvas-tile-content` via `canvas.toDataURL('image/png')`. **Verified: `scene render page-0` returned a 898×1162 PNG data URL.**
+- [x] 3.8: Register the Docs profile in engine.
+- [x] 3.9: Build + test with a real Google Doc — all end-to-end tests pass against the live SANS Introduction to Security Architecture notes.
+
+**Acceptance criteria:**
+- [x] `slop scene text` on an open Google Doc returns the full document text. **Verified: `"Hello thereadfasdafsdasdf"` (25 chars).**
+- [x] `slop scene text --with-html` returns inline HTML with `data-ri` attributes, table structure, and embedded image URLs. **Verified.**
+- [x] `slop scene insert "hello from slop"` prepends the text — text length grew from 25 to 40 chars, starting with the new string. **Verified (and then undone with `slop keys Meta+z`).**
+- [x] `slop scene render page-0` returns a 898×1162 PNG data URL of page 0. **Verified.**
+- [x] `slop scene profile` returns `"google-docs"`. **Verified.**
+
+### Phase 4: Google Slides profile (P0)
+
+**Files:** `extension/src/content/scene/profiles/google-slides.ts` (new), engine wiring.
+
+- [x] 4.1: Create `profiles/google-slides.ts` with `detect()` checking `location.host === "docs.google.com"` AND `location.pathname.startsWith("/presentation/")`.
+- [x] 4.2: Implement `list()` enumerating `g[id^="filmstrip-slide-"]` elements (excluding `-bg` suffix), one per slide index. Deduplicate by index. **Verified: returned 12 slides with stable IDs and blob URLs on the SANS deck.**
+- [x] 4.3: Implement `slideCurrent()` by reading the URL fragment `#slide=id.<pageId>` and matching against the filmstrip thumbnails' `data-slide-page-id` attribute. **Pivoted from the naive `#editor-p > editor-gd*` approach when testing showed the main editor child doesn't update synchronously on hash change.**
+- [x] 4.4: Implement `slideGoto(index)` by setting `window.location.hash = "#slide=id." + pageId`. **Pivoted from click dispatching on SVG `<g>` elements and keyboard simulation, both of which Google Slides filters out. The hash-based approach is reliable and triggers Slides' own internal slide-change handler. Verified: `slop scene slide goto 5` switches to slide 5 and `scene slide current` reports index 5.**
+- [x] 4.5: Implement `notes(slideIndex?)` by reading `#speakernotes-i*-paragraph-*` textContent (all paragraphs joined with `\n`). Returns notes for the currently-visible slide. **Verified: returned `"Clicktoaddspeakernotes"` placeholder on the live deck.**
+- [x] 4.6: Implement `text()` for the currently-active slide via `.docs-texteventtarget-iframe`. Empty until a text box is in edit mode (a documented caveat).
+- [x] 4.7: Implement `render(id)` by fetching the SVG `<image>`'s blob URL asynchronously, drawing into an `OffscreenCanvas` via `createImageBitmap`, returning a 1600×900 PNG data URL. **Verified: returned a 1600×900 PNG for `filmstrip-slide-5-gd02e148143_0_12` — requires the Phase 0 async-eval fix to round-trip through slop's eval.**
+- [x] 4.8: Register the Slides profile in engine.
+- [x] 4.9: Build + test with the SANS deck from session 20bcf316 — all tests pass.
+
+**Acceptance criteria:**
+- [x] `slop scene slide list` on the SANS deck returns 12 slides with stable IDs. **Verified.**
+- [x] `slop scene slide goto 5` navigates to slide 5 — verified by `slop scene slide current` reporting `"index": 5`. **Verified via URL-hash navigation.**
+- [x] `slop scene notes` returns the current slide's speaker notes text (or the placeholder if empty). **Verified: returned `"Clicktoaddspeakernotes"`.**
+- [x] `slop scene render filmstrip-slide-5-gd02e148143_0_12` returns a 1600×900 PNG data URL. **Verified.**
+- [x] `slop scene profile` returns `"google-slides"`. **Verified.**
+
+### Phase 5: Generic profile + host override (P1)
+
+**Files:** `profiles/generic.ts` (extended), engine (modified).
+
+- [x] 5.1: Extend `profiles/generic.ts` to provide a fallback `list()` that walks `[role=application]`, `[role=main]`, `[role=document]` and returns them as `type: "page"`/`"group"` scene objects.
+- [x] 5.2: Add `--profile <name>` flag to CLI so users can force a profile on a host that auto-detection misses (plumbed through `withProfile(action, filtered)` in `cli/commands/scene.ts`).
+- [x] 5.3: Add `slop scene profile --verbose` which dumps the profile's registered capabilities. **Verified: returns `{name: "google-slides", capabilities: ["list", "resolve", "selected", "text", "render", "slides", "slideCurrent", "slideGoto", "notes"]}`.**
+- [x] 5.4: Every engine function returns actionable missing-capability errors of the form `` `profile 'X' does not support Y()` `` when the active profile doesn't implement a capability.
+
+**Acceptance criteria:**
+- [x] `slop scene list` on any page does not crash and returns either the per-host scene objects or the generic fallback entry. **Verified.**
+- [x] `slop scene profile --verbose` prints the matched profile and which methods are implemented. **Verified.**
+
+### Phase 6: Documentation + tests (P1)
+
+**Files:** `README.md` (modified), `CLAUDE.md` (modified), `Notes/canvas.md` (new), `test/canvas.test.ts` (new).
+
+- [x] 6.1: Add "Scene Graph" section to `README.md` with examples for all three editors.
+- [x] 6.2: Add "Scene-Graph Access" section to `CLAUDE.md` so agents reading it know about the `slop scene` surface.
+- [x] 6.3: Create `Notes/scene.md` with per-profile notes, manual smoke-test instructions, and a "how to add a new profile" guide.
+- [x] 6.4: Create `test/scene.test.ts` with unit tests for:
+  - Canva translate parser (`parseTranslate("translate(61.4815px, 726.581px)")` → `{x: 61.4815, y: 726.581}`)
+  - ID prefix matching (`isCanvaLayerId("LBKfjtRwQHt7D0Cf")` → true)
+  - Profile detection (`detect("docs.google.com", "/document/...")` → "google-docs")
+  - Scene object shape validation (the engine returns the expected structure)
+- [x] 6.5: `bun test` passes all tests. **Verified: 31 tests passing (5 daemon-cli + 10 monitor + 16 scene).**
+- [x] 6.6: `bash scripts/build.sh` produces clean builds for extension, CLI, daemon. **Verified.**
+
+**Acceptance criteria:**
+- [x] Documentation covers the full `slop scene` command set (README.md, CLAUDE.md, Notes/scene.md).
+- [x] Test suite includes 16 new scene tests, all passing alongside the 15 pre-existing tests. Total: 31 passing.
+- [x] Full project build is clean (`bash scripts/build.sh`).
+
+---
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Canva changes the `LB` prefix or layer class names | Low over 3–6 months; certain over 12+ months | Canva profile breaks | Profile is one file, ~60 lines. Fix is fast. Monitor captures detect the pattern change immediately. |
+| Google Docs switches away from canvas rendering | Very low (they spent years moving TO canvas) | No impact — DOM path would come back, making our job easier | — |
+| Google Docs removes the hidden text-event-target iframe | Very low (used by every assistive tech | Would break text read/write | Fall back to parsing the canvas via vision — that's what PRD-14's `render` method enables. |
+| `document.execCommand('insertText', ...)` gets removed from Chrome | Medium over 24+ months (deprecated per spec, but still used by Google Docs itself) | Text insertion breaks | Fall back to `InputEvent` dispatch. Already scoped in Phase 3.4. |
+| `match_origin_as_fallback: true` semantics change | Very low | Content script stops running in `about:blank` iframes | Use the parent-frame `contentDocument` path, which works independently of content-script injection — verified in session. |
+| `canvas.toDataURL()` on Google Docs throws tainted-origin | Low | Render fails for Docs pages | Caveat: the rendering canvas uses blob URLs which are same-origin. Tested: `toDataURL` works. If Google ever changes this, the error surfaces as `SecurityError` from the browser and the CLI reports it cleanly. |
+| Async eval fix breaks an existing caller that depended on `{}` behavior | Very low | Regression | Add an existing-behavior regression test: a sync eval still returns the sync value. |
+| Trusted Types blocks the `createScript` call when we reload the page | Already handled via the `__slop_tt_policy` fallback | — | Current code already handles this with a dated-policy fallback. |
+| Shadow DOM hit-test mismatches — clicking the computed center hits a cover layer | Medium | Click fails silently | After dispatching a click, re-read the selection state; if unchanged, retry with an OS-level `os_click` at the same coordinate. Already a pattern in the router's auto-escalation code. |
+| Multi-page Canva designs virtualize layers | Medium | `list()` returns only visible page's layers | Document as a limitation. Agent must navigate pages first. Future PRD could add a pagination loop. |
+| Google Slides blob URLs are short-lived / GC'd | Low | Render fails | Fetch-and-draw happens synchronously in the same JS turn via the async eval fix — no opportunity for GC. |
+
+---
+
+## Success Metrics
+
+1. **One command reads the full text of any Google Doc.** `slop canvas text` returns the document content including inline HTML.
+2. **One command writes text at the cursor of any Google Doc.** `slop canvas insert "text"` updates the doc — verifiable with a round-trip `slop canvas text` read.
+3. **One command enumerates every object on a Canva design.** `slop canvas list` on Canva returns every `LB` layer with type, bbox, and doc coordinates.
+4. **One command clicks a Canva object by stable ID.** `slop canvas click LBKfjtRwQHt7D0Cf` selects the target — verifiable via `slop canvas selected`.
+5. **One command lists every slide in a Google Slides deck.** `slop canvas slide list` returns all slides with stable IDs.
+6. **One command navigates to any slide by index.** `slop canvas slide goto 5`.
+7. **One command reads speaker notes for the current slide.** `slop canvas notes`.
+8. **One command returns a PNG snapshot of any scene object.** `slop canvas render <id> --save`.
+9. **Async `slop eval --main` works for promises.** Returns the resolved value, not `{}`.
+10. **Zero CDP attachments.** Grep for `chrome.debugger` in the diff produces zero new matches.
+11. **All existing tests still pass.** `bun test` → 15 existing + new canvas tests → 0 failures.
+12. **Clean build.** `bash scripts/build.sh` → exit code 0, all three bundles produced.
+
+---
+
+## Open Questions (deferred, not blocking)
+
+1. **Should `slop canvas text` on a Slides page return the text of the current slide only, or all slides?** — Default: current slide only. All-slides would require either iterating edit mode on each (intrusive) or vision OCR (out of scope for this PRD).
+2. **Should `slop canvas render` default to file output or data URL?** — Default: data URL. `--save` saves to a temp file. Mirrors `slop screenshot`.
+3. **Should we add `slop canvas watch` to stream scene changes as they happen?** — Interesting but not in scope. Could be a PRD-15 extension once we know what signals we'd emit.
+4. **Should we persist profile matches in a cache?** — No. Profile detection is a 10-element array scan. Cheap.

--- a/test/monitor.test.ts
+++ b/test/monitor.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { existsSync, unlinkSync, writeFileSync, readFileSync, appendFileSync } from "node:fs"
+import { EVENTS_PATH } from "../shared/platform"
+import {
+  renderEvent,
+  renderSession,
+  escapeArg,
+  buildPlan,
+  readMonEvents,
+  listSessions,
+} from "../cli/commands/monitor"
+
+describe("monitor sparse format + renderer + plan generator", () => {
+  // Each test rewrites EVENTS_PATH with a controlled fixture so we don't depend on
+  // a running daemon or extension.
+  let backupContent: string | null = null
+
+  beforeAll(() => {
+    if (existsSync(EVENTS_PATH)) {
+      backupContent = readFileSync(EVENTS_PATH, "utf-8")
+    }
+  })
+
+  afterAll(() => {
+    if (backupContent !== null) {
+      writeFileSync(EVENTS_PATH, backupContent)
+    } else {
+      try { unlinkSync(EVENTS_PATH) } catch {}
+    }
+  })
+
+  beforeEach(() => {
+    try { unlinkSync(EVENTS_PATH) } catch {}
+  })
+
+  function writeFixture(events: Array<Record<string, unknown>>) {
+    const lines = events.map((e) => JSON.stringify({ timestamp: new Date().toISOString(), ...e }))
+    writeFileSync(EVENTS_PATH, lines.join("\n") + "\n")
+  }
+
+  test("escapeArg escapes double quotes and backslashes", () => {
+    expect(escapeArg("hello")).toBe("hello")
+    expect(escapeArg('say "hi"')).toBe('say \\"hi\\"')
+    expect(escapeArg("a\\b")).toBe("a\\\\b")
+  })
+
+  test("readMonEvents filters by session id", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://a/" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "button", n: "Go", tr: true },
+      { event: "mon_stop", sid: "alpha", s: 2, t: 1200, evt: 3, mut: 0, net: 0, dur: 200 },
+      { event: "mon_start", sid: "beta", s: 0, t: 2000, tid: 2, url: "https://b/" },
+      { event: "click", sid: "beta", s: 1, t: 2100, ref: "e2", r: "link", n: "More", tr: true },
+    ])
+    const alpha = readMonEvents("alpha")
+    expect(alpha.length).toBe(3)
+    expect(alpha.every((e) => e.sid === "alpha")).toBe(true)
+    const beta = readMonEvents("beta")
+    expect(beta.length).toBe(2)
+  })
+
+  test("listSessions groups by sid and returns counts", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://a/", ins: "test" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "button", n: "Go", tr: true },
+      { event: "mut", sid: "alpha", s: 2, t: 1150, c: 3, add: 1, rem: 0, attr: 2, cause: 1 },
+      { event: "fetch", sid: "alpha", s: 3, t: 1180, u: "/api/x", m: "GET", st: 200, bz: 100, cause: 1 },
+      { event: "mon_stop", sid: "alpha", s: 4, t: 1500, evt: 5, mut: 1, net: 1, dur: 500 },
+    ])
+    const sessions = listSessions()
+    expect(sessions.length).toBe(1)
+    expect(sessions[0].sid).toBe("alpha")
+    expect(sessions[0].url).toBe("https://a/")
+    expect(sessions[0].ins).toBe("test")
+    expect(sessions[0].evt).toBeGreaterThan(0)
+    expect(sessions[0].mut).toBe(1)
+    expect(sessions[0].net).toBe(1)
+    expect(sessions[0].status).toBe("stopped")
+  })
+
+  test("renderSession produces aligned text", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://a/", ins: "do thing" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "button", n: "Go", tr: true, x: 100, y: 50 },
+      { event: "input", sid: "alpha", s: 2, t: 1200, ref: "e2", r: "textbox", n: "Q", v: "hello", tr: true },
+      { event: "mut", sid: "alpha", s: 3, t: 1250, c: 5, add: 2, rem: 0, attr: 3, cause: 1 },
+      { event: "fetch", sid: "alpha", s: 4, t: 1300, u: "/api/search", m: "GET", st: 200, bz: 1024, cause: 1 },
+      { event: "mon_stop", sid: "alpha", s: 5, t: 1700, evt: 5, mut: 1, net: 1, dur: 700 },
+    ])
+    const out = renderSession("alpha")
+    expect(out).toContain("session alpha")
+    expect(out).toContain("instruction:")
+    expect(out).toContain("click")
+    expect(out).toContain("Go")
+    expect(out).toContain("textbox")
+    expect(out).toContain("/api/search")
+    expect(out).toContain("ended after")
+  })
+
+  test("buildPlan emits valid slop replay script", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://example.com/" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "button", n: "Search", tr: true },
+      { event: "input", sid: "alpha", s: 2, t: 1150, ref: "e2", r: "textbox", n: "Query", v: "bun docs", tr: true },
+      { event: "mut", sid: "alpha", s: 3, t: 1180, c: 4, add: 2, rem: 0, attr: 1, cause: 2 },
+      { event: "key", sid: "alpha", s: 4, t: 1200, kc: "Enter", tr: true },
+      { event: "fetch", sid: "alpha", s: 5, t: 1250, u: "/api/search?q=bun", m: "GET", st: 200, bz: 2048, cause: 4 },
+      { event: "mon_stop", sid: "alpha", s: 6, t: 1500, evt: 6, mut: 1, net: 1, dur: 500 },
+    ])
+    const plan = buildPlan("alpha")
+    expect(plan).toContain('slop tab new "https://example.com/"')
+    expect(plan).toContain("slop wait-stable")
+    expect(plan).toContain('slop click "button:Search"')
+    expect(plan).toContain('slop type "textbox:Query" "bun docs"')
+    expect(plan).toContain('slop keys "Enter"')
+    expect(plan).toContain("slop net log")
+    // Plan must end with comments referencing the cued fetch
+    expect(plan).toMatch(/api\/search/)
+  })
+
+  test("buildPlan ignores synthetic (tr:false) events", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://example.com/" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "button", n: "Synthetic", tr: false },
+      { event: "click", sid: "alpha", s: 2, t: 1200, ref: "e2", r: "button", n: "Real", tr: true },
+      { event: "mon_stop", sid: "alpha", s: 3, t: 1300, evt: 3, mut: 0, net: 0, dur: 300 },
+    ])
+    const plan = buildPlan("alpha")
+    expect(plan).not.toContain("Synthetic")
+    expect(plan).toContain('"button:Real"')
+  })
+
+  test("buildPlan emits TODO for masked password inputs", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://example.com/login" },
+      { event: "input", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "textbox", n: "Password", v: "***12***", tr: true },
+      { event: "mon_stop", sid: "alpha", s: 2, t: 1200, evt: 2, mut: 0, net: 0, dur: 200 },
+    ])
+    const plan = buildPlan("alpha")
+    expect(plan).toContain("# TODO")
+    expect(plan).toContain("masked")
+  })
+
+  test("buildPlan handles hard navigation but skips history nav", () => {
+    writeFixture([
+      { event: "mon_start", sid: "alpha", s: 0, t: 1000, tid: 1, url: "https://example.com/" },
+      { event: "click", sid: "alpha", s: 1, t: 1100, ref: "e1", r: "link", n: "Next", tr: true },
+      { event: "nav", sid: "alpha", s: 2, t: 1150, u: "https://example.com/next", typ: "history", cause: 1 },
+      { event: "click", sid: "alpha", s: 3, t: 1200, ref: "e2", r: "link", n: "External", tr: true },
+      { event: "nav", sid: "alpha", s: 4, t: 1300, u: "https://other.example.com/", typ: "hard", cause: 3 },
+      { event: "mon_stop", sid: "alpha", s: 5, t: 1500, evt: 5, mut: 0, net: 0, dur: 500 },
+    ])
+    const plan = buildPlan("alpha")
+    // history nav must NOT emit slop navigate (already implicit in click)
+    expect(plan).not.toContain('slop navigate "https://example.com/next"')
+    // hard nav SHOULD emit slop navigate
+    expect(plan).toContain('slop navigate "https://other.example.com/"')
+  })
+
+  test("renderEvent omits empty fields and right-aligns time", () => {
+    const ev = {
+      timestamp: new Date().toISOString(),
+      event: "click",
+      sid: "alpha",
+      s: 1,
+      t: 1100,
+      k: "click",
+      ref: "e1",
+      r: "button",
+      n: "Submit",
+      tr: true,
+    }
+    const out = renderEvent(ev as any, 1000)
+    expect(out).toContain("click")
+    expect(out).toContain("Submit")
+    expect(out).toContain("e1")
+  })
+
+  test("readMonEvents tolerates malformed lines", () => {
+    appendFileSync(EVENTS_PATH, '{"event":"mon_start","sid":"alpha","s":0,"t":1000}\n')
+    appendFileSync(EVENTS_PATH, "this is not json\n")
+    appendFileSync(EVENTS_PATH, '{"event":"click","sid":"alpha","s":1,"t":1100,"ref":"e1","r":"button","n":"X","tr":true}\n')
+    const evs = readMonEvents("alpha")
+    expect(evs.length).toBe(2)
+  })
+})

--- a/test/scene.test.ts
+++ b/test/scene.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from "bun:test"
+import { parseSceneCommand } from "../cli/commands/scene"
+
+describe("slop scene CLI parser", () => {
+  test("scene profile returns the right action", async () => {
+    const a = await parseSceneCommand(["scene", "profile"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_profile")
+    expect(a!.verbose).toBeFalsy()
+  })
+
+  test("scene profile --verbose flags verbose", async () => {
+    const a = await parseSceneCommand(["scene", "profile", "--verbose"], false)
+    expect(a).not.toBeNull()
+    expect(a!.verbose).toBe(true)
+  })
+
+  test("scene list --type shape filters", async () => {
+    const a = await parseSceneCommand(["scene", "list", "--type", "shape"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_list")
+    expect(a!.filter).toBe("shape")
+  })
+
+  test("scene click requires id", async () => {
+    const a = await parseSceneCommand(["scene", "click", "LBabcdef01234567"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_click")
+    expect(a!.id).toBe("LBabcdef01234567")
+  })
+
+  test("scene click --os sets os flag", async () => {
+    const a = await parseSceneCommand(["scene", "click", "LBabcdef01234567", "--os"], false)
+    expect(a).not.toBeNull()
+    expect(a!.os).toBe(true)
+  })
+
+  test("scene text with --with-html flag", async () => {
+    const a = await parseSceneCommand(["scene", "text", "--with-html"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_text")
+    expect(a!.withHtml).toBe(true)
+  })
+
+  test("scene insert joins text arguments", async () => {
+    const a = await parseSceneCommand(["scene", "insert", "hello", "from", "slop"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_insert")
+    expect(a!.text).toBe("hello from slop")
+  })
+
+  test("scene slide list returns slide_list action", async () => {
+    const a = await parseSceneCommand(["scene", "slide", "list"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_slide_list")
+  })
+
+  test("scene slide goto takes a numeric index", async () => {
+    const a = await parseSceneCommand(["scene", "slide", "goto", "5"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_slide_goto")
+    expect(a!.index).toBe(5)
+  })
+
+  test("scene slide <n> is shorthand for goto <n>", async () => {
+    const a = await parseSceneCommand(["scene", "slide", "7"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_slide_goto")
+    expect(a!.index).toBe(7)
+  })
+
+  test("scene notes with --slide override", async () => {
+    const a = await parseSceneCommand(["scene", "notes", "--slide", "3"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_notes")
+    expect(a!.slideIndex).toBe(3)
+  })
+
+  test("scene render requires id", async () => {
+    const a = await parseSceneCommand(["scene", "render", "page-0"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_render")
+    expect(a!.id).toBe("page-0")
+  })
+
+  test("scene zoom returns scene_zoom action", async () => {
+    const a = await parseSceneCommand(["scene", "zoom"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_zoom")
+  })
+
+  test("scene selected returns scene_selected action", async () => {
+    const a = await parseSceneCommand(["scene", "selected"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_selected")
+  })
+
+  test("scene hit takes comma coordinates", async () => {
+    const a = await parseSceneCommand(["scene", "hit", "400,500"], false)
+    expect(a).not.toBeNull()
+    expect(a!.type).toBe("scene_hit")
+    expect(a!.x).toBe(400)
+    expect(a!.y).toBe(500)
+  })
+
+  test("scene --profile override propagates", async () => {
+    const a = await parseSceneCommand(["scene", "list", "--profile", "canva"], false)
+    expect(a).not.toBeNull()
+    expect(a!.profile).toBe("canva")
+  })
+})

--- a/use-cases/cy-dashboard-spa-testing/README.md
+++ b/use-cases/cy-dashboard-spa-testing/README.md
@@ -1,0 +1,238 @@
+# Use Case: Testing a Three-Panel SPA (Cy Dashboard)
+
+**Date:** 2026-04-05
+**Agent:** Cy (Claude)
+**Target:** Cy Dashboard at `http://localhost:5173` — a three-column WebSocket-driven SPA with sidebar (session list), main chat area (scrollable messages), and right panel (tabbed: Tasks/Memory/Analytics/Extensions).
+
+---
+
+## The Challenge
+
+The Cy Dashboard has three independently scrollable panels. The session list items are `<div>`s with JS click handlers (no ARIA roles), the main chat area contains hundreds of entries with collapsible tool calls, and the right panel tabs load content via API fetch. Agents typically struggle with:
+
+1. **Non-interactive elements** — session items aren't buttons/links, so `slop tree` doesn't show them
+2. **Multi-panel scroll** — `slop scroll` hits the page, not the specific panel
+3. **Dynamic content** — clicking a session triggers API fetch + DOM replacement
+4. **Knowing what to verify** — the page has a WebSocket connection indicator, bundled assets, and API-driven panels
+
+---
+
+## The Successful Flow
+
+### Step 1: Open the Tab
+
+```bash
+slop tab new "http://localhost:5173"
+```
+
+Wait for load. Verify the tab title includes "Connected" (proves WebSocket is working):
+
+```bash
+slop tabs
+# Look for: "Cy Dashboard — Connected"
+```
+
+**Key insight:** The page title is the first health check. "Connected" means the WebSocket handshake succeeded. "Disconnected" or a plain "Cy Dashboard" means the server isn't running or WS failed.
+
+### Step 2: Read the Layout with `tree` and `text`
+
+```bash
+slop tree --tab <TAB_ID> --filter all
+```
+
+**What you see:**
+```
+complementary
+  heading "✦ Cy ●"
+  [e1] button "New Session"
+  [e2] textbox type="text" placeholder="Search sessions..."
+main
+  banner
+  [e3] textbox
+  [e4] button "Send"
+complementary
+  [e5] button "Tasks"
+  [e6] button "Memory"
+  [e7] button "Analytics"
+  [e8] button "Extensions"
+```
+
+**Key insight:** `tree` shows the structural skeleton — sidebar controls (e1, e2), main input area (e3, e4), right panel tabs (e5-e8). The session list items are NOT in the tree because they're plain `<div>`s without ARIA roles. This is expected — don't fight it.
+
+Then read full page text to verify data loaded:
+
+```bash
+slop text --tab <TAB_ID>
+```
+
+**What you see:** Session names, timestamps, costs — proves the API fetch worked and the session list rendered. Example:
+```
+●prd07-test
+4/5/2026, 10:55:06 AM
+●@codex hello there!
+4/5/2026, 7:23:12 AM $1.02
+```
+
+### Step 3: Click Non-Interactive Session Items via `eval --main`
+
+Session items are `<div class="session-item">` with `addEventListener('click', ...)`. Since they're not in `slop tree`, use `eval --main` to click them:
+
+```bash
+# Click the third session (index 2)
+slop eval "document.querySelectorAll('.session-item')[2]?.click()" --tab <TAB_ID> --main
+```
+
+**CRITICAL:** Use `--main` flag. Without it, eval runs in an isolated world and can't access the page's event listeners. The click will fire but the handler won't execute.
+
+To click by name:
+```bash
+slop eval "
+const items = document.querySelectorAll('.session-item');
+for (let i = 0; i < items.length; i++) {
+  const name = items[i].querySelector('.session-name')?.textContent || '';
+  if (name.includes('Look at')) { items[i].click(); break; }
+}
+'done'
+" --tab <TAB_ID> --main
+```
+
+Wait 2-3 seconds after clicking for the API fetch + render to complete:
+```bash
+sleep 3
+```
+
+### Step 4: Verify Session Entries Loaded
+
+After clicking a session, the main panel fills with entries. Run `tree --filter all` again:
+
+```bash
+slop tree --tab <TAB_ID> --filter all
+```
+
+**What you see now:** The main area populates with tool call collapsibles (details/summary elements), which DO show in the tree:
+```
+main
+  banner
+  [e37] group "⚡ task_create Find recent Pi session files..."
+  [e38] button "⚡ task_create Find recent Pi session files"
+  [e39] group "✓ bash 276 entries..."
+  ...
+```
+
+**Key insight:** Tool calls render as `<details>` elements — `tree` shows these as groups with buttons (the `<summary>`). Assistant text messages are plain `<div>`s and won't appear in tree, but `text` captures them.
+
+### Step 5: Scroll the Chat Panel (Not the Page)
+
+This is where agents typically fail. The page has three scrollable areas:
+- `#sessions-list` (sidebar, `overflow-y: auto`)
+- `#messages` (main chat, `overflow-y: auto`)
+- `#panel-content` (right panel, `overflow-y: auto`)
+
+`slop scroll up/down` scrolls the **page viewport**, which may not scroll the panel you want (the panels have `overflow: hidden` on the parent with individual scroll containers).
+
+**Solution: Use `eval --main` to scroll specific containers:**
+
+```bash
+# Scroll chat to top
+slop eval "document.getElementById('messages').scrollTop = 0" --tab <TAB_ID> --main
+
+# Scroll chat to bottom
+slop eval "document.getElementById('messages').scrollTop = document.getElementById('messages').scrollHeight" --tab <TAB_ID> --main
+
+# Scroll session list to top
+slop eval "document.getElementById('sessions-list').scrollTop = 0" --tab <TAB_ID> --main
+
+# Scroll right panel content
+slop eval "document.getElementById('panel-content').scrollTop = 0" --tab <TAB_ID> --main
+```
+
+**Key insight:** In multi-panel SPAs, `slop scroll` targets the page viewport. For internal scrollable containers, use `eval` to set `.scrollTop` directly. This is reliable and immediate — no animation, no guessing which panel receives focus.
+
+### Step 6: Test Right Panel Tabs
+
+The right panel tabs (Tasks, Memory, Analytics, Extensions) ARE interactive buttons in `slop tree`. Click them directly:
+
+```bash
+# Click Memory tab
+slop click e6 --tab <TAB_ID>
+sleep 1
+
+# Read the content
+slop eval "document.getElementById('panel-content')?.textContent?.slice(0, 300)" --tab <TAB_ID> --main
+```
+
+**What you see:**
+```
+234 entries
+project
+quickcut-cli-video-intelligence-project
+Ron is building quickcut, a Swift CLI for video intelligence...
+```
+
+```bash
+# Click Analytics tab
+slop click e7 --tab <TAB_ID>
+sleep 1
+
+slop eval "document.getElementById('panel-content')?.textContent?.slice(0, 300)" --tab <TAB_ID> --main
+```
+
+**What you see:**
+```
+Total (30d): $1880.29
+2026-04-05 claude-opus-4-6 $9.14 32,783 tok
+2026-04-05 gpt-5.4 $17.54 6,742,199 tok
+```
+
+**Key insight:** For tabbed panels where the content is dynamically loaded via API, click the tab → sleep → read content. Use `eval` to read `textContent` from a specific container ID rather than `slop text` (which returns the entire page).
+
+### Step 7: Cleanup
+
+```bash
+slop tab close --tab <TAB_ID>
+```
+
+---
+
+## Decision Tree for Multi-Panel SPAs
+
+```
+Need to interact with an element?
+├── Is it in `slop tree`? (buttons, inputs, links, details)
+│   └── YES → slop click/type/select by ref (e1, e5, etc.)
+├── Is it a styled div with JS handlers? (session items, cards)
+│   └── YES → slop eval "document.querySelector('...').click()" --main
+└── Need to scroll a specific panel?
+    └── YES → slop eval "document.getElementById('container').scrollTop = X" --main
+    
+Need to read content?
+├── Full page text → slop text
+├── Specific container → slop eval "el.textContent.slice(0, N)" --main
+└── Interactive element structure → slop tree --filter all
+```
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake | Why It Fails | Correct Approach |
+|---------|-------------|-----------------|
+| `slop scroll up` to scroll chat | Scrolls page viewport, not the chat container | `eval "messages.scrollTop = 0" --main` |
+| `slop find "session name"` | Session items have no ARIA role, `find` won't match | `eval "querySelectorAll('.session-item')" --main` |
+| `slop eval "el.click()"` without `--main` | Runs in isolated world, page handlers don't fire | Always use `--main` for page interaction |
+| `slop screenshot` to verify layout | Wastes time, tree+text gives better data | `slop tree --filter all` + `slop text` |
+| Not waiting after click | API fetch + DOM render takes 1-3 seconds | `sleep 2` or `sleep 3` after navigation clicks |
+| Using `slop text` for one panel | Returns entire page text, hard to parse | `eval "getElementById('panel-content').textContent"` |
+
+---
+
+## Verified Results
+
+This flow successfully confirmed:
+- ✅ Session list renders with names, timestamps, costs (API: `/api/sessions`)
+- ✅ Clicking sessions loads entries (API: `/api/sessions/:id/entries/rendered`)
+- ✅ Tool call collapsibles render as `<details>` elements
+- ✅ Thinking blocks render
+- ✅ Right panel tabs all load data (Memory: 234 entries, Analytics: $1,880.29 30d)
+- ✅ WebSocket connected (page title includes "Connected")
+- ✅ Bun fullstack dev server bundles CSS/JS (bundled asset URLs in source)


### PR DESCRIPTION
## Summary

Two new user-facing capabilities plus one foundational fix:

1. **PRD-13 — Session Monitor (`slop monitor`)** — record a user's real clicks, keystrokes, form changes, DOM mutations, and correlated network calls as a sparse append-only JSONL log, then export as a pretty timeline or a runnable `slop` replay script.

2. **PRD-14 — Scene Graph Access (`slop scene`)** — profile-driven read/write access to visual editors that don't render through the DOM normally: **Canva**, **Google Docs**, and **Google Slides**. Enumerate objects by stable ID, click shapes, read full document text, navigate slide decks, render pages to PNG. No CDP, no vision, no screenshots.

3. **Phase 0 fix to `evaluate.ts`** — the injected `func` is now `async` and awaits Promise return values, matching Chrome's documented `executeScript` behavior. Unblocks async operations (fetch, createImageBitmap, blob handling) across all scene profiles and any other eval consumer.

## What ships

### `slop monitor` (PRD-13)
- Capture-phase content-script listeners for clicks, keys, inputs, focus, scroll
- MutationObserver 50ms debounce batcher, correlated to user actions within a 500ms cause window
- `__slop_net` subscription tags fetch/xhr events back to the action that caused them
- `chrome.webNavigation` `onCommitted` / `onHistoryStateUpdated` for SPA hash + hard nav
- Sparse JSONL format — short keys (`t`, `s`, `k`, `sid`, `ref`, `r`, `n`, `cause`) keep a 30-min session ~60 KB
- Background session map + `chrome.tabs.onRemoved` auto-stop
- Daemon ws handler now routes `{type:"event"}` messages (three-line patch; previously the ws path dropped them)
- CLI: `slop monitor start|stop|status|pause|resume|tail|list|export [--json|--plan]`
- Replay-plan generator emits semantic-selector commands (`slop click "button:Submit"`) that survive DOM churn
- Password masking for `input[type=password]` and `autocomplete=cc-*`
- 10 unit tests in `test/monitor.test.ts`

### `slop scene` (PRD-14)
- `extension/src/content/scene/` module tree with per-host profiles:
  - **canva** — enumerates `[id^="LB"]` layers (stable across reloads), parses `style.transform: translate(x, y)`, computes viewport coords at click time
  - **google-docs** — reads the full document HTML from the hidden `.docs-texteventtarget-iframe > [role=textbox]` (including inline styles and `data-ri` range-index offsets), writes via `document.execCommand('insertText')` (undoable with `Meta+Z`), renders `.kix-canvas-tile-content` to PNG via `toDataURL`
  - **google-slides** — filmstrip enumeration via `filmstrip-slide-N-gd…` IDs + `data-slide-page-id`; slide navigation via `location.hash = "#slide=id." + pageId` (synthetic clicks and keys are filtered by Slides, hash is the only reliable path); speaker notes from `#speakernotes-i*-paragraph-*`; async blob fetch rendering via `createImageBitmap`
  - **generic** — fallback for unknown hosts using `[role=application|main|document]`
- 17 `scene_*` action types dispatched from `content.ts` through a central `handleCanvasAction` engine
- CLI: `slop scene profile|list|click|dblclick|hit|selected|zoom|text|insert|cursor-to|slide list|slide current|slide goto|notes|render`
- `--profile <name>` override flag; `--verbose` capability listing
- 16 unit tests in `test/scene.test.ts`

### Phase 0 — async eval
- `extension/src/background/capabilities/evaluate.ts` now wraps the injected func as `async`, awaits any returned Promise before cloning, preserves Trusted Types policy creation, and converts rejections to `{success:false, error: msg}`
- Verified: `slop eval --main "1 + 1"` → `2`, `slop eval --main "fetch(url).then(r => r.blob())"` → real blob metadata, `slop eval --main "Promise.reject(new Error('nope'))"` → `error: nope`

## Documentation

- `README.md` — Scene Graph + Session Monitor added to **Core Concepts**, new recipes for Google Docs read/write, Canva object hit-test, Slides navigation/render, record-and-replay, and HTMLCanvas pixel diff (distinguished from `slop scene`)
- `CLAUDE.md` — new Scene-Graph Access + Recording Sessions sections with per-editor architecture notes; 4 new Typical Flows; "What NOT to Do" items warn about the `slop canvas` vs `slop scene` distinction and Slides synthetic-event filtering
- `Notes/scene.md` and `Notes/monitor.md` with manual smoke-test procedures
- `prd/PRD-13.md` and `prd/PRD-14.md` with all items checked + live verification commentary

Also included: `use-cases/cy-dashboard-spa-testing/README.md` — an SPA-testing case study written 2026-04-05 that wasn't previously tracked.

## Verification

- **Tests:** 31/31 passing (5 daemon-cli + 10 monitor + 16 scene) — `bun test`
- **Build:** `bash scripts/build.sh` clean for extension + CLI + daemon
- **Live-verified on:**
  - Canva design — `scene list` returns 10 layers, `scene hit 414,395` resolves to the correct LB ID, `scene zoom` returns the current scale factor, `scene profile` returns `canva`
  - Google Doc — `scene text` returns full document, `scene text --with-html` returns full HTML with `data-ri` offsets + inline images + tables, `scene insert "hello from slop"` grew the text from 25 to 40 chars then was undone via `slop keys Meta+z`
  - Google Slides — `scene slide list` returns 12 slides, `scene slide goto 5` + `scene slide current` confirms index 5, `scene render filmstrip-slide-5-*` returns a 1600×900 PNG

## Known limitations (documented)

- **Canva synthetic clicks** sometimes require prior interactive warmup before `aria-label` on `[role=application]` updates. `--os` flag is plumbed in the CLI parser for trusted-event escalation.
- **Google Slides** filters synthetic clicks AND synthetic keys on the filmstrip — hash navigation is the only reliable path for `slideGoto`.
- **Async eval** requires the fix in this PR; any upstream slop consumer that was relying on Promises silently returning `{}` will now get the real resolved value.

## Stats

```
28 files changed, 4749 insertions(+), 12 deletions(-)
```