### PR TITLE
docs: integrate Pedram's installation section without README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,61 @@ The agent calls `slop` CLI commands, reads the output, decides what to do next. 
 
 **Binary:** `dist/slop`
 
+## Installation
+
+### Prerequisites
+
+- [Bun](https://bun.sh/) runtime
+- Chrome or Brave browser
+
+### Build
+
+```bash
+git clone https://github.com/Hacker-Valley-Media/slop-browser.git
+cd slop-browser
+bash scripts/build.sh
+```
+
+This produces three artifacts:
+
+| Artifact | Path |
+|----------|------|
+| CLI binary | `dist/slop` |
+| Background daemon | `daemon/slop-daemon` |
+| Chrome extension | `extension/dist/` |
+
+### Install the CLI
+
+Add the binary to your PATH:
+
+```bash
+cp dist/slop /usr/local/bin/
+```
+
+### Install the Chrome Extension
+
+1. Open Chrome or Brave and navigate to `chrome://extensions`
+2. Enable **Developer mode** (toggle in the top-right corner)
+3. Click **Load unpacked**
+4. Select the `extension/dist/` directory from this repo
+5. The slop extension icon should appear in your toolbar
+
+### Register Native Messaging (macOS)
+
+The CLI communicates with the extension via Chrome's native messaging protocol. Run the install script to register the manifest:
+
+```bash
+bash scripts/install.sh
+```
+
+### Verify
+
+```bash
+slop status    # Should report daemon status
+```
+
+The daemon auto-starts on first command — no manual launch needed.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ You stay logged in. You pass bot detection. Your agent sees exactly what you see
 
 The agent calls `slop` CLI commands, reads the output, decides what to do next. No MCP, no API keys.
 
-## To install it:
-1. Go to chrome://extensions
-2. Enable "Developer mode"
-3. Click "Load unpacked"
-4. Select the extension/dist/ directory
-
-**Binary:** `dist/slop`
-
 ## Installation
 
 ### Prerequisites
@@ -71,8 +63,6 @@ bash scripts/install.sh
 slop status    # Should report daemon status
 ```
 
-The daemon auto-starts on first command — no manual launch needed.
-
 ## Quick Start
 
 ```bash
@@ -84,7 +74,7 @@ slop type e2 "hello world"            # Type into a field
 slop text                             # Read visible text
 ```
 
-The daemon auto-starts on first command. No setup needed.
+Once installed, the daemon auto-starts on first command. No manual launch needed.
 
 ## Core Concepts
 


### PR DESCRIPTION
## Summary
- cherry-pick Pedram's README installation commit onto a new branch so his authored commit lands on main
- remove the older duplicate install snippet from README
- update Quick Start wording so it no longer claims there is no setup

## Why this path
Directly merging #6 would duplicate install guidance because main has moved since Pedram opened the PR. This preserves Pedram's authored contribution while keeping the newer README structure intact.

## Test plan
- [x] inspect final README diff locally
- [x] run git diff --check

## Attribution
Includes Pedram's cherry-picked commit:
- a25455e authored by Pedram Amini


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation instructions now include explicit prerequisites and build-from-source workflow
  * Added comprehensive installation guide with artifact summary table
  * Separated instructions for CLI and Chrome extension setup
  * Added macOS native-messaging registration steps
  * Introduced system verification command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->