### PR TITLE
fix: restore real TypeScript coverage across host and extension code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ bash scripts/install.sh
 slop status    # Should report daemon status
 ```
 
+## Development Verification
+
+Use the verification command that matches the kind of change you made:
+
+```bash
+bun run typecheck    # Static typing across Bun host code and extension code
+bun test             # Runtime tests and CLI/parser coverage
+bash scripts/build.sh # Build compiled host binaries and extension bundles
+```
+
+- Run `bun run typecheck` when you change TypeScript types, runtime wiring, Chrome API usage, Bun socket usage, or any code that crosses host/extension boundaries.
+- Run `bun test` when you change parser behavior, monitor/scene helpers, or any logic already covered by the repo test suite.
+- Run `bash scripts/build.sh` when you need to verify the actual host binaries and extension bundles still compile.
+- For changes that affect browser behavior or shared infrastructure, run all three.
+
 ## Quick Start
 
 ```bash

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,96 @@
+# Architecture
+
+## Top-Level Flow
+
+`slop` follows a four-layer path:
+
+1. `cli/` parses commands, global flags, and output formatting.
+2. `extension/src/background/` owns routing, Chrome APIs, tab policy, transport selection, and background-only capability modules.
+3. `extension/src/content/` owns DOM interaction, in-page buffers, scene profiles, semantic selectors, and action execution inside tabs.
+4. `daemon/` owns native messaging, websocket fallback, OS-level trusted input, and event/log files.
+
+## Runtime Surfaces
+
+The repo intentionally spans multiple TypeScript runtime environments:
+
+- **Bun host code**: `cli/**`, `daemon/**`, `shared/**`, `scripts/**`, `test/**`
+- **Extension service worker / background**: `extension/src/background/**`
+- **Content scripts and page-facing browser code**: `extension/src/content/**`
+- **MAIN-world injected browser code**: `extension/src/inject-net.ts`
+
+These surfaces do not share the same ambient globals. Bun host code relies on Bun runtime types and socket APIs, while extension code relies on DOM, Web Worker, and Chrome extension APIs.
+
+## TypeScript Layout
+
+The repo now uses runtime-aware TypeScript configs instead of a single mixed ambient environment:
+
+- `tsconfig.base.json`
+  - shared strict compiler rules
+- `tsconfig.host.json`
+  - Bun host code and tests
+  - `types: ["bun"]`
+- `tsconfig.extension.json`
+  - browser and extension code under `extension/src/**`
+  - `lib: ["ESNext", "DOM", "DOM.Iterable", "WebWorker"]`
+  - `types: ["chrome"]`
+- `tsconfig.json`
+  - top-level strict repo check covering both host and extension code
+
+This split restores real static checking without excluding the extension surface or weakening strict mode.
+
+## File Map
+
+### CLI
+
+- `cli/index.ts` - main command dispatcher plus special-case orchestration for `chatgpt send` and `chatgpt read`
+- `cli/help.ts` - global help text
+- `cli/parse.ts` - shared target parsing for refs, indexes, and semantic selectors
+- `cli/commands/*.ts` - command-family parsers
+- `cli/transport.ts` - host-side daemon transport over Bun sockets and websocket fallback
+
+### Background Extension
+
+- `extension/src/background.ts` - startup wiring
+- `extension/src/background/transport.ts` - native messaging plus websocket fallback
+- `extension/src/background/message-dispatch.ts` - request lifecycle, active-tab lookup, slop-group enforcement
+- `extension/src/background/router.ts` - action routing to background capabilities or content script
+- `extension/src/background/tab-group.ts` - slop tab-group policy
+- `extension/src/background/linkedin-orchestration.ts` - LinkedIn event and attendees flows
+- `extension/src/background/capabilities/*.ts` - Chrome API and background-only capability handlers
+
+### Content Script
+
+- `extension/src/content.ts` - action multiplexer inside the page
+- `extension/src/content/actions/*.ts` - click, type, scroll, hover, drag, focus, wait
+- `extension/src/content/data/*.ts` - text/html extraction, query helpers, forms, storage, clipboard
+- `extension/src/content/find.ts` - semantic lookup and `find_and_*` helpers
+- `extension/src/content/net-buffer.ts` - passive fetch/XHR and SSE buffers exposed to the background
+- `extension/src/content/monitor.ts` - monitor capture inside the page
+- `extension/src/content/scene/engine.ts` - scene dispatcher and profile selection
+- `extension/src/content/scene/profiles/*.ts` - editor-specific scene-graph logic
+
+### Native Host And Shared Platform
+
+- `daemon/index.ts` - native messaging server, websocket bridge, OS-event execution
+- `daemon/os-input*.ts` - platform-specific trusted input
+- `shared/platform.ts` - socket, PID, log, and events paths
+
+## Verification Surfaces
+
+Use the verification command that matches the change you made:
+
+- `bun run typecheck`
+  - strict static checking across Bun host code and extension code
+- `bun test`
+  - runtime tests and parser/helper coverage
+- `bash scripts/build.sh`
+  - compiled host binaries and extension bundle build
+
+For changes that cross host/extension boundaries, touch transport, or modify Chrome API usage, run all three.
+
+## Build Outputs
+
+- `scripts/build.sh` builds the extension plus host binaries
+- `dist/slop` is the compiled CLI on host and macOS target builds
+- `daemon/slop-daemon` is the compiled daemon on host and macOS target builds
+- `extension/dist/` is the unpacked extension directory to load or reload in Chrome/Brave

