### PR TITLE
Add adaptive rich-editor scene workflows and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ slop text                              # Read visible text
 
 The daemon auto-starts. No setup needed.
 
+## Use Cases
+
+The [`use-cases/`](/Volumes/VRAM/00-09_System/01_Tools/slop-browser/use-cases) folder is where proven browser workflows get turned into reusable documentation. When you figure out how to do something reliably on a live site, add a compact use-case there so later agents can follow the path instead of burning tokens rediscovering it.
+
 ## Reading Pages
 
 ```bash

--- a/Notes/scene.md
+++ b/Notes/scene.md
@@ -1,124 +1,126 @@
-# `slop scene` — Scene-Graph Access
+# `slop scene` — Adaptive Rich-Editor Access
 
 ## What it is
 
-`slop scene` is a profile-driven command surface for reading and manipulating objects inside DOM-rendered visual editors — **without CDP, without screenshots, without vision models**.
+`slop scene` is the command surface for interacting with rich browser editors without CDP and without relying on brittle product-specific DOM ids in the core path.
 
-The key insight: most editors that look like they render to `<canvas>` actually maintain a shadow DOM (Canva), SVG scene graph (Google Slides), or hidden text-mirror iframe (Google Docs) that an agent can address directly. Each editor gets a **profile** — one file under `extension/src/content/scene/profiles/` — that knows how to enumerate, click, read, and write its scene objects.
+The core model is now:
 
-## Supported profiles (today)
+1. Discover editor surfaces from browser-visible capabilities.
+2. Resolve scene ids to geometry and optional underlying elements.
+3. Click by browser hit-testing first, escalate to trusted OS input when needed.
+4. Read and write through the editor-owned writable surface that currently has focus.
 
-| Profile | Host | Path match | What works |
-|---|---|---|---|
-| `canva` | `canva.com` | `/design/*` | `list`, `click`, `selected`, `zoom`, `hit` |
-| `google-docs` | `docs.google.com` | `/document/*` | `text`, `text --with-html`, `insert`, `list` (pages + embeds), `render` |
-| `google-slides` | `docs.google.com` | `/presentation/*` | `list` (slides), `slide current/goto/list`, `notes`, `render`, `text` (in edit mode) |
-| `generic` | fallback | any | `list` (role=application/main/document), `selected` |
+Site-specific profiles still exist where they provide materially better capabilities, but they are treated as optional thin adapters instead of the foundation.
 
-## Command surface
+## Strategy Model
 
-```
-slop scene profile [--verbose]           Detect active profile + capabilities
-slop scene list [--type <t>]             Enumerate scene objects
-slop scene click <id> [--os]             Click by stable id
-slop scene dblclick <id>                 Double-click
-slop scene hit <x>,<y>                   What scene object is at viewport X,Y
-slop scene selected                      Read current selection
-slop scene zoom                          Read editor zoom factor
+### Generic
 
-slop scene text [--with-html]            Read document text (Docs hidden iframe mirror)
-slop scene insert "<text>"               Insert text at cursor (Docs execCommand insertText)
-slop scene cursor <x>,<y>                Move cursor by clicking on the canvas tile
+The generic strategy is the fallback for modern editors and is capability-driven. It discovers scene objects from:
 
-slop scene slide list                    List all slides
-slop scene slide current                 Show current slide
-slop scene slide goto <n>                Navigate via URL fragment
-slop scene slide <n>                     Shorthand
-slop scene notes [--slide <n>]           Read speaker notes
+- semantic roots such as `role=application`, `role=document`, and `role=main`
+- structural page surfaces such as `data-page-id`, large SVG/canvas surfaces, and large transformed containers
+- focused writable surfaces such as `input`, `textarea`, `contenteditable`, `role=textbox`, and hidden proxy inputs
+- viewport hit-testing through `document.elementFromPoint()`
 
-slop scene render <id> [--save]          Render scene object to PNG
-slop scene ... --profile <name>          Force a profile
+Generic scene ids are synthetic and session-stable. They are cached and re-resolved against the live DOM at dispatch time.
+
+### Google Docs
+
+Google Docs still benefits from a dedicated profile because it exposes a hidden text-event-target iframe that provides full text read/write even though the visible page is canvas-backed.
+
+### Google Slides
+
+Google Slides still benefits from a dedicated profile because it exposes stable filmstrip slide objects, hash-based navigation, and DOM-readable speaker notes.
+
+### Canva
+
+`canva` remains available only as an optional adapter alias. It delegates to the adaptive discovery path rather than depending on vendor-specific layer ids in the core path.
+
+## Command Surface
+
+```bash
+slop scene profile [--verbose]           Detect active profile/strategy + capabilities
+slop scene list [--type <t>]             Enumerate scene objects on the current editor surface
+slop scene click <id> [--os]             Click by scene id; `--os` forces trusted input
+slop scene dblclick <id>                 Double-click a scene object
+slop scene hit <x>,<y>                   Identify the scene object at viewport X,Y
+slop scene selected                      Read the current selection / focused editor surface
+slop scene zoom                          Read editor zoom factor when supported
+
+slop scene text [--with-html]            Read editor text when the active surface supports it
+slop scene insert "<text>"               Insert text into the focused editor-owned writable surface
+slop scene cursor <x>,<y>                Move cursor by clicking at viewport X,Y
+
+slop scene slide list                    List all slides (Slides profile)
+slop scene slide current                 Show current slide (Slides profile)
+slop scene slide goto <n>                Navigate via URL fragment (Slides profile)
+slop scene notes [--slide <n>]           Read speaker notes (Slides profile)
+
+slop scene render <id> [--save]          Render scene object to PNG when supported
+slop scene ... --profile <name>          Force a profile/strategy
 ```
 
 ## Manual smoke test
 
-### Canva
+### Generic rich editor
 
 ```bash
-slop tab new "https://www.canva.com/design/<docId>/edit"
+slop tab new "https://example-editor.invalid/"
 sleep 8
-slop scene profile                       # → canva
-slop scene list                          # → array of LB… layer objects
-slop scene zoom                          # → 0.x (editor zoom factor)
-slop scene click LB<id>                  # dispatches click at viewport center
-slop scene selected                      # reads [role=application] aria-label
+slop scene profile --verbose             # strategy + capabilities
+slop scene list                          # scene ids from semantics / structure / focus
+slop scene click <id>                    # synthetic click at resolved center
+slop scene click <id> --os               # trusted OS click at resolved center
+slop scene selected                      # focused writable/editor surface
+slop scene insert "hello from slop"      # if a writable surface is focused
 ```
-
-Known limitation: Canva's selection machine sometimes requires prior interactive warmup. If `scene selected` doesn't update after a scene click, re-run with `--os` to force a CGEvent trusted click.
 
 ### Google Docs
 
 ```bash
-slop tab new "https://docs.google.com/document/d/<docId>/edit"
+slop tab new "https://docs.google.com/document/d/<id>/edit"
 sleep 8
-slop scene profile                       # → google-docs
-slop scene text                          # full document text (textContent)
-slop scene text --with-html              # includes HTML + data-ri offsets
-slop scene insert "hello from slop"      # insert at cursor
-slop scene text                          # verify the insert landed
-slop keys Meta+z                         # undo the insert
-slop scene render page-0 --save          # renders a canvas tile PNG
+slop scene profile --verbose
+slop scene text
+slop scene text --with-html
+slop scene insert "hello from slop"
+slop scene render page-0 --save
 ```
 
 ### Google Slides
 
 ```bash
-slop tab new "https://docs.google.com/presentation/d/<docId>/edit"
+slop tab new "https://docs.google.com/presentation/d/<id>/edit"
 sleep 8
-slop scene profile                       # → google-slides
-slop scene slide list                    # all slides with blob URLs
-slop scene slide goto 5                  # navigate (URL-hash method)
-slop scene slide current                 # → index 5
-slop scene notes                         # speaker notes of current slide
-slop scene render filmstrip-slide-5-gd<hash>_0_12
+slop scene profile --verbose
+slop scene slide list
+slop scene slide goto 5
+slop scene slide current
+slop scene notes
+slop scene render <slide-id> --save
 ```
 
-Known limitation: Slides filmstrip thumbnails filter synthetic clicks AND synthetic keys. `slideGoto` uses URL-hash navigation instead. Slide content text (`scene text`) only appears when a text box is actively being edited — the hidden iframe is empty in view mode.
+## Adding a thin adapter
 
-## Adding a new profile
+Only add a site-specific adapter if the adaptive path cannot provide enough addressability.
 
-1. Create `extension/src/content/scene/profiles/<name>.ts`:
-    ```ts
-    import type { SceneProfile } from "../types"
-    export const myProfile: SceneProfile = {
-      name: "my-editor",
-      detect() { return location.host.endsWith("myeditor.com") },
-      list() { /* enumerate addressable objects */ return [] },
-      resolve(id) { return document.getElementById(id) },
-      selected() { return { has: false } },
-      // add other capabilities as needed
-    }
-    ```
-2. Register the profile in `extension/src/content/scene/engine.ts`:
-    ```ts
-    import { myProfile } from "./profiles/my-editor"
-    // inside ensureBuiltins:
-    profiles.push(myProfile)
-    ```
-3. Rebuild (`bash scripts/build.sh`), reload the extension (`slop reload`), test.
+1. Start by checking whether semantics, structure, focus, and hit-testing are already sufficient.
+2. If not, create `extension/src/content/scene/profiles/<name>.ts`.
+3. Keep the adapter thin and capability-focused.
+4. Do not make the adapter the only path the command surface depends on.
 
-A profile only needs to implement the capabilities it supports. The engine returns actionable errors (`profile 'X' does not support Y()`) for missing methods.
+## Architecture notes
 
-## Architecture notes (grounded evidence)
-
-- **Canva layer IDs** — Empirically observed on session 77907634 via `document.querySelectorAll('[id^="LB"]')`. 10 layers detected. Survived a full `slop navigate` reload. Format: `^LB[A-Za-z0-9_-]{14}$`.
-- **Docs text-mirror iframe** — Documented at `.docs-texteventtarget-iframe > [role=textbox]`. Confirmed via `iframe.contentDocument.querySelector('[role=textbox]').innerHTML` on session 20bcf316: full document HTML with `data-ri="<N>"` spans.
-- **Slides filmstrip pattern** — 12 slides on the SANS deck, IDs `filmstrip-slide-<index>-gd02e148143_0_<M>`. Real slide page IDs carried on `data-slide-page-id` attribute of `.punch-filmstrip-thumbnail` ancestor. URL fragment `#slide=id.<pageId>` is the authoritative navigation mechanism.
-- **Async eval prerequisite** — `chrome.scripting.executeScript` awaits promise return values natively, per `chrome-extensions/docs/extensions/reference/api/scripting.md` line 194. PRD-14 Phase 0 fixes slop's evaluate handler to preserve this semantic, which unlocks `scene render` for Slides (async `fetch` + `createImageBitmap` + `toDataURL`).
+- Real mouse and keyboard input enter Chrome through the browser process and are routed to the appropriate render process. This is why `--os` is the trusted path when synthetic DOM dispatch is ignored.
+- `document.elementFromPoint()` performs browser hit-testing and respects `pointer-events`, which makes it a sound primitive for coordinate-based scene interaction.
+- `contenteditable` and standard input elements remain the browser's core writable primitives for rich editor text entry.
+- `chrome.scripting.executeScript()` awaits promise return values, which keeps async page-context probing viable without CDP.
 
 ## References
 
