### PR TITLE
docs: add installation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,61 @@ Browser control for AI agents. No CDP, no MCP, no API keys. The agent calls `slo
 
 **Binary:** `dist/slop`
 
+## Installation
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) runtime
+- Chrome or Brave browser
+
+### Build
+
+```bash
+git clone https://github.com/Hacker-Valley-Media/slop-browser.git
+cd slop-browser
+bash scripts/build.sh
+```
+
+This produces three artifacts:
+
+| Artifact | Path |
+|----------|------|
+| CLI binary | `dist/slop` |
+| Background daemon | `daemon/slop-daemon` |
+| Chrome extension | `extension/dist/` |
+
+### Install the CLI
+
+Add the binary to your PATH:
+
+```bash
+cp dist/slop /usr/local/bin/
+```
+
+### Install the Chrome Extension
+
+1. Open Chrome or Brave and navigate to `chrome://extensions`
+2. Enable **Developer mode** (toggle in the top-right corner)
+3. Click **Load unpacked**
+4. Select the `extension/dist/` directory from this repo
+5. The slop extension icon should appear in your toolbar
+
+### Register Native Messaging (macOS)
+
+The CLI communicates with the extension via Chrome's native messaging protocol. Run the install script to register the manifest:
+
+```bash
+bash scripts/install.sh
+```
+
+### Verify
+
+```bash
+slop status    # Should report daemon status
+```
+
+The daemon auto-starts on first command — no manual launch needed.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a new **Installation** section to the README covering build from source, CLI install, Chrome extension loading, and native messaging registration
- Placed before Quick Start so new users see setup instructions first

## Test plan
- [ ] Verify `bash scripts/build.sh` produces all three artifacts listed
- [ ] Confirm Chrome extension loads successfully from `extension/dist/`
- [ ] Confirm `bash scripts/install.sh` registers native messaging on macOS