--- a/cli/commands/actions.ts
+++ b/cli/commands/actions.ts
@@ -60,7 +60,7 @@ export function parseActionsCommand(filtered: string[]): Action {
       return { type: "blur" }
 
     case "hover": {
-      const hoverAction: Record<string, unknown> = { type: "hover", ...parseElementTarget(filtered[1]) }
+      const hoverAction: Action = { type: "hover", ...parseElementTarget(filtered[1]) }
       if (filtered.includes("--from")) {
         const fromParts = filtered[filtered.indexOf("--from") + 1].split(",").map(Number)
         hoverAction.fromX = fromParts[0]
@@ -73,7 +73,7 @@ export function parseActionsCommand(filtered: string[]): Action {
     }
 
     case "drag": {
-      const dragAction: Record<string, unknown> = { type: "drag", ...parseElementTarget(filtered[1]) }
+      const dragAction: Action = { type: "drag", ...parseElementTarget(filtered[1]) }
       if (filtered.includes("--from")) {
         const fromParts = filtered[filtered.indexOf("--from") + 1].split(",").map(Number)
         dragAction.fromX = fromParts[0]

--- a/cli/commands/screenshot.ts
+++ b/cli/commands/screenshot.ts
@@ -10,12 +10,12 @@ export function parseScreenshotCommand(filtered: string[]): Action {
   switch (cmd) {
     case "screenshot": {
       if (filtered.includes("--background")) {
-        const bgAction: Record<string, unknown> = { type: "screenshot_background" }
+        const bgAction: Action = { type: "screenshot_background" }
         if (filtered.includes("--format")) bgAction.format = filtered[filtered.indexOf("--format") + 1]
         if (filtered.includes("--quality")) bgAction.quality = parseInt(filtered[filtered.indexOf("--quality") + 1])
         return bgAction
       }
-      const ssAction: Record<string, unknown> = { type: "screenshot" }
+      const ssAction: Action = { type: "screenshot" }
       if (filtered.includes("--save")) ssAction.save = true
       if (filtered.includes("--format")) ssAction.format = filtered[filtered.indexOf("--format") + 1]
       if (filtered.includes("--quality")) ssAction.quality = parseInt(filtered[filtered.indexOf("--quality") + 1])
@@ -33,7 +33,7 @@ export function parseScreenshotCommand(filtered: string[]): Action {
         case "list":
           return { type: "canvas_list" }
         case "read": {
-          const crAction: Record<string, unknown> = { type: "canvas_read", canvasIndex: parseInt(filtered[2]) }
+          const crAction: Action = { type: "canvas_read", canvasIndex: parseInt(filtered[2]) }
           if (filtered.includes("--format")) crAction.format = filtered[filtered.indexOf("--format") + 1]
           if (filtered.includes("--quality")) crAction.quality = parseInt(filtered[filtered.indexOf("--quality") + 1])
           if (filtered.includes("--webgl")) crAction.webgl = true
@@ -44,7 +44,7 @@ export function parseScreenshotCommand(filtered: string[]): Action {
           return crAction
         }
         case "diff": {
-          const cdAction: Record<string, unknown> = { type: "canvas_diff", image1: filtered[2], image2: filtered[3] }
+          const cdAction: Action = { type: "canvas_diff", image1: filtered[2], image2: filtered[3] }
           if (filtered.includes("--threshold")) cdAction.threshold = parseInt(filtered[filtered.indexOf("--threshold") + 1])
           if (filtered.includes("--image")) cdAction.returnImage = true
           return cdAction
@@ -60,7 +60,7 @@ export function parseScreenshotCommand(filtered: string[]): Action {
         case "start":
           return { type: "capture_start" }
         case "frame": {
-          const cfAction: Record<string, unknown> = { type: "capture_frame" }
+          const cfAction: Action = { type: "capture_frame" }
           if (filtered.includes("--format")) cfAction.format = filtered[filtered.indexOf("--format") + 1]
           if (filtered.includes("--quality")) cfAction.quality = parseInt(filtered[filtered.indexOf("--quality") + 1])
           return cfAction

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,7 +1,7 @@
 import { HELP } from "./help"
 import { parseTabFlag } from "./parse"
 import { formatState, formatTabs, formatCookies, formatResult } from "./format"
-import { sendCommand, sendCommandWs } from "./transport"
+import { sendCommand, sendCommandWs, type DaemonResult, type DaemonResponse } from "./transport"
 import { ensureDaemon } from "./daemon-spawn"
 import { parseStateCommand } from "./commands/state"
 import { parseActionsCommand } from "./commands/actions"
@@ -41,6 +41,10 @@ const NO_DAEMON = new Set(["status", "help", "events", "session"])
 
 // Monitor subcommands that are handled locally (no daemon needed)
 const MONITOR_LOCAL_SUBCOMMANDS = new Set(["tail", "list", "export"])
+
+function unwrapResult(response: DaemonResponse): DaemonResult {
+  return response.result
+}
 
 async function main() {
   const args = process.argv.slice(2)
@@ -109,7 +113,7 @@ async function main() {
         const resp = useWs
           ? await sendCommandWs(chunkAction, globalTabId)
           : await sendCommand(chunkAction, globalTabId)
-        const result = resp?.result || resp
+        const result = unwrapResult(resp)
         if (result?.success && result.data) {
           const d = result.data as { active: boolean; text?: string; offset?: number }
           if (d.text) {
@@ -136,7 +140,7 @@ async function main() {
     const treeResp = useWs
       ? await sendCommandWs({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
       : await sendCommand({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
-    const tree = (treeResp?.result?.data || treeResp?.data || "") as string
+    const tree = (unwrapResult(treeResp).data || "") as string
     const match = tree.match(/\[(e\d+)\]\s+textbox\s+"Chat with ChatGPT"/)
     if (!match) {
       console.error("error: could not find ChatGPT input textbox. Is chatgpt.com open in a slop tab?")
@@ -171,7 +175,7 @@ async function main() {
         const resp = useWs
           ? await sendCommandWs(chunkAction, globalTabId)
           : await sendCommand(chunkAction, globalTabId)
-        const result = resp?.result || resp
+        const result = unwrapResult(resp)
         if (result?.success && result.data) {
           const d = result.data as { active: boolean; text?: string; offset?: number }
           if (d.text) {
@@ -223,7 +227,7 @@ async function main() {
     const resp = useWs
       ? await sendCommandWs(textAction, globalTabId)
       : await sendCommand(textAction, globalTabId)
-    const result = resp?.result || resp
+    const result = unwrapResult(resp)
     if (result?.success) {
       const text = result.data as string
       const chatMarker = text.indexOf("ChatGPT said:")
@@ -242,7 +246,7 @@ async function main() {
     const streamsResp = useWs
       ? await sendCommandWs({ type: "sse_streams" }, globalTabId)
       : await sendCommand({ type: "sse_streams" }, globalTabId)
-    const streams = (streamsResp?.result?.data || streamsResp?.data || []) as any[]
+    const streams = (unwrapResult(streamsResp).data || []) as any[]
     const active = streams.filter((s: any) => s.url?.includes("backend-api"))
 
     console.log(JSON.stringify({
@@ -258,7 +262,7 @@ async function main() {
     const resp = useWs
       ? await sendCommandWs(netAction, globalTabId)
       : await sendCommand(netAction, globalTabId)
-    const result = resp?.result || resp
+    const result = unwrapResult(resp)
     if (result?.success && Array.isArray(result.data) && result.data.length > 0) {
       try {
         const body = JSON.parse(result.data[result.data.length - 1].body)
@@ -289,7 +293,7 @@ async function main() {
     const treeResp = useWs
       ? await sendCommandWs({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
       : await sendCommand({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
-    const tree = (treeResp?.result?.data || treeResp?.data || "") as string
+    const tree = (unwrapResult(treeResp).data || "") as string
     const stopMatch = tree.match(/\[(e\d+)\]\s+button\s+"Stop"/)
     if (stopMatch) {
       await (useWs
@@ -308,7 +312,7 @@ async function main() {
       const treeResp = useWs
         ? await sendCommandWs({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
         : await sendCommand({ type: "get_a11y_tree", filter: "interactive" }, globalTabId)
-      const tree = (treeResp?.result?.data || treeResp?.data || "") as string
+      const tree = (unwrapResult(treeResp).data || "") as string
       const modelMatch = tree.match(/\[(e\d+)\]\s+button\s+"Model selector"/)
       if (modelMatch) {
         console.log("Model selector found at", modelMatch[1])
@@ -333,46 +337,41 @@ async function main() {
     const response = useWs
       ? await sendCommandWs(action, globalTabId)
       : await sendCommand(action, globalTabId)
+    const result = unwrapResult(response)
 
-    if (response.result) {
-      const result = response.result
-
-      // Screenshot save-to-disk post-processing
-      if (result.success && result.data && typeof result.data === "object" &&
-          (result.data as Record<string, unknown>).save &&
-          (result.data as Record<string, unknown>).dataUrl) {
-        const d = result.data as Record<string, unknown>
-        const dataUrl = d.dataUrl as string
-        const base64 = dataUrl.split(",")[1]
-        const ext = (d.format as string) === "png" ? "png" : "jpg"
-        const filename = `slop-screenshot-${Date.now()}.${ext}`
-        const bytes = Buffer.from(base64, "base64")
-        await Bun.write(filename, bytes)
-        d.filePath = `${process.cwd()}/${filename}`
-        delete d.save
-        process.stderr.write(`saved: ${d.filePath}\n`)
-      }
-
-      // Pretty-print known result types
-      if (!jsonMode && result.success) {
-        if (action.type === "get_state") {
-          console.log(formatState(result.data as Parameters<typeof formatState>[0]))
-          return
-        }
-        if (action.type === "tab_list") {
-          console.log(formatTabs(result.data as Parameters<typeof formatTabs>[0]))
-          return
-        }
-        if (action.type === "cookies_get") {
-          console.log(formatCookies(result.data as Parameters<typeof formatCookies>[0]))
-          return
-        }
-      }
-
-      console.log(formatResult(result, jsonMode))
-    } else {
-      console.log(formatResult(response as unknown as { success: boolean; error?: string; data?: unknown }, jsonMode))
+    // Screenshot save-to-disk post-processing
+    if (result.success && result.data && typeof result.data === "object" &&
+        (result.data as Record<string, unknown>).save &&
+        (result.data as Record<string, unknown>).dataUrl) {
+      const d = result.data as Record<string, unknown>
+      const dataUrl = d.dataUrl as string
+      const base64 = dataUrl.split(",")[1]
+      const ext = (d.format as string) === "png" ? "png" : "jpg"
+      const filename = `slop-screenshot-${Date.now()}.${ext}`
+      const bytes = Buffer.from(base64, "base64")
+      await Bun.write(filename, bytes)
+      d.filePath = `${process.cwd()}/${filename}`
+      delete d.save
+      process.stderr.write(`saved: ${d.filePath}\n`)
     }
+
+    // Pretty-print known result types
+    if (!jsonMode && result.success) {
+      if (action.type === "get_state") {
+        console.log(formatState(result.data as Parameters<typeof formatState>[0]))
+        return
+      }
+      if (action.type === "tab_list") {
+        console.log(formatTabs(result.data as Parameters<typeof formatTabs>[0]))
+        return
+      }
+      if (action.type === "cookies_get") {
+        console.log(formatCookies(result.data as Parameters<typeof formatCookies>[0]))
+        return
+      }
+    }
+
+    console.log(formatResult(result, jsonMode))
   } catch (err) {
     console.error(`error: ${(err as Error).message}`)
     process.exit(1)

--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -2,14 +2,15 @@
  * cli/transport.ts — sendCommand (Unix socket / TCP) and sendCommandWs (WebSocket)
  */
 
-import { connectOptions, WS_PORT } from "../shared/platform"
+import { IPC_PORT, IS_WIN, SOCKET_PATH, WS_PORT } from "../shared/platform"
 
 export const SLOP_TIMEOUT_MS = parseInt(process.env.SLOP_TIMEOUT || "15000")
 
 export type Action = { type: string; [key: string]: unknown }
+export type DaemonResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
 export type DaemonResponse = {
   id: string
-  result: { success: boolean; error?: string; data?: unknown; tabId?: number }
+  result: DaemonResult
 }
 
 export function sendCommand(action: Action, tabId?: number): Promise<DaemonResponse> {
@@ -19,7 +20,7 @@ export function sendCommand(action: Action, tabId?: number): Promise<DaemonRespo
     process.stderr.write(`[${shortId}] → ${action.type}\n`)
     let buffer = Buffer.alloc(0)
     let resolved = false
-    let socketRef: ReturnType<Awaited<ReturnType<typeof Bun.connect>>> | null = null
+    let socketRef: Bun.Socket<undefined> | null = null
 
     const timer = setTimeout(() => {
       if (!resolved) {
@@ -29,8 +30,8 @@ export function sendCommand(action: Action, tabId?: number): Promise<DaemonRespo
       }
     }, SLOP_TIMEOUT_MS)
 
-    Bun.connect(connectOptions({
-      open(socket) {
+    const socketHandlers: Bun.SocketHandler<undefined> = {
+      open(socket: Bun.Socket<undefined>) {
         socketRef = socket
         const payload = JSON.stringify({ id, action, ...(tabId !== undefined && { tabId }) })
         const encoded = Buffer.from(payload, "utf-8")
@@ -38,7 +39,7 @@ export function sendCommand(action: Action, tabId?: number): Promise<DaemonRespo
         header.writeUInt32LE(encoded.byteLength, 0)
         socket.write(Buffer.concat([header, encoded]))
       },
-      data(_socket, raw) {
+      data(socket: Bun.Socket<undefined>, raw: Buffer<ArrayBufferLike>) {
         buffer = Buffer.concat([buffer, Buffer.from(raw)])
         if (buffer.length >= 4) {
           const msgLen = buffer.readUInt32LE(0)
@@ -47,30 +48,36 @@ export function sendCommand(action: Action, tabId?: number): Promise<DaemonRespo
             clearTimeout(timer)
             try {
               resolved = true
-              resolve(JSON.parse(json))
+              resolve(JSON.parse(json) as DaemonResponse)
             } catch {
               resolved = true
               reject(new Error("invalid response from daemon"))
             }
-            _socket.end()
+            socket.end()
           }
         }
       },
-      close() {
+      close(_socket: Bun.Socket<undefined>) {
         clearTimeout(timer)
         if (!resolved) {
           reject(new Error("connection closed before response"))
         }
       },
-      connectError(_socket, _err) {
+      connectError(_socket: Bun.Socket<undefined>, _err: Error) {
         clearTimeout(timer)
         reject(new Error("daemon not running. Open Chrome with the slop-browser extension loaded."))
       },
-      error(_socket, err) {
+      error(_socket: Bun.Socket<undefined>, err: Error) {
         clearTimeout(timer)
         reject(err)
       }
-    }))
+    }
+
+    const connectPromise = IS_WIN
+      ? Bun.connect({ hostname: "127.0.0.1", port: IPC_PORT, socket: socketHandlers })
+      : Bun.connect({ unix: SOCKET_PATH, socket: socketHandlers })
+
+    void connectPromise.catch(() => {})
   })
 }
 
@@ -91,7 +98,7 @@ export function sendCommandWs(action: Action, tabId?: number): Promise<DaemonRes
     ws.onmessage = (event) => {
       clearTimeout(timer)
       try {
-        resolve(JSON.parse(typeof event.data === "string" ? event.data : ""))
+        resolve(JSON.parse(typeof event.data === "string" ? event.data : "") as DaemonResponse)
       } catch {
         reject(new Error("invalid response from daemon via WebSocket"))
       }

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -160,6 +160,7 @@ function handleNativeMessage(msg: { id?: string; type?: string; [key: string]: u
   if (msg.id) {
     const pending = pendingRequests.get(msg.id)
     if (pending) {
+      const requestId = msg.id
       clearTimeout(pending.timer)
       const duration = Date.now() - pending.startTime
       const result = (msg as { result?: { success?: boolean; data?: Record<string, unknown> } }).result
@@ -189,12 +190,12 @@ function handleNativeMessage(msg: { id?: string; type?: string; [key: string]: u
             enrichedAction.path = data.path
             enrichedAction.duration = data.duration
           }
-          log(`[${msg.id.slice(0, 8)}] posting OS event for ${pending.actionType}`)
-          handleOsAction(msg.id, enrichedAction).then((osResult) => {
+          log(`[${requestId.slice(0, 8)}] posting OS event for ${pending.actionType}`)
+          handleOsAction(requestId, enrichedAction).then((osResult) => {
             const finalResult = osResult || { success: false, error: "os action failed" }
-            emitEvent("request_complete", { requestId: msg.id, action: pending.actionType, duration: Date.now() - pending.startTime, success: finalResult.success })
-            pending.resolve(JSON.stringify({ id: msg.id, result: finalResult }))
-            pendingRequests.delete(msg.id)
+            emitEvent("request_complete", { requestId, action: pending.actionType, duration: Date.now() - pending.startTime, success: finalResult.success })
+            pending.resolve(JSON.stringify({ id: requestId, result: finalResult }))
+            pendingRequests.delete(requestId)
           })
           return
         }
@@ -336,20 +337,15 @@ async function handleOsAction(
   }
 }
 
-let socketServer: ReturnType<typeof Bun.listen> | null = null
+let socketServer: Bun.TCPSocketListener<undefined> | Bun.UnixSocketListener<undefined> | null = null
 
 try {
-  const listenOpts = IS_WIN
-    ? { hostname: "127.0.0.1", port: IPC_PORT }
-    : { unix: SOCKET_PATH }
-  socketServer = Bun.listen({
-    ...listenOpts,
-    socket: {
-      open(socket) {
+  const socketHandlers: Bun.SocketHandler<undefined> = {
+      open(socket: Bun.Socket<undefined>) {
         socketBuffers.set(socket, Buffer.alloc(0))
         log("cli connected via socket")
       },
-      data(socket, raw) {
+      data(socket: Bun.Socket<undefined>, raw: Buffer<ArrayBufferLike>) {
         let buf = Buffer.concat([socketBuffers.get(socket) || Buffer.alloc(0), Buffer.from(raw)])
 
         while (buf.length >= 4) {
@@ -413,19 +409,23 @@ try {
 
         socketBuffers.set(socket, buf)
       },
-      drain(socket) {
+      drain(socket: Bun.Socket<undefined>) {
         drainSocketQueue(socket)
       },
-      close(socket) {
+      close(socket: Bun.Socket<undefined>) {
         socketBuffers.delete(socket)
         socketWriteQueues.delete(socket)
         log("cli disconnected")
       },
-      error(_socket, err) {
+      error(_socket: Bun.Socket<undefined>, err: Error) {
         log(`socket error: ${err.message}`)
       }
     }
-  })
+  if (IS_WIN) {
+    socketServer = Bun.listen({ hostname: "127.0.0.1", port: IPC_PORT, socket: socketHandlers })
+  } else {
+    socketServer = Bun.listen({ unix: SOCKET_PATH, socket: socketHandlers })
+  }
   log(`socket listening on ${transportLabel()}`)
 } catch (err) {
   log(`socket listen failed: ${(err as Error).message}`)
@@ -437,10 +437,10 @@ log(`pid file written: ${process.pid}`)
 
 let wsServer: ReturnType<typeof Bun.serve> | null = null
 try {
-  wsServer = Bun.serve({
+  wsServer = Bun.serve<undefined>({
     port: WS_PORT,
     fetch(req, server) {
-      if (server.upgrade(req)) return
+      if (server.upgrade(req, {})) return
       return new Response("slop-browser daemon", { status: 200 })
     },
     websocket: {

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -70,7 +70,7 @@ export async function handleScreenshotActions(
           const scrollTo = i * viewportHeight
           await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo })
           await new Promise(r => setTimeout(r, 150))
-          const stripUrl = await chrome.tabs.captureVisibleTab(undefined, { format, quality })
+          const stripUrl = await chrome.tabs.captureVisibleTab({ format, quality })
           strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) })
           if (i < stripCount - 1) await new Promise(r => setTimeout(r, 500))
         }
@@ -97,7 +97,7 @@ export async function handleScreenshotActions(
 
       let dataUrl: string
       try {
-        dataUrl = await chrome.tabs.captureVisibleTab(undefined, { format, quality })
+        dataUrl = await chrome.tabs.captureVisibleTab({ format, quality })
       } catch {
         const fallback = await handleScreenshotBackground(
           { type: "screenshot_background", format: action.format, quality: action.quality },

--- a/extension/src/background/capabilities/tabs.ts
+++ b/extension/src/background/capabilities/tabs.ts
@@ -72,7 +72,7 @@ export async function handleTabActions(
       if (action.title || action.color) {
         await chrome.tabGroups.update(groupId, {
           title: action.title as string | undefined,
-          color: action.color as chrome.tabGroups.ColorEnum | undefined
+          color: action.color as chrome.tabGroups.UpdateProperties["color"]
         })
       }
       return { success: true, data: { groupId } }

--- a/extension/src/background/capabilities/windows.ts
+++ b/extension/src/background/capabilities/windows.ts
@@ -10,7 +10,7 @@ export async function handleWindowActions(
     case "window_create": {
       const win = await chrome.windows.create({
         url: action.url as string | undefined,
-        type: (action.windowType as chrome.windows.createTypeEnum) || "normal",
+        type: (action.windowType as chrome.windows.CreateData["type"]) || "normal",
         width: action.width as number | undefined,
         height: action.height as number | undefined,
         left: action.left as number | undefined,
@@ -18,6 +18,7 @@ export async function handleWindowActions(
         incognito: !!action.incognito,
         focused: action.focused !== false
       })
+      if (!win) return { success: false, error: "window creation returned no window" }
       const firstTab = win.tabs?.[0]
       let groupId: number | undefined
       if (firstTab?.id && !action.incognito) {
@@ -39,12 +40,13 @@ export async function handleWindowActions(
 
     case "window_resize": {
       const targetId = (action.windowId as number) || (await chrome.windows.getCurrent()).id
+      if (targetId === undefined) return { success: false, error: "no target window id available" }
       await chrome.windows.update(targetId, {
         width: action.width as number | undefined,
         height: action.height as number | undefined,
         left: action.left as number | undefined,
         top: action.top as number | undefined,
-        state: action.state as chrome.windows.windowStateEnum | undefined
+        state: action.state as chrome.windows.UpdateInfo["state"]
       })
       return { success: true }
     }

--- a/extension/src/background/content-bridge.ts
+++ b/extension/src/background/content-bridge.ts
@@ -49,7 +49,7 @@ export function waitForTabLoad(
       resolve({ ready: probeResult, elapsed: Date.now() - start })
     }, timeoutMs)
 
-    function listener(updatedTabId: number, changeInfo: chrome.tabs.TabChangeInfo) {
+    function listener(updatedTabId: number, changeInfo: chrome.tabs.OnUpdatedInfo) {
       if (updatedTabId === tabId && changeInfo.status === "complete") {
         clearTimeout(hardTimer)
         chrome.tabs.onUpdated.removeListener(listener)

--- a/extension/src/background/message-dispatch.ts
+++ b/extension/src/background/message-dispatch.ts
@@ -88,7 +88,7 @@ export async function handleDaemonMessage(msg: {
   let tabId = msg.tabId
 
   if (!tabId && needsTab(action.type)) {
-    const stored = await chrome.storage.session.get("activeTabId")
+    const stored = await chrome.storage.session.get("activeTabId") as { activeTabId?: number }
     tabId = stored.activeTabId
   }
 

--- a/extension/src/content/element-tree.ts
+++ b/extension/src/content/element-tree.ts
@@ -11,9 +11,10 @@ export function buildSelector(el: Element): string {
       parts.unshift(`#${CSS.escape(current.id)}`)
       break
     }
-    const parent = current.parentElement
+    const parent: Element | null = current.parentElement
     if (parent) {
-      const siblings = Array.from(parent.children).filter(c => c.tagName === current!.tagName)
+      const currentTagName = current.tagName
+      const siblings = Array.from(parent.children).filter((c: Element) => c.tagName === currentTagName)
       if (siblings.length > 1) {
         const idx = siblings.indexOf(current) + 1
         selector += `:nth-of-type(${idx})`

--- a/extension/src/content/monitor.ts
+++ b/extension/src/content/monitor.ts
@@ -111,7 +111,7 @@ function truncate(s: string, max: number): string {
 function targetFromEvent(e: Event): EventTarget | null {
   try {
     const path = (e.composedPath && e.composedPath()) || []
-    if (path.length > 0) return path[0]
+    if (path.length > 0) return path[0] ?? null
   } catch {}
   return e.target
 }

--- a/extension/src/content/scene/engine.ts
+++ b/extension/src/content/scene/engine.ts
@@ -4,7 +4,8 @@ import type {
   SceneEngineResult,
   SceneProfileDescription,
   SceneRenderResult,
-  SceneResolvedTarget
+  SceneResolvedTarget,
+  SceneInsertResult
 } from "./types"
 import { genericProfile } from "./profiles/generic"
 import { canvaProfile } from "./profiles/canva"
@@ -141,7 +142,7 @@ export function canvasText(opts?: { withHtml?: boolean; profile?: string }): Sce
   return wrap(p, () => p.text!({ withHtml: opts?.withHtml }))
 }
 
-export function canvasInsertText(text: string, profileOverride?: string): SceneEngineResult<{ inserted: number }> {
+export function canvasInsertText(text: string, profileOverride?: string): SceneEngineResult<SceneInsertResult> {
   const p = detectProfile(profileOverride)
   if (!p.writeAtCursor) return { success: false, error: `profile '${p.name}' does not support writeAtCursor()`, profile: p.name }
   const r = p.writeAtCursor(text)

--- a/extension/src/content/scene/types.ts
+++ b/extension/src/content/scene/types.ts
@@ -72,6 +72,13 @@ export interface SceneWriteResult {
   verified?: boolean
 }
 
+export interface SceneInsertResult {
+  inserted: number
+  method: "dom" | "os_type"
+  verified: boolean
+  text?: string
+}
+
 export interface SceneProfileDescription {
   name: string
   capabilities: string[]

--- a/extension/src/inject-net.ts
+++ b/extension/src/inject-net.ts
@@ -52,7 +52,7 @@ if ((window as any).__slop_net_installed) {
 
   const originalFetch = window.fetch
 
-  window.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const patchedFetch = Object.assign(function (this: typeof window, input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     let url: string
     try {
       if (typeof input === "string") url = input
@@ -192,7 +192,9 @@ if ((window as any).__slop_net_installed) {
     }).catch((err) => {
       throw err
     })
-  }
+  }, originalFetch)
+
+  window.fetch = patchedFetch
 
   const XHR = XMLHttpRequest.prototype
 
@@ -283,6 +285,7 @@ if ((window as any).__slop_net_installed) {
           origAddEventListener(type, wrapped as EventListener, options)
           return
         }
+        if (!listener) return
         origAddEventListener(type, listener, options)
       } as typeof real.addEventListener
 
@@ -329,10 +332,12 @@ if ((window as any).__slop_net_installed) {
       return real as unknown as EventSource
     } as unknown as typeof EventSource
 
-    SlopEventSource.prototype = OriginalEventSource.prototype
-    SlopEventSource.CONNECTING = OriginalEventSource.CONNECTING
-    SlopEventSource.OPEN = OriginalEventSource.OPEN
-    SlopEventSource.CLOSED = OriginalEventSource.CLOSED
-    ;(window as any).EventSource = SlopEventSource
+      SlopEventSource.prototype = OriginalEventSource.prototype
+      Object.defineProperties(SlopEventSource, {
+        CONNECTING: { value: OriginalEventSource.CONNECTING },
+        OPEN: { value: OriginalEventSource.OPEN },
+        CLOSED: { value: OriginalEventSource.CLOSED }
+      })
+      ;(window as any).EventSource = SlopEventSource
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build": "./scripts/build.sh",
+    "typecheck": "bunx tsc -p tsconfig.host.json && bunx tsc -p tsconfig.extension.json",
     "daemon": "bun run daemon/index.ts",
     "cli": "bun run cli/index.ts"
   },

--- a/prd/PRD-17.md
+++ b/prd/PRD-17.md
@@ -1,0 +1,285 @@
+# PRD-17: Restore Real TypeScript Coverage Across Bun Host Code and Chrome Extension Surfaces
+
+**Goal:** Make `slop-browser` actually type-check under TypeScript so that the repo's strictness claims match reality, and regressions in CLI, daemon, background, and content-script code are caught before shipping.
+
+**Scope:** Fix the type-checking architecture behind the current `bunx tsc --noEmit` failure by separating host and browser runtimes where necessary, loading the correct ambient types for each surface, and cleaning up the concrete type errors that remain after the config is corrected. Add a first-class `typecheck` verification path for local development and CI.
+
+**Status:** Implemented in this repo revision.
+
+## Implementation Checklist
+
+- [x] Expand this checklist into an executable internal todo list.
+- [x] Reproduce and categorize the current `tsc` failures by root cause instead of treating them as one blob.
+- [x] Introduce a runtime-aware TypeScript project layout for host and extension code.
+- [x] Load the correct Bun, DOM, Web Worker, and Chrome ambient types for the files that actually use them.
+- [x] Fix the remaining host-side type errors in CLI parsing, transport, and daemon networking after config is corrected.
+- [x] Fix the remaining extension-side type errors in background, content, scene, and network-capture code after config is corrected.
+- [x] Add an explicit `typecheck` command to the repo and document it alongside build/test.
+- [x] Gate completion on passing type-check, build, and existing tests.
+
+## Non-Negotiable
+
+1. **Do not hide the problem by excluding extension code.** The browser-side code in `extension/src/**` must remain part of the verified type surface.
+2. **Do not weaken strictness to get green output.** No solution that "passes" by turning off `strict`, broadly adding `any`, or papering over runtime boundaries with `skip`-style escapes.
+3. **Respect runtime boundaries.** Bun host code, content scripts, and the MV3 service worker do not run in the same ambient environment and must not share a fake one-size-fits-all type layer.
+4. **Preserve current behavior.** This PRD is about restoring static guarantees, not changing the command surface or browser architecture.
+5. **Keep the verification path simple.** A contributor should have one obvious command to run to verify types locally.
+
+## Evidence Sources
+
+| ID | Source | Path / Reference | Finding |
+|----|--------|------------------|---------|
+| CODE-TSCONFIG | Current TypeScript config | `tsconfig.json:2-15` | The repo includes `extension/src/**/*.ts`, but only loads `lib: ["ESNext"]` and `types: ["bun-types"]`, which is insufficient for browser globals and Chrome extension APIs. |
+| CODE-PKG | Current dev dependencies | `package.json:13-16` | `@types/chrome` is installed, but the current tsconfig does not load it. |
+| CODE-EXT-BG | Extension background entry | `extension/src/background.ts:1-19` | Background code uses `chrome.*` globals directly. |
+| CODE-EXT-CONTENT | Content script entry | `extension/src/content.ts:1-180` | Content code uses `document`, `window`, `HTMLElement`, `PointerEvent`, and many DOM APIs directly. |
+| CODE-CLI-TRANSPORT | Host transport layer | `cli/transport.ts:15-107` | Host code depends on Bun socket APIs and currently has unresolved generic/type mismatches under `tsc`. |
+| CODE-DAEMON | Daemon networking | `daemon/index.ts:339-516` | Daemon code mixes TCP/Unix socket shapes and WebSocket upgrade/server types in ways that currently fail strict typing. |
+| LIVE-TSC | Local verification during review | `bunx tsc --noEmit` run in this repo on 2026-04-09 | TypeScript currently reports hundreds of diagnostics across CLI, daemon, and extension code. |
+| BUN-TS | Bun TypeScript guidance | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/typescript.md:17-44,60-62` | Bun recommends explicit compiler options and `types: ["bun"]` for Bun globals. |
+| BUN-TEST | Bun test runner docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/bun/docs/test.md:7-24` | `bun test` is a runtime test surface, not a substitute for TypeScript static checking. |
+| CHR-CONTENT | Chrome Extensions content scripts docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/content-scripts.md:1-25,79-117` | Content scripts run in browser pages and use DOM APIs, with messaging to the extension as the bridge. |
+| CHR-SW | Chrome Extensions service worker docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/develop/concepts/service-workers.md:10-14` | Extension service workers are event-driven background scripts with different capabilities than DOM-bearing pages. |
+| CHR-TABS | Chrome tabs API docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/reference/api/tabs.md:13-18,185-190` | `chrome.tabs` lives in extension pages/service workers, not in generic Bun/Node code. |
+| CHR-OFFSCREEN | Chrome offscreen API docs | `/Volumes/VRAM/80-89_Resources/80_Reference/docs/chrome-extensions/docs/extensions/reference/api/offscreen.md:1-32` | Offscreen documents are browser DOM contexts with tightly scoped extension API access, reinforcing that extension runtime surfaces are heterogeneous. |
+
+## Problem
+
+### Root issue
+
+The repository currently presents itself as a strict TypeScript project, but the configured type-checking surface does not model the environments the code actually runs in.
+
+The result is a split-brain workflow:
+
+- `bun test` passes,
+- `bash scripts/build.sh` passes,
+- but `bunx tsc --noEmit` fails heavily.
+
+That means contributors can change extension code, see green build/test output, and still ship type regressions that static analysis should have caught.
+
+### Why this is happening
+
+There are two different problems layered together:
+
+1. **The config is wrong for the repo shape.**
+   - The repo mixes Bun host code (`cli/`, `daemon/`, `shared/`) with Chrome extension browser code (`extension/src/**`).
+   - Those files do not share the same ambient globals.
+   - The current `tsconfig.json` applies one environment to all of them.
+
+2. **The code contains real strict-mode typing debt.**
+   - Some of the current errors are just missing DOM/Chrome ambient types.
+   - Others are genuine typing mistakes in unions, generic socket signatures, and response shapes.
+
+The first problem hides the second. Once the environment model is corrected, the remaining real errors need to be fixed intentionally.
+
+### Why this matters now
+
+This repo has grown beyond a tiny Bun-only CLI. It now spans:
+
+- a compiled Bun CLI,
+- a Bun daemon,
+- an MV3 extension service worker,
+- content scripts,
+- MAIN-world injection code,
+- and offscreen-document/browser-side processing.
+
+That architecture is valid, but it requires explicit typing boundaries. Without them, strict mode becomes performative rather than protective.
+
+## Product Requirements
+
+### 1. Introduce runtime-aware TypeScript projects
+
+The repo must stop pretending that all files run in the same environment.
+
+#### Required project layout
+
+At minimum, introduce:
+
+- `tsconfig.base.json`
+  - shared strict compiler rules
+  - no runtime-specific ambient globals
+- `tsconfig.host.json`
+  - includes `cli/**`, `daemon/**`, `shared/**`, and any Bun-only scripts
+  - loads Bun ambient types
+  - does not load DOM/Chrome globals by default
+- `tsconfig.extension.json`
+  - includes `extension/src/**`
+  - loads the browser/DOM/Chrome ambient layer needed by MV3 extension code
+
+If background service-worker typing and content-script typing cannot be modeled cleanly in one extension config, it is acceptable to split the extension project further, but only if that reduces ambiguity rather than adding ceremony.
+
+#### Required outcome
+
+A contributor must be able to run one top-level typecheck command that checks all relevant projects in a predictable way.
+
+### 2. Load the correct ambient types for each runtime
+
+#### Host requirements
+
+Host-side TypeScript configuration must follow Bun's documented typing model closely enough that Bun globals and socket APIs are type-checked correctly.
+
+This includes:
+
+- using the Bun ambient type package in the supported way,
+- aligning compiler options with Bun's TypeScript guidance where applicable,
+- and avoiding fake DOM globals in host code.
+
+#### Extension requirements
+
+Extension-side TypeScript configuration must load the globals used by:
+
+- content scripts,
+- browser pages/offscreen documents,
+- and the extension service worker / Chrome APIs.
+
+The goal is not theoretical purity. The goal is that references like `document`, `window`, `HTMLElement`, `PointerEvent`, and `chrome.tabs` are checked in the project where they are real.
+
+### 3. Fix the remaining real type errors after config correction
+
+Config cleanup alone is not sufficient. The repo must also address the strict-mode issues that remain once the correct ambient types are loaded.
+
+#### Known error classes to resolve
+
+1. **Action object widening in CLI parsers**
+   - Several parser branches build `Record<string, unknown>` objects and return them as `Action`, causing `type` property loss under strict inference.
+
+2. **Daemon and CLI Bun socket typing mismatches**
+   - The current `Bun.connect` / `Bun.listen` usage mixes incompatible option shapes and listener types.
+
+3. **Daemon response typing drift**
+   - Some CLI callers assume response shapes that are looser than the declared `DaemonResponse`.
+
+4. **Implicit `any` leakage**
+   - Particularly in callback parameters and Chrome API mapping code.
+
+5. **Browser API narrowing issues**
+   - Canvas, DOM, and scene code currently relies on values inferred as `{}` or `unknown` in places where proper narrowing should exist.
+
+#### Non-goal
+
+This PRD does not require every local helper type to become elegant. It does require the code to pass strict checking without broad unsafe escapes.
+
+### 4. Add a first-class repo typecheck command
+
+The repository must define and document a standard type-check entry point.
+
+#### Required behavior
+
+- Add a `typecheck` script to `package.json`.
+- The command must verify every relevant TypeScript project.
+- The command must be appropriate for both local development and CI.
+
+#### Acceptable implementation shapes
+
+- `tsc --noEmit -p tsconfig.host.json` plus `tsc --noEmit -p tsconfig.extension.json`
+- or project references / build mode,
+- or another equivalent approach that stays transparent.
+
+### 5. Update repo docs to reflect the real verification story
+
+The current repo guidance emphasizes build and test. After this PRD, docs must clearly distinguish:
+
+- build verification,
+- runtime tests,
+- and static type verification.
+
+At minimum, update the local workflow docs or README so contributors know:
+
+1. when to run `typecheck`,
+2. when `bun test` is enough,
+3. and when a cross-surface change requires all three: typecheck, build, and tests.
+
+## Acceptance Criteria
+
+### Functional
+
+1. A single documented top-level typecheck command exists and succeeds.
+2. `extension/src/**` remains inside the checked type surface.
+3. Host code is checked with Bun-aware ambient types, not browser globals.
+4. Extension code is checked with browser/Chrome-aware ambient types.
+5. The current strict-mode diagnostics are reduced to zero for the checked projects, or to a deliberately documented residual list with explicit ownership if a staged rollout is used.
+
+### Regression
+
+1. `bash scripts/build.sh` still succeeds.
+2. `bun test` still succeeds.
+3. No user-facing CLI command or browser feature is removed as a side effect of typing cleanup.
+
+### Quality bar
+
+1. No solution that passes by excluding `extension/src/**` from checking.
+2. No solution that passes by disabling strict mode.
+3. No broad `// @ts-ignore` sweep or global `any` fallback used as the primary remediation strategy.
+
+## Implementation Plan
+
+### Phase 0: Establish the real failure inventory
+
+- Capture the current `bunx tsc --noEmit` failure set.
+- Group failures into:
+  - config/environment errors,
+  - host typing errors,
+  - extension typing errors,
+  - and response/modeling drift.
+- Decide whether a two-project or three-project TypeScript layout is the cleanest fix.
+
+### Phase 1: Split the repo by runtime
+
+- Create a shared base tsconfig with strict rules only.
+- Create a Bun host tsconfig for CLI/daemon/shared code.
+- Create an extension tsconfig for browser-side code.
+- Wire a top-level typecheck command that runs both.
+
+### Phase 2: Fix host-side type debt
+
+- Normalize `Action` builder typing in CLI parsers.
+- Correct Bun socket/listener typings in `cli/transport.ts` and `daemon/index.ts`.
+- Tighten daemon response types so CLI callers stop reaching through undeclared shapes.
+
+### Phase 3: Fix extension-side type debt
+
+- Load Chrome ambient types and the required DOM/worker libs.
+- Add explicit narrowing where `unknown` or `{}` currently leaks into DOM/canvas/scene code.
+- Clean up implicit-`any` callback parameters and Chrome API mapping code.
+
+### Phase 4: Make the typecheck path part of normal development
+
+- Add `typecheck` to `package.json`.
+- Update docs/workflows to mention it next to build/test.
+- If this repo has CI workflows that already run build/test, extend them to run typecheck as well.
+
+## Risks
+
+### Risk 1: One extension tsconfig may still be too coarse
+
+The extension bundle mixes content-script DOM code, service-worker code, and offscreen document code. A single config may technically work but still blur runtime boundaries.
+
+**Mitigation:** Start with one extension project only if it stays readable. Split further only when a concrete type conflict remains.
+
+### Risk 2: Bun and TypeScript disagree on edge-case APIs
+
+Some Bun socket/runtime types may require code adjustments even though the code works at runtime.
+
+**Mitigation:** Prefer small modeling fixes and explicit narrowings over unsafe casts. If a Bun typing limitation is the blocker, isolate the cast to the narrowest possible boundary and document why.
+
+### Risk 3: Contributors may keep using build/test only
+
+If the repo adds a correct typecheck command but does not document or run it routinely, the project will regress back into the same state.
+
+**Mitigation:** Make `typecheck` visible in both docs and CI.
+
+## Out of Scope
+
+- Rewriting the build pipeline.
+- Migrating the repo away from Bun.
+- Converting the project to a different testing framework.
+- Refactoring unrelated runtime behavior under the guise of typing cleanup.
+
+## Definition of Done
+
+This PRD is complete when:
+
+1. The repo has a runtime-aware TypeScript configuration layout.
+2. `bunx tsc`-equivalent verification passes across the intended host and extension surfaces.
+3. The verified command is documented and easy to run.
+4. Build and tests still pass afterward.

--- a/scripts/auto-improve/orchestrator.ts
+++ b/scripts/auto-improve/orchestrator.ts
@@ -9,6 +9,14 @@ import { join } from "path";
 import { mkdirSync } from "fs";
 import { $ } from "bun";
 
+type BunCronApi = {
+  (schedule: string, handler: () => void | Promise<void>): Disposable;
+  (path: string, schedule: string, title: string): Promise<void>;
+  remove(title: string): Promise<void>;
+};
+
+const BunWithCron = Bun as typeof Bun & { cron: BunCronApi };
+
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 const disable = args.includes("--disable");
@@ -16,7 +24,7 @@ const enable = args.includes("--enable");
 
 if (disable) {
   try {
-    await Bun.cron.remove("slop-auto-improve");
+    await BunWithCron.cron.remove("slop-auto-improve");
     console.log("Cron job removed.");
   } catch {
     console.log("No cron job to remove.");
@@ -25,7 +33,7 @@ if (disable) {
 }
 
 if (enable) {
-  await Bun.cron(
+  await BunWithCron.cron(
     join(import.meta.dir, "orchestrator.ts"),
     config.cron,
     "slop-auto-improve"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}

--- a/tsconfig.extension.json
+++ b/tsconfig.extension.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "WebWorker"],
+    "types": ["chrome"]
+  },
+  "include": [
+    "extension/src/**/*.ts"
+  ]
+}

--- a/tsconfig.host.json
+++ b/tsconfig.host.json
@@ -1,14 +1,12 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable", "WebWorker"],
-    "types": ["bun", "chrome"]
+    "types": ["bun"]
   },
   "include": [
     "cli/**/*.ts",
     "daemon/**/*.ts",
     "shared/**/*.ts",
-    "extension/src/**/*.ts",
     "scripts/**/*.ts",
     "test/**/*.ts"
   ]


### PR DESCRIPTION
## Summary
- restore real TypeScript coverage across Bun host code and Chrome extension code
- add runtime-aware tsconfig files, a repo `typecheck` script, and architecture/readme docs
- fix the remaining strict-mode host and extension typing issues so both `bun run typecheck` and root `bunx tsc --noEmit` pass

## Verification
- bunx tsc --noEmit
- bun run typecheck
- bash scripts/build.sh
- bun test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development verification guide to README documenting validation commands.
  * Added architecture documentation outlining the runtime structure and component organization.

* **Chores**
  * Enhanced TypeScript configuration with runtime-aware type checking.
  * Improved type safety across CLI, daemon, and extension code.
  * Added stricter null-checking and error handling throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->