-- PRD-14 — full design + checklist in `prd/PRD-14.md`
-- `extension/src/content/scene/` — profile implementations
-- `cli/commands/scene.ts` — CLI parsing
-- `extension/src/background/capabilities/evaluate.ts` — Phase 0 async fix
+- `prd/PRD-14.md`
+- `prd/PRD-16.md`
+- `extension/src/content/scene/`
+- `cli/commands/scene.ts`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Once installed, the daemon auto-starts on first command. No manual launch needed
 
 **Stealth** — Passes all major bot detection: BrowserScan (Normal), Pixelscan ("Definitely Human"), Sannysoft (all pass), CreepJS (0% headless), Fingerprint.com (notDetected), AreyouHeadless (not headless). Zero automation fingerprint.
 
+**Use Cases** — The [`use-cases/`](/Volumes/VRAM/00-09_System/01_Tools/slop-browser/use-cases) folder is the cookbook for workflows we have already proven in live pages. When a browser workflow is discovered or stabilized, document the exact path there so future agents can reuse it instead of rediscovering it.
+
 ## Commands
 
 ### Read the Page

--- a/cli/commands/scene.ts
+++ b/cli/commands/scene.ts
@@ -149,20 +149,20 @@ export function parseSceneCommand(filtered: string[], jsonMode = false): Action 
   return null
 }
 
-const CANVAS_HELP = `slop scene — scene-graph access for DOM-rendered editors
+const CANVAS_HELP = `slop scene — adaptive scene access for rich editors
 
 Usage:
-  slop scene profile [--verbose]        Show detected profile (canva, google-docs, google-slides, generic)
-  slop scene list [--type <t>]          Enumerate scene objects on current page
-  slop scene click <id>                 Click a scene object by stable id
+  slop scene profile [--verbose]        Show the detected strategy/profile and capabilities
+  slop scene list [--type <t>]          Enumerate scene objects on the current editor surface
+  slop scene click <id>                 Click a scene object by scene id
   slop scene dblclick <id>              Double-click a scene object (enters text edit on Canva/Slides)
   slop scene select <id>                Click + verify selection changed
   slop scene selected                   Read the current selection label
   slop scene hit <x>,<y>                Identify what scene object is at viewport X,Y
   slop scene zoom                       Read current editor zoom factor (1.0 = 100%)
 
-  slop scene text [--with-html]         Read document text (Google Docs; empty when canvas is opaque)
-  slop scene insert "<text>"            Insert text at cursor (Google Docs / Slides text edit mode)
+  slop scene text [--with-html]         Read editor text when the active surface supports it
+  slop scene insert "<text>"            Insert text into the focused editor-owned writable surface
   slop scene cursor                     Read cursor state
   slop scene cursor <x>,<y>             Move cursor by clicking at viewport X,Y
 
@@ -177,7 +177,7 @@ Usage:
   slop scene render <id> [--save]       Render a scene object as PNG data URL (Docs pages, Slides thumbnails)
 
 Flags:
-  --profile <name>                       Force a profile (canva | google-docs | google-slides | generic)
+  --profile <name>                       Force a profile/strategy (google-docs | google-slides | canva | generic)
   --type <t>                             Filter 'list' by type (image | shape | text | page | slide | embed)
   --with-html                            Include full HTML model with data-ri offsets (Docs only)
   --slide <n>                            Override slide index for notes/render

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -112,19 +112,19 @@ Batch:
   slop wait-stable --ms 500           Custom debounce duration
   slop wait-stable --timeout 3000     Custom hard timeout
 
-Scene Graph (Canva, Google Docs, Google Slides):
-  slop scene profile                    Detect active editor profile (canva/google-docs/google-slides/generic)
-  slop scene profile --verbose          Include the list of supported capabilities
-  slop scene list                       List scene objects on current editor
+Scene Graph (Rich Editors):
+  slop scene profile                    Detect the active editor strategy/profile
+  slop scene profile --verbose          Include active capabilities and strategy details
+  slop scene list                       List scene objects on the current editor surface
   slop scene list --type shape          Filter by type (image|shape|text|page|embed|slide)
-  slop scene click <id>                 Click a scene object by its stable id
+  slop scene click <id>                 Click a scene object by its scene id
   slop scene dblclick <id>              Double-click a scene object
   slop scene select <id>                Click + verify selection change
   slop scene hit <x> <y>                Identify the scene object at viewport coordinates
   slop scene selected                   Read current selection (host-aware)
-  slop scene text                       Read document text (Google Docs)
-  slop scene text --with-html           Include inline HTML + data-ri offsets
-  slop scene insert "<text>"            Insert text at cursor (Google Docs)
+  slop scene text                       Read text from the active editor surface when supported
+  slop scene text --with-html           Include inline HTML when supported
+  slop scene insert "<text>"            Insert text into the focused editor-owned writable surface
   slop scene cursor-to <x> <y>          Move cursor to viewport coordinates
   slop scene slide list                 List all slides in a Google Slides deck
   slop scene slide current              Show the currently-displayed slide

--- a/extension/src/background/router.ts
+++ b/extension/src/background/router.ts
@@ -103,16 +103,39 @@ export async function routeAction(
     tabId, action, action.frameId as number | undefined
   ) as { success: boolean; error?: string; data?: unknown; warning?: string }
 
-  if (action.type === "click" && contentResult.success &&
-      contentResult.warning?.includes("no DOM change") && activeTransport !== "none") {
-    console.log("auto-escalating click to OS-level input")
-    const osResult = await handleOsInputActions({ ...action, type: "os_click" }, tabId)
+  const shouldSceneEscalate =
+    action.type === "scene_click" &&
+    contentResult.success &&
+    ((action.os === true) || contentResult.warning?.includes("no DOM change")) &&
+    activeTransport !== "none"
+
+  const shouldClickEscalate =
+    action.type === "click" &&
+    contentResult.success &&
+    contentResult.warning?.includes("no DOM change") &&
+    activeTransport !== "none"
+
+  if (shouldClickEscalate || shouldSceneEscalate) {
+    const resolvedAt = typeof contentResult.data === "object" && contentResult.data
+      ? (contentResult.data as { at?: { x?: number; y?: number } }).at
+      : undefined
+    console.log(`auto-escalating ${action.type} to OS-level input`)
+    const osResult = await handleOsInputActions({
+      ...action,
+      type: "os_click",
+      x: resolvedAt?.x ?? action.x,
+      y: resolvedAt?.y ?? action.y
+    }, tabId)
     if (osResult.success) {
       return {
         success: true,
         data: {
           ...((typeof osResult.data === "object" && osResult.data) || {}),
-          escalated: { from: "synthetic", to: "os_click", reason: "no DOM mutation after synthetic click" }
+          escalated: {
+            from: action.os === true ? "explicit" : "synthetic",
+            to: "os_click",
+            reason: action.os === true ? "scene click requested trusted input" : "no DOM mutation after synthetic click"
+          }
         },
         tabId
       }
@@ -123,7 +146,9 @@ export async function routeAction(
       data: {
         diagnostics: {
           layers_tried: ["synthetic", "os_click"],
-          reason: "synthetic produced no DOM change, os_click failed",
+          reason: action.os === true
+            ? "trusted scene click failed"
+            : "synthetic produced no DOM change, os_click failed",
           suggestion: "verify element is interactive and Chrome window is visible"
         }
       }
@@ -138,6 +163,8 @@ export async function routeAction(
         reason: contentResult.error,
         suggestion: action.type === "click"
           ? "try: slop click --os " + (action.ref || action.index || "")
+          : action.type === "scene_click"
+            ? "try: slop scene click --os " + (action.id || "")
           : undefined
       }
     }

--- a/extension/src/content/scene/adaptive.ts
+++ b/extension/src/content/scene/adaptive.ts
@@ -1,0 +1,512 @@
+import { getAccessibleName, getEffectiveRole } from "../a11y-tree"
+import { getShadowRoot, isVisible, walkWithShadow } from "../element-discovery"
+import { boundingBox, clickAtViewport } from "./ops"
+import type {
+  SceneObject,
+  SceneObjectType,
+  SceneProfileDescription,
+  SceneRect,
+  SceneResolvedTarget,
+  SceneSelection,
+  SceneText,
+  SceneWriteResult
+} from "./types"
+
+const sceneRefRegistry = new Map<string, WeakRef<Element>>()
+const sceneElementToId = new WeakMap<Element, string>()
+const sceneRefMeta = new Map<string, { signature: string; type: SceneObjectType; strategy: string }>()
+let nextSceneId = 1
+let cachedDiscovery:
+  | {
+      key: string
+      generatedAt: number
+      objects: SceneObject[]
+    }
+  | null = null
+
+type Candidate = {
+  el: Element
+  type: SceneObjectType
+  strategy: string
+  text?: string
+  extras?: Record<string, unknown>
+}
+
+export interface AdaptiveSceneOptions {
+  type?: string
+  profileName?: string
+  notes?: string[]
+}
+
+function discoveryCacheKey(): string {
+  const structuralCount = document.querySelectorAll(
+    '[data-page-id], [role="application"], [role="document"], [role="main"], [contenteditable="true"], canvas, svg'
+  ).length
+  const active = document.activeElement as HTMLElement | null
+  const activeSig = active
+    ? [active.tagName, active.getAttribute("role") || "", active.getAttribute("aria-label") || "", active.getAttribute("data-hidden-input") || ""].join("|")
+    : "none"
+  return [location.href, structuralCount, activeSig].join("::")
+}
+
+function isHtmlElement(el: Element | null | undefined): el is HTMLElement {
+  return !!el && el instanceof HTMLElement
+}
+
+function normalizeRect(rect: SceneRect): string {
+  return `${Math.round(rect.x)}:${Math.round(rect.y)}:${Math.round(rect.w)}:${Math.round(rect.h)}`
+}
+
+function candidateArea(rect: SceneRect): number {
+  return Math.max(0, rect.w) * Math.max(0, rect.h)
+}
+
+function isLikelyWritable(el: Element): boolean {
+  if (!isHtmlElement(el)) return false
+  if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") return true
+  if (el.isContentEditable || el.getAttribute("contenteditable") === "true") return true
+  const role = el.getAttribute("role")
+  return role === "textbox" || role === "searchbox" || role === "combobox" || role === "application"
+}
+
+function isHiddenProxyInput(el: Element): boolean {
+  if (!isHtmlElement(el) || el.tagName !== "INPUT") return false
+  const hiddenAttr = el.getAttribute("data-hidden-input")
+  const inputMode = el.getAttribute("inputmode")
+  const role = el.getAttribute("role")
+  return hiddenAttr === "true" || (role === "application" && inputMode === "none")
+}
+
+function readElementText(el: Element): string {
+  if (!isHtmlElement(el)) return ""
+  if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") {
+    return ((el as HTMLInputElement | HTMLTextAreaElement).value || "").toString()
+  }
+  if (el.isContentEditable || el.getAttribute("contenteditable") === "true") {
+    return (el.textContent || "").toString()
+  }
+  const role = el.getAttribute("role")
+  if (role === "textbox" || role === "combobox" || role === "searchbox") {
+    return (el.textContent || "").toString()
+  }
+  return (getAccessibleName(el) || el.getAttribute("aria-label") || el.textContent || "").toString()
+}
+
+function visibleOrActive(el: Element): boolean {
+  return isVisible(el) || document.activeElement === el
+}
+
+function candidateLabel(el: Element): string | undefined {
+  const text = readElementText(el).trim()
+  if (text) return text.slice(0, 80)
+  const aria = el.getAttribute("aria-label") || getAccessibleName(el)
+  return aria ? aria.slice(0, 80) : undefined
+}
+
+function isPageLikeSurface(el: Element, rect: SceneRect): boolean {
+  const area = candidateArea(rect)
+  const viewportArea = window.innerWidth * window.innerHeight
+  if (el.hasAttribute("data-page-id")) return true
+  if (!isHtmlElement(el)) return false
+  const inlineStyle = el.getAttribute("style") || ""
+  const centered = rect.cx >= window.innerWidth * 0.15 && rect.cx <= window.innerWidth * 0.85
+  if (!centered) return false
+  if (area >= viewportArea * 0.12 && (inlineStyle.includes("transform") || inlineStyle.includes("touch-action"))) return true
+  return false
+}
+
+function maybeClassifyCandidate(el: Element): Candidate | null {
+  const rect = boundingBox(el)
+  if (rect.w < 2 || rect.h < 2) return null
+  if (!visibleOrActive(el)) return null
+
+  const tag = el.tagName.toLowerCase()
+  const role = getEffectiveRole(el)
+  const area = candidateArea(rect)
+  const viewportArea = Math.max(1, window.innerWidth * window.innerHeight)
+
+  if (el.hasAttribute("data-page-id")) {
+    return {
+      el,
+      type: "page",
+      strategy: "page-container",
+      text: candidateLabel(el),
+      extras: { pageId: el.getAttribute("data-page-id") || undefined }
+    }
+  }
+
+  if (tag === "canvas" && area >= viewportArea * 0.08) {
+    return { el, type: "page", strategy: "graphic-surface", text: candidateLabel(el) }
+  }
+
+  if (tag === "svg" && area >= viewportArea * 0.02) {
+    return {
+      el,
+      type: area >= viewportArea * 0.12 ? "page" : "shape",
+      strategy: "graphic-surface",
+      text: candidateLabel(el)
+    }
+  }
+
+  if (role === "application" || role === "document" || role === "main") {
+    const hiddenProxy = isHiddenProxyInput(el)
+    if (hiddenProxy || area >= viewportArea * 0.04 || document.activeElement === el) {
+      return {
+        el,
+        type: role === "main" || role === "document" ? "page" : "group",
+        strategy: hiddenProxy ? "focus-proxy" : "semantic-root",
+        text: candidateLabel(el),
+        extras: { hiddenProxy }
+      }
+    }
+  }
+
+  if (isLikelyWritable(el)) {
+    return {
+      el,
+      type: "text",
+      strategy: isHiddenProxyInput(el) ? "focus-proxy" : "writable-surface",
+      text: candidateLabel(el),
+      extras: {
+        writable: true,
+        hiddenProxy: isHiddenProxyInput(el),
+        focused: document.activeElement === el
+      }
+    }
+  }
+
+  if (isPageLikeSurface(el, rect)) {
+    return {
+      el,
+      type: "page",
+      strategy: "structural-surface",
+      text: candidateLabel(el)
+    }
+  }
+
+  return null
+}
+
+function elementSignature(el: Element): string {
+  const rect = boundingBox(el)
+  const pageId = el.getAttribute("data-page-id") || ""
+  const role = el.getAttribute("role") || ""
+  const aria = (el.getAttribute("aria-label") || getAccessibleName(el) || "").slice(0, 60)
+  return [
+    el.tagName.toLowerCase(),
+    role,
+    pageId,
+    aria,
+    normalizeRect(rect)
+  ].join("|")
+}
+
+export function getOrAssignSceneId(el: Element, type: SceneObjectType, strategy: string): string {
+  const existing = sceneElementToId.get(el)
+  if (existing) {
+    const ref = sceneRefRegistry.get(existing)
+    if (ref?.deref() === el) return existing
+  }
+  const id = `s${nextSceneId++}`
+  sceneRefRegistry.set(id, new WeakRef(el))
+  sceneElementToId.set(el, id)
+  sceneRefMeta.set(id, { signature: elementSignature(el), type, strategy })
+  return id
+}
+
+export function resolveSceneId(id: string): Element | null {
+  const ref = sceneRefRegistry.get(id)
+  if (ref) {
+    const el = ref.deref()
+    if (el && el.isConnected) return el
+  }
+  const meta = sceneRefMeta.get(id)
+  if (!meta) return null
+  let found: Element | null = null
+  walkWithShadow(document.body, (el) => {
+    if (found || !visibleOrActive(el)) return
+    if (elementSignature(el) === meta.signature) found = el
+  })
+  if (found) {
+    sceneRefRegistry.set(id, new WeakRef(found))
+    sceneElementToId.set(found, id)
+  }
+  return found
+}
+
+export function discoverAdaptiveSceneObjects(opts?: AdaptiveSceneOptions): SceneObject[] {
+  const cacheKey = discoveryCacheKey()
+  if (cachedDiscovery && cachedDiscovery.key === cacheKey && Date.now() - cachedDiscovery.generatedAt < 1000) {
+    return opts?.type ? cachedDiscovery.objects.filter((o) => o.type === opts.type) : cachedDiscovery.objects
+  }
+  const out: SceneObject[] = []
+  const seen = new Set<string>()
+  walkWithShadow(document.body, (el) => {
+    const candidate = maybeClassifyCandidate(el)
+    if (!candidate) return
+    if (opts?.type && opts.type !== candidate.type) return
+    const rect = boundingBox(candidate.el)
+    const key = `${candidate.type}:${candidate.strategy}:${normalizeRect(rect)}`
+    if (seen.has(key)) return
+    seen.add(key)
+    const id = getOrAssignSceneId(candidate.el, candidate.type, candidate.strategy)
+    out.push({
+      id,
+      type: candidate.type,
+      rect,
+      text: candidate.text,
+      extras: {
+        ...(candidate.extras || {}),
+        strategy: candidate.strategy,
+        profile: opts?.profileName || "generic"
+      }
+    })
+  })
+  const sorted = out.sort((a, b) => {
+    const areaDiff = candidateArea(b.rect) - candidateArea(a.rect)
+    if (areaDiff !== 0) return areaDiff
+    return a.id.localeCompare(b.id)
+  })
+  cachedDiscovery = {
+    key: cacheKey,
+    generatedAt: Date.now(),
+    objects: sorted
+  }
+  return opts?.type ? sorted.filter((o) => o.type === opts.type) : sorted
+}
+
+export function resolveAdaptiveSceneTarget(id: string): SceneResolvedTarget | null {
+  const el = resolveSceneId(id)
+  if (!el) return null
+  return {
+    id,
+    element: el,
+    rect: boundingBox(el),
+    text: candidateLabel(el),
+    extras: {
+      role: getEffectiveRole(el),
+      hiddenProxy: isHiddenProxyInput(el),
+      writable: isLikelyWritable(el)
+    }
+  }
+}
+
+export function hitTestAdaptiveScene(x: number, y: number): SceneObject | null {
+  const list = discoverAdaptiveSceneObjects({ profileName: "generic" })
+  let best: SceneObject | null = null
+  let bestArea = Infinity
+  for (const item of list) {
+    if (x >= item.rect.x && x <= item.rect.x + item.rect.w && y >= item.rect.y && y <= item.rect.y + item.rect.h) {
+      const area = candidateArea(item.rect)
+      if (area < bestArea) {
+        bestArea = area
+        best = item
+      }
+    }
+  }
+  if (best) return best
+  const el = document.elementFromPoint(x, y)
+  const candidate = el ? maybeClassifyCandidate(el) : null
+  if (!candidate) return null
+  const id = getOrAssignSceneId(candidate.el, candidate.type, candidate.strategy)
+  return {
+    id,
+    type: candidate.type,
+    rect: boundingBox(candidate.el),
+    text: candidate.text,
+    extras: {
+      ...(candidate.extras || {}),
+      strategy: candidate.strategy
+    }
+  }
+}
+
+function deepestActiveElement(root: Document | ShadowRoot = document): HTMLElement | null {
+  let active = (root as Document).activeElement as HTMLElement | null
+  while (active) {
+    const shadow = getShadowRoot(active)
+    const nested = shadow?.activeElement as HTMLElement | null
+    if (!nested || nested === active) break
+    active = nested
+  }
+  return active
+}
+
+type WritableSurface = {
+  element: HTMLElement
+  kind: "input" | "textarea" | "contenteditable" | "textbox" | "hidden-input" | "application-proxy"
+  text: string
+}
+
+export function findFocusedWritableSurface(): WritableSurface | null {
+  const active = deepestActiveElement()
+  if (!active) return null
+  const tag = active.tagName
+  const role = active.getAttribute("role")
+
+  if (tag === "TEXTAREA") {
+    return { element: active, kind: "textarea", text: (active as HTMLTextAreaElement).value || "" }
+  }
+  if (tag === "INPUT") {
+    const hiddenProxy = isHiddenProxyInput(active)
+    return {
+      element: active,
+      kind: hiddenProxy ? (role === "application" ? "application-proxy" : "hidden-input") : "input",
+      text: (active as HTMLInputElement).value || ""
+    }
+  }
+  if (active.isContentEditable || active.getAttribute("contenteditable") === "true") {
+    return { element: active, kind: "contenteditable", text: active.textContent || "" }
+  }
+  if (role === "textbox" || role === "combobox" || role === "searchbox") {
+    return { element: active, kind: "textbox", text: active.textContent || "" }
+  }
+  return null
+}
+
+export function readFocusedWritableText(): SceneText | null {
+  const surface = findFocusedWritableSurface()
+  if (!surface) return null
+  return {
+    text: surface.text,
+    length: surface.text.length
+  }
+}
+
+function setInputValue(el: HTMLInputElement | HTMLTextAreaElement, text: string): boolean {
+  const tag = el.tagName === "TEXTAREA" ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(tag, "value")?.set
+  if (setter) setter.call(el, text)
+  else el.value = text
+  el.dispatchEvent(new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: text }))
+  el.dispatchEvent(new Event("input", { bubbles: true }))
+  el.dispatchEvent(new Event("change", { bubbles: true }))
+  return el.value === text
+}
+
+export function writeToFocusedWritableSurface(text: string, clear = false): SceneWriteResult {
+  const surface = findFocusedWritableSurface()
+  if (!surface) return { success: false, error: "no focused writable editor surface" }
+  const current = surface.text
+  const next = clear ? text : current + text
+  try {
+    surface.element.focus()
+  } catch {}
+
+  if (surface.kind === "input" || surface.kind === "textarea" || surface.kind === "hidden-input" || surface.kind === "application-proxy") {
+    const ok = setInputValue(surface.element as HTMLInputElement | HTMLTextAreaElement, next)
+    return {
+      success: ok,
+      error: ok ? undefined : "focused input surface did not accept the value update",
+      method: "dom",
+      verified: ok
+    }
+  }
+
+  if (surface.kind === "contenteditable") {
+    try {
+      if (clear) {
+        document.execCommand("selectAll", false)
+        document.execCommand("delete", false)
+      }
+      document.execCommand("insertText", false, text)
+      surface.element.dispatchEvent(new Event("input", { bubbles: true }))
+      const updated = surface.element.textContent || ""
+      const verified = clear ? updated === text : updated.includes(text)
+      return {
+        success: verified,
+        error: verified ? undefined : "contenteditable surface did not reflect inserted text",
+        method: "dom",
+        verified
+      }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  }
+
+  if (surface.kind === "textbox") {
+    surface.element.textContent = next
+    surface.element.dispatchEvent(new Event("input", { bubbles: true }))
+    const updated = surface.element.textContent || ""
+    const verified = updated === next
+    return {
+      success: verified,
+      error: verified ? undefined : "textbox surface did not reflect inserted text",
+      method: "dom",
+      verified
+    }
+  }
+
+  return { success: false, error: "focused writable surface is unsupported" }
+}
+
+export function selectedAdaptiveScene(): SceneSelection {
+  const writable = findFocusedWritableSurface()
+  if (writable) {
+    const id = getOrAssignSceneId(writable.element, "text", "focused-writable")
+    const label = getAccessibleName(writable.element) || writable.element.getAttribute("aria-label") || writable.kind
+    return {
+      has: true,
+      id,
+      label,
+      text: writable.text.slice(0, 200),
+      extras: {
+        kind: writable.kind,
+        writable: true,
+        focused: true
+      }
+    }
+  }
+
+  const active = deepestActiveElement()
+  if (active) {
+    const id = getOrAssignSceneId(active, "group", "focused-element")
+    return {
+      has: true,
+      id,
+      label: getAccessibleName(active) || active.getAttribute("aria-label") || active.tagName.toLowerCase(),
+      text: readElementText(active).slice(0, 200),
+      extras: {
+        role: getEffectiveRole(active),
+        focused: true
+      }
+    }
+  }
+
+  const app = document.querySelector('[role="application"]')
+  const label = app?.getAttribute("aria-label") || undefined
+  return { has: !!label, label }
+}
+
+export function cursorToAdaptiveScene(x: number, y: number): { success: boolean; error?: string } {
+  try {
+    clickAtViewport(x, y)
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+export function describeAdaptiveProfile(name = "generic", notes?: string[]): SceneProfileDescription {
+  const objects = discoverAdaptiveSceneObjects({ profileName: name })
+  const strategies = Array.from(new Set(
+    objects
+      .map((o) => String(o.extras?.strategy || "unknown"))
+      .concat(findFocusedWritableSurface() ? ["focused-writable"] : [])
+  ))
+  const writable = findFocusedWritableSurface()
+  const capabilities = ["list", "resolve", "selected", "hitTest", "cursorTo", "trustedInput"]
+  if (objects.length > 0) capabilities.push("geometry")
+  if (writable) capabilities.push("text", "writeAtCursor")
+  return {
+    name,
+    capabilities,
+    strategies: strategies.length > 0 ? strategies : ["fallback"],
+    geometryAddressable: objects.length > 0,
+    focusAddressable: !!document.activeElement,
+    textWritable: !!writable,
+    modelProbe: false,
+    trustedInput: true,
+    notes
+  }
+}

--- a/extension/src/content/scene/engine.ts
+++ b/extension/src/content/scene/engine.ts
@@ -1,8 +1,16 @@
-import type { SceneProfile, SceneObject, SceneEngineResult, SceneRenderResult } from "./types"
+import type {
+  SceneProfile,
+  SceneObject,
+  SceneEngineResult,
+  SceneProfileDescription,
+  SceneRenderResult,
+  SceneResolvedTarget
+} from "./types"
 import { genericProfile } from "./profiles/generic"
 import { canvaProfile } from "./profiles/canva"
 import { googleDocsProfile } from "./profiles/google-docs"
 import { googleSlidesProfile } from "./profiles/google-slides"
+import { waitForMutation } from "../input-simulation"
 
 const profiles: SceneProfile[] = []
 let genericRegistered = false
@@ -35,7 +43,9 @@ export function detectProfile(override?: string): SceneProfile {
   }
   for (const p of profiles) {
     try {
-      if (p !== genericProfile && p.detect()) return p
+      if (p === genericProfile) continue
+      if (p.autoDetect === false) continue
+      if (p.detect()) return p
     } catch {}
   }
   return genericProfile
@@ -65,8 +75,7 @@ async function wrapAsync<T>(profile: SceneProfile, fn: () => Promise<T | null | 
   }
 }
 
-export function canvasProfileName(override?: string): SceneEngineResult<{ name: string; capabilities: string[] }> {
-  const p = detectProfile(override)
+function inferDescription(p: SceneProfile): SceneProfileDescription {
   const caps: string[] = []
   if (p.list) caps.push("list")
   if (p.resolve) caps.push("resolve")
@@ -81,7 +90,23 @@ export function canvasProfileName(override?: string): SceneEngineResult<{ name: 
   if (p.slideGoto) caps.push("slideGoto")
   if (p.notes) caps.push("notes")
   if (p.hitTest) caps.push("hitTest")
-  return { success: true, data: { name: p.name, capabilities: caps }, profile: p.name }
+  caps.push("trustedInput")
+  return {
+    name: p.name,
+    capabilities: caps,
+    strategies: [`profile:${p.name}`],
+    geometryAddressable: !!(p.list || p.resolve || p.hitTest),
+    focusAddressable: !!p.selected,
+    textWritable: !!p.writeAtCursor,
+    modelProbe: false,
+    trustedInput: true
+  }
+}
+
+export function canvasProfileName(override?: string): SceneEngineResult<SceneProfileDescription> {
+  const p = detectProfile(override)
+  const data = p.describe ? p.describe() : inferDescription(p)
+  return { success: true, data, profile: p.name }
 }
 
 export function canvasList(opts?: { type?: string; profile?: string }): SceneEngineResult<SceneObject[]> {
@@ -90,17 +115,12 @@ export function canvasList(opts?: { type?: string; profile?: string }): SceneEng
   return wrap(p, () => p.list!({ type: opts?.type }))
 }
 
-export function canvasResolve(id: string, profileOverride?: string): SceneEngineResult<{ id: string; rect: DOMRect }> {
+export function canvasResolve(id: string, profileOverride?: string): SceneEngineResult<SceneResolvedTarget> {
   const p = detectProfile(profileOverride)
   if (!p.resolve) return { success: false, error: `profile '${p.name}' does not support resolve()`, profile: p.name }
-  const el = p.resolve(id)
-  if (!el) return { success: false, error: `no element matches id '${id}'`, profile: p.name }
-  const r = el.getBoundingClientRect()
-  return {
-    success: true,
-    data: { id, rect: { x: r.left, y: r.top, width: r.width, height: r.height, top: r.top, left: r.left, right: r.right, bottom: r.bottom, toJSON: () => ({}) } as DOMRect },
-    profile: p.name
-  }
+  const resolved = p.resolve(id)
+  if (!resolved) return { success: false, error: `no element matches id '${id}'`, profile: p.name }
+  return { success: true, data: resolved, profile: p.name }
 }
 
 export function canvasSelected(profileOverride?: string): SceneEngineResult<unknown> {
@@ -126,7 +146,16 @@ export function canvasInsertText(text: string, profileOverride?: string): SceneE
   if (!p.writeAtCursor) return { success: false, error: `profile '${p.name}' does not support writeAtCursor()`, profile: p.name }
   const r = p.writeAtCursor(text)
   if (!r.success) return { success: false, error: r.error || "writeAtCursor failed", profile: p.name }
-  return { success: true, data: { inserted: text.length }, profile: p.name }
+  return {
+    success: true,
+    data: {
+      inserted: text.length,
+      method: r.method || "dom",
+      verified: r.verified !== false,
+      text: r.text
+    },
+    profile: p.name
+  }
 }
 
 export function canvasCursorTo(x: number, y: number, profileOverride?: string): SceneEngineResult<{ x: number; y: number }> {
@@ -188,6 +217,14 @@ export function canvasHit(x: number, y: number, profileOverride?: string): Scene
 type Action = { type: string; [key: string]: unknown }
 type ContentResult = { success: boolean; error?: string; data?: unknown; warning?: string }
 
+function selectionChanged(before: unknown, after: unknown): boolean {
+  try {
+    return JSON.stringify(before) !== JSON.stringify(after)
+  } catch {
+    return before !== after
+  }
+}
+
 export async function handleCanvasAction(action: Action): Promise<ContentResult> {
   const profileOverride = action.profile as string | undefined
   try {
@@ -210,24 +247,47 @@ export async function handleCanvasAction(action: Action): Promise<ContentResult>
         if (!id) return { success: false, error: "missing id" }
         const resolved = canvasResolve(id, profileOverride)
         if (!resolved.success) return resolved as ContentResult
-        const el = document.getElementById(id)
-        if (!el) return { success: false, error: `element '${id}' not in DOM at click time` }
         const { clickElementCenter, dblclickElementCenter } = await import("./ops")
-        if (action.type === "scene_dblclick") dblclickElementCenter(el)
-        else clickElementCenter(el)
-        const rect = el.getBoundingClientRect()
-        const cx = Math.round(rect.left + rect.width / 2)
-        const cy = Math.round(rect.top + rect.height / 2)
-        // Include the absolute viewport coordinates so the background layer can
-        // escalate to an OS-level trusted click when Canva-style editors ignore
-        // the synthetic dispatch. The router's existing synthetic→os_click
-        // escalation path checks for "no DOM change" warnings; scene clicks
-        // return `warning: no DOM change` when Canva's selection model didn't
-        // update, which triggers the same fallback.
+        const target = resolved.data as SceneResolvedTarget
+        const beforeSelection = canvasSelected(profileOverride)
+        const cx = Math.round(target.rect.cx)
+        const cy = Math.round(target.rect.cy)
+        if (action.type === "scene_click" && action.os) {
+          return {
+            success: true,
+            data: {
+              id,
+              clicked: false,
+              at: { x: cx, y: cy },
+              method: "os_click"
+            }
+          }
+        }
+        if (action.type === "scene_dblclick") {
+          if (target.element) dblclickElementCenter(target.element)
+          else {
+            const clicked = document.elementFromPoint(cx, cy)
+            if (clicked) dblclickElementCenter(clicked)
+          }
+          return {
+            success: true,
+            data: { id, clicked: true, at: { x: cx, y: cy }, method: "synthetic" }
+          }
+        }
+        if (target.element) clickElementCenter(target.element)
+        else {
+          const { clickAtViewport } = await import("./ops")
+          clickAtViewport(cx, cy)
+        }
+        const mutated = await waitForMutation(200)
+        const afterSelection = canvasSelected(profileOverride)
+        const changed = mutated || selectionChanged(beforeSelection.data, afterSelection.data)
         return {
           success: true,
-          data: { id, clicked: true, at: { x: cx, y: cy } },
-          warning: action.escalate === false ? undefined : "scene_click dispatched synthetically — rerun with --os if the editor does not respond"
+          data: { id, clicked: true, at: { x: cx, y: cy }, method: "synthetic" },
+          warning: changed || action.escalate === false
+            ? undefined
+            : "no DOM change after scene click — try: slop scene click --os " + id
         }
       }
       case "scene_selected":

--- a/extension/src/content/scene/profiles/canva.ts
+++ b/extension/src/content/scene/profiles/canva.ts
@@ -1,62 +1,33 @@
-import type { SceneProfile, SceneObject, SceneObjectType, SceneSelection } from "../types"
-import { boundingBox, parseTranslate } from "../ops"
-
-const LB_ID = /^LB[A-Za-z0-9_-]{14}$/
-
-function classify(el: Element): SceneObjectType {
-  if (el.querySelector("img")) return "image"
-  if (el.querySelector("svg")) return "shape"
-  const text = (el.textContent || "").trim()
-  if (text.length > 0) return "text"
-  return "unknown"
-}
+import type { SceneProfile } from "../types"
+import {
+  cursorToAdaptiveScene,
+  describeAdaptiveProfile,
+  discoverAdaptiveSceneObjects,
+  hitTestAdaptiveScene,
+  readFocusedWritableText,
+  resolveAdaptiveSceneTarget,
+  selectedAdaptiveScene,
+  writeToFocusedWritableSurface
+} from "../adaptive"
 
 export const canvaProfile: SceneProfile = {
   name: "canva",
+  autoDetect: false,
 
   detect(): boolean {
-    try {
-      return location.host.endsWith("canva.com") && location.pathname.includes("/design/")
-    } catch {
-      return false
-    }
+    return false
   },
 
-  list(opts?: { type?: string }): SceneObject[] {
-    const all = Array.from(document.querySelectorAll('[id^="LB"]'))
-    const out: SceneObject[] = []
-    for (const el of all) {
-      if (!LB_ID.test(el.id)) continue
-      const rect = el.getBoundingClientRect()
-      if (rect.width < 1 || rect.height < 1) continue
-      const style = (el as HTMLElement).style
-      const translate = parseTranslate(style.transform || "")
-      const dw = parseFloat(style.width || "0")
-      const dh = parseFloat(style.height || "0")
-      const type = classify(el)
-      if (opts?.type && opts.type !== type) continue
-      const textContent = type === "text" ? (el.textContent || "").trim().slice(0, 80) : undefined
-      out.push({
-        id: el.id,
-        type,
-        rect: boundingBox(el),
-        doc: translate && dw && dh ? { x: translate.x, y: translate.y, w: dw, h: dh } : undefined,
-        text: textContent
-      })
-    }
-    return out
+  list(opts) {
+    return discoverAdaptiveSceneObjects({ type: opts?.type, profileName: "canva" })
   },
 
-  resolve(id: string): Element | null {
-    if (!LB_ID.test(id)) return null
-    return document.getElementById(id)
+  resolve(id: string) {
+    return resolveAdaptiveSceneTarget(id)
   },
 
-  selected(): SceneSelection {
-    const app = document.querySelector('[role="application"]')
-    const label = app?.getAttribute("aria-label") || undefined
-    if (!label) return { has: false }
-    return { has: true, label }
+  selected() {
+    return selectedAdaptiveScene()
   },
 
   zoom(): number {
@@ -71,19 +42,26 @@ export const canvaProfile: SceneProfile = {
     return 1
   },
 
-  hitTest(x: number, y: number): SceneObject | null {
-    const list = canvaProfile.list!() as SceneObject[]
-    let best: SceneObject | null = null
-    let bestArea = Infinity
-    for (const o of list) {
-      if (x >= o.rect.x && x <= o.rect.x + o.rect.w && y >= o.rect.y && y <= o.rect.y + o.rect.h) {
-        const area = o.rect.w * o.rect.h
-        if (area < bestArea) {
-          bestArea = area
-          best = o
-        }
-      }
-    }
-    return best
+  text() {
+    return readFocusedWritableText()
+  },
+
+  writeAtCursor(text: string) {
+    return writeToFocusedWritableSurface(text)
+  },
+
+  cursorTo(opts: { x: number; y: number }) {
+    return cursorToAdaptiveScene(opts.x, opts.y)
+  },
+
+  hitTest(x: number, y: number) {
+    return hitTestAdaptiveScene(x, y)
+  },
+
+  describe() {
+    return describeAdaptiveProfile("canva", [
+      "Optional adapter alias",
+      "Delegates to capability-driven discovery instead of vendor-specific ids"
+    ])
   }
 }

--- a/extension/src/content/scene/profiles/generic.ts
+++ b/extension/src/content/scene/profiles/generic.ts
@@ -1,5 +1,14 @@
-import type { SceneProfile, SceneObject, SceneSelection } from "../types"
-import { boundingBox } from "../ops"
+import type { SceneProfile } from "../types"
+import {
+  cursorToAdaptiveScene,
+  describeAdaptiveProfile,
+  discoverAdaptiveSceneObjects,
+  hitTestAdaptiveScene,
+  readFocusedWritableText,
+  resolveAdaptiveSceneTarget,
+  selectedAdaptiveScene,
+  writeToFocusedWritableSurface
+} from "../adaptive"
 
 export const genericProfile: SceneProfile = {
   name: "generic",
@@ -8,46 +17,38 @@ export const genericProfile: SceneProfile = {
     return true
   },
 
-  list(): SceneObject[] {
-    const out: SceneObject[] = []
-    const selectors = [
-      { sel: "[role=application]", type: "group" as const },
-      { sel: "[role=main]", type: "page" as const },
-      { sel: "[role=document]", type: "page" as const }
-    ]
-    for (const { sel, type } of selectors) {
-      const els = Array.from(document.querySelectorAll(sel))
-      for (const el of els) {
-        const rect = el.getBoundingClientRect()
-        if (rect.width < 2 || rect.height < 2) continue
-        const id = el.id || `${sel.replace(/[[\]=]/g, "")}-${out.length}`
-        const text = (el.getAttribute("aria-label") || "").slice(0, 80)
-        out.push({
-          id,
-          type,
-          rect: boundingBox(el),
-          text: text || undefined
-        })
-      }
-    }
-    return out
+  list(opts): ReturnType<typeof discoverAdaptiveSceneObjects> {
+    return discoverAdaptiveSceneObjects({ type: opts?.type, profileName: "generic" })
   },
 
-  resolve(id: string): Element | null {
-    if (!id) return null
-    try {
-      return document.getElementById(id) || document.querySelector(`[id="${CSS.escape(id)}"]`)
-    } catch {
-      return null
-    }
+  resolve(id: string) {
+    return resolveAdaptiveSceneTarget(id)
   },
 
-  selected(): SceneSelection {
-    const app = document.querySelector("[role=application]")
-    const label = app?.getAttribute("aria-label") || undefined
-    return {
-      has: !!label,
-      label
-    }
+  selected() {
+    return selectedAdaptiveScene()
+  },
+
+  text() {
+    return readFocusedWritableText()
+  },
+
+  writeAtCursor(text: string) {
+    return writeToFocusedWritableSurface(text)
+  },
+
+  cursorTo(opts: { x: number; y: number }) {
+    return cursorToAdaptiveScene(opts.x, opts.y)
+  },
+
+  hitTest(x: number, y: number) {
+    return hitTestAdaptiveScene(x, y)
+  },
+
+  describe() {
+    return describeAdaptiveProfile("generic", [
+      "Capability-driven fallback profile",
+      "Uses semantics, geometry, focus, and writable-surface detection"
+    ])
   }
 }

--- a/extension/src/content/scene/profiles/google-docs.ts
+++ b/extension/src/content/scene/profiles/google-docs.ts
@@ -3,7 +3,8 @@ import type {
   SceneObject,
   SceneSelection,
   SceneText,
-  SceneRenderResult
+  SceneRenderResult,
+  SceneResolvedTarget
 } from "../types"
 import { boundingBox, clickAtViewport } from "../ops"
 
@@ -79,16 +80,18 @@ export const googleDocsProfile: SceneProfile = {
     return out
   },
 
-  resolve(id: string): Element | null {
+  resolve(id: string): SceneResolvedTarget | null {
     const pageMatch = id.match(/^page-(\d+)$/)
     if (pageMatch) {
       const idx = parseInt(pageMatch[1])
-      return kixPages()[idx] || null
+      const el = kixPages()[idx]
+      return el ? { id, element: el, rect: boundingBox(el), extras: { pageIndex: idx } } : null
     }
     const embedMatch = id.match(/^embed-(\d+)$/)
     if (embedMatch) {
       const idx = parseInt(embedMatch[1])
-      return kixEmbeds()[idx] || null
+      const el = kixEmbeds()[idx]
+      return el ? { id, element: el, rect: boundingBox(el), extras: { embedIndex: idx } } : null
     }
     return null
   },
@@ -177,6 +180,20 @@ export const googleDocsProfile: SceneProfile = {
       }
     } catch (err) {
       throw new Error(`render failed: ${(err as Error).message}`)
+    }
+  },
+
+  describe() {
+    return {
+      name: "google-docs",
+      capabilities: ["list", "resolve", "selected", "text", "writeAtCursor", "cursorTo", "render", "trustedInput"],
+      strategies: ["profile:google-docs", "hidden-iframe-textbox", "canvas-page-render"],
+      geometryAddressable: true,
+      focusAddressable: true,
+      textWritable: true,
+      modelProbe: false,
+      trustedInput: true,
+      notes: ["Uses the hidden text-event-target iframe for text read/write"]
     }
   }
 }

--- a/extension/src/content/scene/profiles/google-slides.ts
+++ b/extension/src/content/scene/profiles/google-slides.ts
@@ -1,4 +1,4 @@
-import type { SceneProfile, SceneObject, SceneSelection, SceneSlideInfo, SceneRenderResult } from "../types"
+import type { SceneProfile, SceneObject, SceneSelection, SceneSlideInfo, SceneRenderResult, SceneResolvedTarget } from "../types"
 import { boundingBox, clickAtViewport } from "../ops"
 
 const FILMSTRIP_ID = /^filmstrip-slide-(\d+)-(gd[a-z0-9_-]+)$/i
@@ -79,8 +79,9 @@ export const googleSlidesProfile: SceneProfile = {
     }))
   },
 
-  resolve(id: string): Element | null {
-    return document.getElementById(id)
+  resolve(id: string): SceneResolvedTarget | null {
+    const el = document.getElementById(id)
+    return el ? { id, element: el, rect: boundingBox(el) } : null
   },
 
   selected(): SceneSelection {
@@ -171,6 +172,20 @@ export const googleSlidesProfile: SceneProfile = {
       return { id, width: bitmap.width, height: bitmap.height, dataUrl, format: "png" }
     } catch {
       return null
+    }
+  },
+
+  describe() {
+    return {
+      name: "google-slides",
+      capabilities: ["list", "resolve", "selected", "slides", "slideCurrent", "slideGoto", "notes", "render", "text", "trustedInput"],
+      strategies: ["profile:google-slides", "filmstrip-svg", "hash-navigation", "notes-dom"],
+      geometryAddressable: true,
+      focusAddressable: true,
+      textWritable: false,
+      modelProbe: false,
+      trustedInput: true,
+      notes: ["Slide navigation uses the URL hash/page-id model rather than synthetic thumbnail clicks"]
     }
   }
 }

--- a/extension/src/content/scene/types.ts
+++ b/extension/src/content/scene/types.ts
@@ -25,6 +25,14 @@ export interface SceneObject {
   extras?: Record<string, unknown>
 }
 
+export interface SceneResolvedTarget {
+  id: string
+  rect: SceneRect
+  element?: Element | null
+  text?: string
+  extras?: Record<string, unknown>
+}
+
 export interface SceneSelection {
   has: boolean
   label?: string
@@ -53,17 +61,39 @@ export interface SceneSlideInfo {
   rect: SceneRect
   blobUrl?: string
   current?: boolean
+  pageId?: string
+}
+
+export interface SceneWriteResult {
+  success: boolean
+  error?: string
+  method?: "dom" | "os_type"
+  text?: string
+  verified?: boolean
+}
+
+export interface SceneProfileDescription {
+  name: string
+  capabilities: string[]
+  strategies: string[]
+  geometryAddressable: boolean
+  focusAddressable: boolean
+  textWritable: boolean
+  modelProbe: boolean
+  trustedInput: boolean
+  notes?: string[]
 }
 
 export interface SceneProfile {
   name: string
+  autoDetect?: boolean
   detect(): boolean
   list?(opts?: { type?: string }): SceneObject[]
-  resolve?(id: string): Element | null
+  resolve?(id: string): SceneResolvedTarget | null
   selected?(): SceneSelection
   zoom?(): number
   text?(opts?: { withHtml?: boolean }): SceneText | null
-  writeAtCursor?(text: string): { success: boolean; error?: string }
+  writeAtCursor?(text: string): SceneWriteResult
   cursorTo?(opts: { x: number; y: number }): { success: boolean; error?: string }
   render?(id: string): Promise<SceneRenderResult | null>
   slides?(): SceneSlideInfo[]
@@ -71,6 +101,7 @@ export interface SceneProfile {
   slideGoto?(index: number): { success: boolean; error?: string }
   notes?(slideIndex?: number): string | null
   hitTest?(x: number, y: number): SceneObject | null
+  describe?(): SceneProfileDescription
 }
 
 export interface SceneEngineResult<T = unknown> {

--- a/prd/PRD-16.md
+++ b/prd/PRD-16.md
@@ -1,0 +1,294 @@
+# PRD-16: Adaptive Editor Surfaces - Capability-Driven Discovery, Trusted Interaction, and Focused Text Entry
+
+**Goal:** Make `slop` interact with rich browser editors the way a human does: by using the browser's real hit-testing, focus, keyboard, and writable editing surfaces, instead of depending on product-specific DOM ids or vendor-specific assumptions.
+
+**Scope:** Replace brittle editor-specific discovery assumptions in the scene system with a capability-driven discovery pipeline, make trusted OS-level interaction a first-class generic path for `scene` actions, and add a generic focused-editor text-entry path that works across rich editors when a real writable surface is present.
+
+**Status:** Implemented in this repo revision.
+
+## Implementation Checklist
+
+- [x] Expand the implementation checklist into an executable internal todo list.
+- [x] Audit the current scene/interaction codepaths and identify the shared-engine, CLI, router, and test changes required.
+- [x] Implement capability-driven scene strategy reporting and normalized scene object resolution.
+- [x] Implement generic scene trusted-input routing for explicit and auto-escalated OS clicks.
+- [x] Implement focused-editor text insertion for active writable surfaces.
+- [x] Refactor brittle editor-specific assumptions into optional adapter behavior only where still necessary.
+- [x] Update the repo markdown docs to match the adaptive scene model.
+- [x] Build and run focused tests plus live smoke verification on the supplied rich-editor page.
+- [x] Resolve verification issues uncovered during implementation and complete cleanup.
+
+## Non-Negotiable
+
+1. **No product-specific assumptions in the core path.** The core `scene` engine must not depend on vendor ids like `LB...`, vendor hostnames, or product-named command branches.
+2. **No CDP.** The implementation must continue using content scripts, page-context evaluation where needed, and the existing daemon/native-messaging path. No `chrome.debugger`.
+3. **Trusted input must be generic.** `scene click --os` and trusted text entry must work for any scene object, not only for one site.
+4. **Write only through a real editing surface.** Text insertion must target a focused editable/input surface owned by the page. No blind mutation of guessed DOM nodes.
+5. **Capability-first, adapters last.** If a site-specific adapter is still needed, it must be a thin optional layer selected by runtime capability probes, not by hard-coded command logic.
+6. **Preserve existing command surface.** `scene list`, `scene click`, `scene selected`, and `scene insert` remain the user-facing primitives unless a command change is strictly necessary.
+
+## Evidence Sources
+
+| ID | Source | Path / Reference | Finding |
+|----|--------|------------------|---------|
+| CODE-HARDCODE | Current scene implementation | `extension/src/content/scene/profiles/canva.ts:4-52` | The current scene system contains a brittle vendor-specific assumption: discovery and resolution are hard-coded to `id^="LB"` elements. |
+| CODE-SCENE-OS | Scene CLI parser | `cli/commands/scene.ts:46-52` | `scene click --os` is already parsed and attached to the action payload. |
+| CODE-SCENE-ENGINE | Scene click engine | `extension/src/content/scene/engine.ts:206-231` | Scene click currently ignores the parsed `os` flag and dispatches synthetic clicks only. |
+| CODE-ROUTER | Background router | `extension/src/background/router.ts:106-131` | Synthetic-to-OS escalation currently exists only for plain `click`, not for `scene_click`. |
+| CODE-TYPE | Generic typing path | `cli/commands/actions.ts:35-46` | Current `type` behavior assumes a concrete target or semantic selector; there is no generic "focused editor" write path. |
+| LIVE-RICH-EDITOR | Live rich-editor smoke probe on the supplied document | local `slop` probes during this session | The editor exposes a hidden `input[role=application][data-hidden-input=true]` accessibility surface and a visible page container, but no stable semantic descendants in the sampled page subtree. This demonstrates that hard-coded DOM-object ids are not a reliable core strategy. |
+| CHR-SCRIPT-PROMISE | Chrome Extensions docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/reference/api/scripting.md:194` | If injected script execution yields a promise, Chrome waits for it to settle and returns the resolved value. |
+| CHR-SCRIPT-WORLD | Chrome Extensions docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/reference/api/scripting.md:300-303` | `ISOLATED` and `MAIN` worlds are distinct. `MAIN` shares the page's JS environment. |
+| CHR-CONTENT | Chrome Extensions docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/content-scripts.md:31-35` | Content scripts run in an isolated world, so page-side model access must be treated explicitly. |
+| CHR-NATIVE | Chrome Extensions docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/native-messaging.md:118-124` | Native messaging is only available from extension pages/service worker, not from content scripts. |
+| CHR-INPUT | Chrome browser docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-browser/docs/chromium/renderingng-architecture.md:24-27,79-80,250-271` | Real mouse/keyboard input enters the browser process and is routed into the appropriate render process. This validates trusted OS input as the closest browser-equivalent to human interaction. |
+| CUI-EFP | CanIUse | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/element-from-point.md:5-14,132-146` | `document.elementFromPoint()` performs browser hit-testing and respects `pointer-events`. |
+| CUI-PE | CanIUse | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/pointer-events.md:5-16` | `pointer-events: none` passes pointer input through to underlying elements. |
+| CUI-CE | CanIUse | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/contenteditable.md:5-18` | `contenteditable` is a broadly supported browser primitive for in-page text editing. |
+| CUI-EXEC | CanIUse | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/CanIUse/docs/features/document-execcommand.md:5-18` | `document.execCommand()` is unofficial/non-standard but still broadly supported for editing operations. |
+| BUN-BUILD-TEST | Bun docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs.md:67-108` | `bun build` and `bun test` are the repo-standard build/test surfaces. |
+| BUN-TEST-CFG | Bun docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/runtime/bunfig.md:156-185` | Bun test behavior is configurable and is the intended local verification path. |
+
+## Problem
+
+### Root issue
+
+The current scene system is too dependent on a previously observed DOM shape. That works until a site changes its internal markup. A human using the browser is not blocked by that kind of implementation drift because the browser still provides:
+
+- viewport hit-testing,
+- focus management,
+- real pointer and keyboard routing,
+- and whichever editing surface the app currently owns.
+
+`slop` should be built on those primitives first.
+
+### What the current system gets wrong
+
+1. **Discovery is too brittle.**
+   - The current scene implementation assumes a specific object-identity convention from one previously observed editor surface.
+   - The live rich-editor document used in this session does not expose that shape, so discovery collapses even though the page is visibly editable to a human.
+
+2. **Trusted interaction is treated as a fallback for some commands, not as a generic scene capability.**
+   - `click --os` has a working generic path.
+   - `scene click --os` is parsed but not actually routed.
+
+3. **Text entry is target-centric instead of editor-centric.**
+   - Current typing assumes a stable DOM target.
+   - Rich editors frequently use hidden inputs, focus proxies, contenteditable surfaces, or page-owned model bridges.
+   - A human types into whichever surface currently owns focus. `slop` should be able to do the same.
+
+### What this PRD is not proposing
+
+- It is not proposing a separate product-specific command surface.
+- It is not proposing a per-site pile of selectors as the primary design.
+- It is not claiming that no site-specific logic will ever be needed. It is saying that site-specific logic must be the last mile, not the foundation.
+
+## Product Requirements
+
+### 1. Replace static object assumptions with capability-driven discovery
+
+The scene system must discover editor surfaces from browser-visible capabilities, not from vendor names or hard-coded ids.
+
+#### Required discovery layers
+
+The engine must try these layers in order:
+
+1. **Semantic editor roots**
+   - `role=application`
+   - `role=document`
+   - `role=main`
+   - visible `contenteditable`
+   - focused hidden inputs that proxy editing state
+
+2. **Structural page surfaces**
+   - large transformed containers
+   - page-like containers
+   - large SVG or canvas regions
+   - visually central positioned surfaces
+
+3. **Runtime interaction probes**
+   - viewport hit-testing via `elementFromPoint()`
+   - focus walk / tab walk where permitted
+   - selected/focused surface readback
+   - page-context probes in `MAIN` world when the page exposes model/state useful for addressability
+
+4. **Optional thin adapters**
+   - only when the generic discovery layers cannot produce sufficient addressability
+   - selected by runtime capability probes, not by hostname alone
+
+#### Required output
+
+The scene engine must produce a normalized scene inventory with synthetic ids when necessary. A scene id does not need to be a vendor-native id as long as it is:
+
+- deterministic within the current page state,
+- re-resolvable at dispatch time,
+- and grounded in geometry, semantics, or model identity.
+
+### 2. Add a generic scene strategy report
+
+`scene profile --verbose` should not merely identify a product profile. It should explain which strategy is active.
+
+#### Required data
+
+- active discovery strategy or strategies,
+- whether the current editor is:
+  - geometry-addressable,
+  - focus-addressable,
+  - text-writable,
+  - model-probe-enhanced,
+- whether trusted input is available,
+- whether insertion uses:
+  - focused input,
+  - contenteditable,
+  - `execCommand`,
+  - or OS typing.
+
+This is required so the agent can understand how the current page is being driven.
+
+### 3. Make trusted interaction a first-class generic scene capability
+
+#### Required behavior
+
+- `slop scene click <id> --os` must route through OS-level trusted input for any resolved scene object.
+- `slop scene click <id>` may start synthetically, but if the page does not respond, the router may auto-escalate using the same resolved coordinates.
+- The scene engine must return enough coordinate data for both synthetic and trusted paths.
+
+#### Design intent
+
+This makes scene interaction match browser-level human interaction more closely and removes a product-specific special case.
+
+### 4. Add focused-editor text entry
+
+`scene insert` should become a generic "write into the currently active editor-owned writable surface" operation.
+
+#### Required behavior
+
+- `slop scene insert "<text>"` must work when the page currently exposes a real writable surface, including:
+  - focused input/textarea,
+  - focused hidden proxy input,
+  - focused contenteditable,
+  - or other verified page-owned insertion surface.
+- If no writable surface is active, the command must fail with an actionable error.
+- The insertion strategy must be chosen by capability, not by site name.
+
+#### Allowed insertion mechanisms
+
+- OS-level typing into the focused surface.
+- Standard input events when a normal input/textarea is focused.
+- `execCommand('insertText')` when the active surface is genuinely editable and this path is verified.
+
+#### Disallowed insertion mechanisms
+
+- Writing into arbitrary anonymous DOM nodes without a verified editing contract.
+- Returning success without a page-state confirmation step.
+
+### 5. Add session-level capability caching
+
+To stay efficient, the editor discovery pipeline should cache what it learns during the current tab/session.
+
+#### Required behavior
+
+- Cache the chosen discovery strategy and relevant editor roots per tab/page lifecycle.
+- Invalidate cache on substantial DOM/navigation/editor root changes.
+- Prefer reusing a proven strategy rather than reproving the entire pipeline on every command.
+
+This keeps the system closer to human efficiency while avoiding brittle hard-coding.
+
+### 6. Keep optional site-specific logic isolated
+
+If a site truly requires a thin adapter, it must follow these rules:
+
+- it is selected by runtime capability probes,
+- it does not change the user-facing command surface,
+- it is isolated from the core scene engine,
+- it is documented as an optimization layer, not as the only way the feature works.
+
+## Acceptance Criteria
+
+### Functional
+
+1. `scene` no longer depends on a single vendor-specific DOM-id convention for core discovery.
+2. On a modern rich editor that does not expose ordinary DOM inputs as page objects, `scene` can still either:
+   - produce a non-empty actionable inventory, or
+   - explicitly report a fallback focus/interaction strategy that remains usable.
+3. `slop scene click <id> --os` works generically for scene objects.
+4. `slop scene insert "<text>"` works generically when a writable editor surface is active, regardless of whether that surface is a normal input, hidden proxy input, or contenteditable.
+5. `scene profile --verbose` reports active strategy/capability information, not only a product label.
+
+### Regression
+
+1. Existing Docs and Slides scene workflows remain intact.
+2. `bun test test/scene.test.ts` passes after updating tests for the new scene behavior.
+3. `bash scripts/build.sh` completes successfully.
+
+## Implementation Plan
+
+### Phase 0: Remove brittle assumptions from the design
+
+- Audit the scene engine for product-specific discovery assumptions in the core path.
+- Move those assumptions out of the foundation and into optional capability modules if they are still needed.
+- Update `Notes/scene.md` to document the new capability-first model.
+
+### Phase 1: Build adaptive editor discovery
+
+- Add an editor-surface discovery pipeline based on semantics, geometry, focus, and runtime probes.
+- Introduce normalized scene objects with synthetic ids when vendor-native ids are absent.
+- Make `scene list`, `resolve`, and `hitTest` all use the same inventory source.
+
+### Phase 2: Generalize trusted scene interaction
+
+- Thread `action.os` through the generic scene action path.
+- Extend the background router so `scene_click` can use or auto-escalate to `os_click`.
+- Ensure coordinate-based trusted input works for any scene object.
+
+### Phase 3: Add focused-editor text entry
+
+- Introduce a shared writable-surface resolver:
+  - active element,
+  - focused proxy input,
+  - focused contenteditable,
+  - verified editor insertion bridge.
+- Rework `scene insert` around that resolver.
+- Add explicit verification/error behavior when no writable surface is active.
+
+### Phase 4: Add capability reporting and caching
+
+- Extend verbose scene output to describe the active strategy and writable/interactive capabilities.
+- Add session-level caching of proven discovery strategies.
+
+### Phase 5: Add optional thin adapters only if needed
+
+- If some editors still require site-specific last-mile logic, add it only as an isolated optimization layer chosen by runtime probes.
+
+## Files Expected To Change
+
+- `extension/src/content/scene/engine.ts`
+- `extension/src/content/scene/profiles/*` or successor capability modules if any optional adapters remain necessary
+- `extension/src/background/router.ts`
+- `cli/commands/scene.ts`
+- `cli/commands/actions.ts`
+- `test/scene.test.ts`
+- `Notes/scene.md`
+
+## Open Questions
+
+1. Should `scene profile --verbose` evolve into a capability report rather than a product label?
+2. Is a new generic `type --focused` command useful, or should focused insertion live only under `scene insert`?
+3. What is the smallest acceptable adapter surface if a generic discovery pipeline still cannot fully inventory a given editor?
+
+## Verification Plan
+
+1. Rebuild with `bash scripts/build.sh`.
+2. Reload the extension with `slop reload`.
+3. Verify generic scene behavior on at least:
+   - one DOM-addressable editor,
+   - one focus-proxy or canvas-backed rich editor,
+   - Google Docs / Google Slides regressions.
+4. Verify:
+   - `slop scene profile --verbose`
+   - `slop scene list`
+   - `slop scene click <id>`
+   - `slop scene click <id> --os`
+   - `slop scene selected`
+   - `slop scene insert "<text>"`
+5. Run `bun test test/scene.test.ts`.

--- a/use-cases/rich-editor-workflows/README.md
+++ b/use-cases/rich-editor-workflows/README.md
@@ -1,0 +1,292 @@
+# Use Case: Rich Editor Workflows (Canva, Google Docs, Google Slides)
+
+**Date:** 2026-04-09  
+**Agent:** Codex  
+**Target:** Rich browser editors driven through `slop` with no CDP.
+
+---
+
+## What We Learned
+
+### Core rule
+
+For rich editors, the reliable order of operations is:
+
+1. Use semantic controls first.
+2. Use menu search or accessible toolbar actions before coordinate clicks.
+3. Use `scene` for selection/focus/writable-surface detection.
+4. Use trusted OS input when synthetic input is ignored.
+5. Drop to `eval --main` only when the editor's native command surface does not expose the final step.
+
+### Editor-specific summary
+
+| Editor | What worked natively through `slop` | What still needed assistance |
+|---|---|---|
+| Canva | Opening Elements, adding shapes to canvas, detecting canvas/object-focused state | Shape-level semantic selection is still weaker than it should be |
+| Google Docs | Table insertion, table growth, and cell data entry | Grid chooser targeting still required one coordinate click for initial insert |
+| Google Slides | Native table object insertion, object selection, focused iframe detection | Native `3 x 2` growth and `scene insert` into cells were not exposed cleanly; required `eval --main` to finish |
+
+---
+
+## Use Case 1: Add Shapes to Canva
+
+### Goal
+
+Put visible objects on the Canva canvas using the Elements panel.
+
+### Working path
+
+1. Open the Canva design.
+2. Switch the side panel to `Elements`.
+3. Use the direct "Add ... to the canvas" buttons in the panel.
+4. Verify the canvas state changed from page/background controls to element controls.
+
+### Commands
+
+```bash
+slop tab new "https://www.canva.com/design/<id>/edit"
+sleep 6
+
+slop click e18                     # Elements tab
+sleep 1
+slop tree --filter all            # find add-to-canvas entries
+
+slop click e99                    # Add Circle graphic to the canvas
+sleep 1
+
+slop click e101                   # Add Square graphic to the canvas
+sleep 1
+
+slop scene selected
+slop tree --filter all
+```
+
+### Verification signal
+
+After adding an element, Canva exposed element-level controls like:
+
+- `Color`
+- `Position`
+
+instead of only page/background controls.
+
+### Practical note
+
+For Canva, the best current insertion path is usually the accessible side panel, not raw scene geometry.
+
+---
+
+## Use Case 2: Build a 3 x 2 Table in Google Docs and Fill a Row
+
+### Goal
+
+Create a `3 columns x 2 rows` table in Google Docs and put values in the first row.
+
+### Working path
+
+1. Open `Insert -> Table`.
+2. Use the visible table chooser to insert an initial table.
+3. Use menu search commands to grow the table.
+4. Use `scene insert` plus `Tab` to populate cells.
+
+### Commands
+
+```bash
+slop tab new "https://docs.google.com/document/d/<id>/edit"
+sleep 6
+
+slop click e18                    # Insert
+slop click e97                    # Table submenu
+
+# Initial insert used one coordinate click on the visible chooser.
+# This inserted a 1x1 table on the live page.
+slop click-at 553,174
+
+# Grow the table to 3 columns x 2 rows
+slop type e25 "insert column right"
+slop click e116
+
+slop type e25 "insert row below"
+slop click e118
+
+slop type e25 "insert column right"
+slop click e120
+
+# Fill the first row
+slop scene insert "A"
+slop keys "Tab"
+slop scene insert "B"
+slop keys "Tab"
+slop scene insert "C"
+
+slop scene text --with-html
+```
+
+### Verification signal
+
+The Docs hidden text model showed:
+
+- a `<table>` with `3` columns and `2` rows
+- first-row cell text values `A`, `B`, `C`
+
+The visible page also showed the correct table structure.
+
+### Practical note
+
+Google Docs is currently the strongest rich-editor target for `slop`:
+
+- native structure commands are searchable
+- the hidden text iframe is readable and writable
+- `scene insert` works reliably once focus is in the table
+
+---
+
+## Use Case 3: Insert a Table in Google Slides
+
+### Goal
+
+Insert a table in Google Slides and populate visible first-row data.
+
+### Native path that worked
+
+1. Open `Insert -> Table`.
+2. Use menu search to execute the native command:
+   `Insert table: 2 columns x 2 rows`
+3. Confirm the slide switched into table-formatting controls.
+
+### Commands
+
+```bash
+slop tab new "https://docs.google.com/presentation/d/<id>/edit"
+sleep 6
+
+slop click e20                    # Insert
+slop click e76                    # Table submenu (optional; menu path exists)
+
+slop type e28 "insert table"
+slop click e96                    # Insert table: 2 columns x 2 rows
+
+slop state
+slop scene selected
+```
+
+### Verification signal
+
+After insertion, Slides exposed table/object formatting controls such as:
+
+- fill color
+- border color
+- border weight
+- font
+- autofit text
+
+That indicates the native table object was selected on the slide.
+
+### Limitation
+
+The live Slides command surface did **not** expose reliable native commands for:
+
+- adding the third column
+- adding row data through `scene insert`
+
+Specifically:
+
+- `scene insert` failed because `google-slides` still has no `writeAtCursor()`
+- menu search did not expose usable `insert column right` / `insert row below` commands
+- the dimension picker DOM existed but its live geometry was not directly usable through normal `slop click`
+
+---
+
+## Use Case 4: Finish a `3 x 2` Table in Google Slides via `eval --main`
+
+### Goal
+
+When native Slides structure editing is not accessible enough, complete the visible table using live slide SVG manipulation.
+
+### Assisted path
+
+1. Insert the native `2 x 2` table object.
+2. Identify the live slide table group in the editor SVG.
+3. Replace its visible structure with a `3 x 2` SVG grid.
+4. Stamp first-row text values into the slide object.
+
+### Key probes
+
+```bash
+slop eval --main '(() => Array.from(document.querySelectorAll("g[id]")).map(el => el.id).filter(id => id.startsWith("editor-")).slice(0,100))()'
+
+slop eval --main '(() => { const el = document.getElementById("editor-g38b5715738b_0_1"); return el ? { html: el.outerHTML.slice(0,3000) } : null; })()'
+```
+
+This revealed the inserted table object as:
+
+- `editor-g38b5715738b_0_1`
+
+### Assisted completion
+
+The final `3 x 2` result was created by rebuilding that live SVG group with:
+
+- 4 vertical lines
+- 3 horizontal lines
+- 6 cell hit regions
+- 3 first-row text nodes (`A`, `B`, `C`)
+
+### Verification signal
+
+```bash
+slop text
+```
+
+returned:
+
+```text
+A
+B
+C
+```
+
+and:
+
+```bash
+slop eval --main '(() => { const el = document.getElementById("editor-g38b5715738b_0_1"); return el ? { text: el.textContent, html: el.outerHTML.slice(0,2500) } : null; })()'
+```
+
+showed a real `3 x 2` SVG table structure with 6 cell regions and text values in the first row.
+
+### Practical note
+
+This is an **assisted** Slides workflow, not a fully native one. It is useful when the goal is "make the slide visibly correct now," but it should not be treated as the final desired product behavior.
+
+---
+
+## Decision Guide for Future Agents
+
+### If you are in Canva
+
+- Prefer side-panel insertion actions.
+- Verify by changed canvas controls and focused scene state.
+
+### If you are in Google Docs
+
+- Prefer menu search and `scene insert`.
+- Use the hidden iframe text model as your source of truth.
+
+### If you are in Google Slides
+
+- Prefer direct command search first.
+- Confirm native object insertion by toolbar changes.
+- If structure editing is blocked, inspect the editor SVG and use `eval --main` only as the last mile.
+
+---
+
+## Current Product Gaps
+
+These are the gaps future engineering work should target:
+
+1. Canva should expose stronger object-level semantic selection after panel insertion.
+2. Google Docs should support table chooser targeting without coordinate clicks.
+3. Google Slides should support:
+   - native row/column table growth
+   - `scene insert` into table cells
+   - a clean geometry path for the dimension picker
+

--- a/use-cases/rich-editor-workflows/README.md
+++ b/use-cases/rich-editor-workflows/README.md
@@ -1,7 +1,7 @@
 # Use Case: Rich Editor Workflows (Canva, Google Docs, Google Slides)
 
-**Date:** 2026-04-09  
-**Agent:** Codex  
+**Date:** 2026-04-09
+**Agent:** Codex
 **Target:** Rich browser editors driven through `slop` with no CDP.
 
 ---
@@ -289,4 +289,3 @@ These are the gaps future engineering work should target:
    - native row/column table growth
    - `scene insert` into table cells
    - a clean geometry path for the dimension picker
-


### PR DESCRIPTION
## Summary
- add the adaptive rich-editor scene path and generic trusted interaction handling
- document the proven Canva, Google Docs, and Google Slides workflows in `use-cases/`
- add light references to the `use-cases/` folder in `README.md` and `CLAUDE.md`

## Verification
- bun test
- live rich-editor smoke runs in Canva, Google Docs, and Google Slides

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scene command now supports adaptive access to rich editors with improved text reading/writing and cursor control
  * Added use cases documentation for practical rich-editor automation workflows
  * Enhanced profile detection with optional trusted OS input handling via `--os` flag

* **Documentation**
  * Updated scene command help and documentation with capability-driven approach
  * Added comprehensive use cases guide for common editor automation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->