### PR TITLE
feat: compound commands (open, read, act, inspect) + SW keepalive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,18 @@ Browser control CLI for AI agents. No CDP, no MCP, no API keys. You call `slop`,
 ## Start Here
 
 ```bash
+slop open "https://example.com"        # Open, wait, return tree + text (1 command)
+slop act e1                            # Click element, return updated tree + diff
+slop act e2 "hello"                    # Type into field, return updated tree
+slop read                              # Re-read current page (tree + text)
+slop inspect                           # Tree + text + network log + headers
+```
+
+The daemon auto-starts. No setup needed.
+
+### Legacy (still works, but prefer compound commands above)
+
+```bash
 slop tab new "https://example.com"    # Open managed tab
 sleep 2                                # Wait for load
 slop tree                              # See interactive elements
@@ -15,11 +27,34 @@ slop type e2 "hello"                   # Type into field
 slop text                              # Read visible text
 ```
 
-The daemon auto-starts. No setup needed.
-
 ## Use Cases
 
 The [`use-cases/`](use-cases/) folder is where proven browser workflows get turned into reusable documentation. When you figure out how to do something reliably on a live site, add a compact use-case there so later agents can follow the path instead of burning tokens rediscovering it.
+
+## Compound Commands (Agent-Optimized)
+
+These collapse multi-step patterns into single CLI invocations. Prefer these over the individual commands below.
+
+```bash
+slop open "https://example.com"        # tab new + wait + tree + text in one call
+slop open "https://example.com" --tree-only   # Skip text
+slop open "https://example.com" --text-only   # Skip tree
+slop open "https://example.com" --full        # Full text (no 2000-char limit)
+slop open "https://example.com" --timeout 10000  # Custom wait timeout
+slop open "https://example.com" --no-wait     # Don't wait for load
+slop read                              # Tree + text for current page
+slop read e5                           # Tree + text for element subtree
+slop read --tree-only                  # Just tree
+slop read --text-only                  # Just text
+slop act e5                            # Click + wait + return updated tree + diff
+slop act e3 "hello"                    # Type + wait + return updated tree
+slop act e5 --os                       # OS-level trusted click
+slop act e5 --keys "Enter"             # Send keyboard shortcut instead
+slop act e5 --no-read                  # Skip post-action tree read
+slop inspect                           # Tree + text + net log + headers
+slop inspect --net-only                # Just network data
+slop inspect --filter api              # Filter network entries
+```
 
 ## Reading Pages
 
@@ -257,46 +292,34 @@ Pass `--any-tab` to operate on any tab.
 
 ### Fill out a form
 ```bash
-slop tab new "https://app.example.com/signup"
-sleep 3
-slop tree
-slop type e5 "user@example.com"
-slop type e7 "password123"
-slop click e9                          # Submit button
-sleep 2
-slop text                              # Read result
+slop open "https://app.example.com/signup"
+slop act e5 "user@example.com"
+slop act e7 "password123"
+slop act e9                            # Submit button
+slop read                              # Read result
 ```
 
 ### Extract API data from an SPA
 ```bash
-slop tab new "https://app.example.com/dashboard"
-sleep 5
-slop net log --filter api              # See what APIs the page called
-slop net headers --filter api          # See auth headers / tokens
+slop open "https://app.example.com/dashboard"
+slop inspect --filter api              # Tree + text + API network calls + headers
 ```
 
 ### Monitor a page for changes
 ```bash
-slop tab new "https://example.com/status"
-sleep 3
-slop tree                              # Baseline
+slop open "https://example.com/status"
 # ... time passes ...
 slop diff                              # What changed
-slop text                              # Current state
+slop read                              # Current state
 ```
 
 ### Navigate a multi-step flow
 ```bash
-slop tab new "https://example.com"
-sleep 2
-slop tree                              # See what's on page
-slop click e12                         # Click "Next"
-sleep 1
-slop tree                              # See new page
-slop type e5 "search query"            # Fill field
-slop click e8                          # Submit
-sleep 2
-slop text                              # Read results
+slop open "https://example.com"
+slop act e12                           # Click "Next", get updated tree
+slop act e5 "search query"             # Fill field
+slop act e8                            # Submit
+slop read                              # Read results
 slop tab close
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,15 +81,16 @@ bash scripts/build.sh # Build compiled host binaries and extension bundles
 ## Quick Start
 
 ```bash
-slop tab new "https://example.com"   # Open a managed tab
-sleep 2                               # Wait for load
-slop tree                             # See what's interactive
-slop click e1                         # Click element by ref
-slop type e2 "hello world"            # Type into a field
-slop text                             # Read visible text
+slop open "https://example.com"       # Open, wait, return tree + text (1 command)
+slop act e1                            # Click element, return updated tree + diff
+slop act e2 "hello world"              # Type into field, return updated tree
+slop read                              # Re-read current page (tree + text)
+slop inspect                           # Tree + text + network log + headers
 ```
 
 Once installed, the daemon auto-starts on first command. No manual launch needed.
+
+The legacy individual commands (`slop tab new`, `slop tree`, `slop click`, etc.) still work, but the compound commands above are preferred — they reduce round-trips and agent deliberation time.
 
 ## Core Concepts
 
@@ -108,6 +109,29 @@ Once installed, the daemon auto-starts on first command. No manual launch needed
 **Use Cases** — The [`use-cases/`](use-cases/) folder is the cookbook for workflows we have already proven in live pages. When a browser workflow is discovered or stabilized, document the exact path there so future agents can reuse it instead of rediscovering it.
 
 ## Commands
+
+### Compound Commands (Agent-Optimized)
+
+These collapse multi-step patterns into single CLI invocations:
+
+```bash
+slop open "https://example.com"        # Open URL, wait, return tree + text
+slop open "https://example.com" --tree-only   # Skip text
+slop open "https://example.com" --text-only   # Skip tree
+slop open "https://example.com" --full        # Full text (no 2000-char limit)
+slop open "https://example.com" --no-wait     # Don't wait for load
+slop read                              # Tree + text for current page
+slop read e5                           # Tree + text for element subtree
+slop read --tree-only                  # Just tree
+slop act e5                            # Click + wait + return updated tree + diff
+slop act e3 "hello"                    # Type + wait + return updated tree
+slop act e5 --os                       # OS-level trusted click
+slop act e5 --keys "Enter"             # Send keyboard shortcut instead
+slop act e5 --no-read                  # Skip post-action tree read
+slop inspect                           # Tree + text + network log + headers
+slop inspect --net-only                # Just network data
+slop inspect --filter api              # Filter network entries
+```
 
 ### Read the Page
 ```bash

--- a/cli/commands/compound.ts
+++ b/cli/commands/compound.ts
@@ -1,0 +1,452 @@
+/**
+ * cli/commands/compound.ts — slop open, read, act, inspect
+ *
+ * Compound commands that collapse multi-step patterns into single CLI invocations.
+ * Each command issues multiple sequential daemon requests via sendCommand() and
+ * combines the results into a single output.
+ */
+
+import { sendCommand, sendCommandWs, type DaemonResponse } from "../transport"
+import { parseElementTarget } from "../parse"
+
+type Action = { type: string; [key: string]: unknown }
+type Result = { success: boolean; error?: string; data?: unknown; tabId?: number }
+
+function unwrap(resp: DaemonResponse): Result {
+  return resp.result
+}
+
+function textData(result: Result): string {
+  if (!result.success) return ""
+  if (typeof result.data === "string") return result.data
+  if (result.data === undefined || result.data === null) return ""
+  return JSON.stringify(result.data, null, 2)
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  return text.slice(0, maxChars) + "\n... (truncated)"
+}
+
+async function send(action: Action, tabId?: number, useWs = false): Promise<Result> {
+  try {
+    const resp = useWs
+      ? await sendCommandWs(action, tabId)
+      : await sendCommand(action, tabId)
+    return unwrap(resp)
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+// ── slop open <url> ──────────────────────────────────────────────────────────
+
+export async function runOpen(
+  filtered: string[],
+  globalTabId?: number,
+  jsonMode = false,
+  useWs = false
+): Promise<void> {
+  const url = filtered[1]
+  if (!url) {
+    console.error("error: slop open requires a URL. Usage: slop open <url>")
+    process.exit(1)
+  }
+
+  const treeOnly = filtered.includes("--tree-only")
+  const textOnly = filtered.includes("--text-only")
+  const full = filtered.includes("--full")
+  const noWait = filtered.includes("--no-wait")
+  const timeoutIdx = filtered.indexOf("--timeout")
+  const timeout = timeoutIdx !== -1 ? parseInt(filtered[timeoutIdx + 1]) : 5000
+
+  // Step 1: Create tab
+  const createResult = await send({ type: "tab_create", url }, globalTabId, useWs)
+  if (!createResult.success) {
+    output(jsonMode, { success: false, error: createResult.error || "failed to create tab" })
+    return
+  }
+  const dataObj = (typeof createResult.data === "object" && createResult.data) ? createResult.data as Record<string, unknown> : {}
+  const tabId = (dataObj.tabId as number) || createResult.tabId || globalTabId
+
+  if (noWait) {
+    output(jsonMode, { success: true, data: { tabId, url, message: "tab created (no-wait)" } })
+    return
+  }
+
+  // Step 2: Wait for content script + DOM stability (retry for new tab load)
+  const waitDeadline = Date.now() + timeout
+  let waitOk = false
+  while (Date.now() < waitDeadline) {
+    try {
+      const waitResult = await send({ type: "wait_stable", ms: 200, timeout: Math.min(3000, waitDeadline - Date.now()) }, tabId, useWs)
+      if (waitResult.success) { waitOk = true; break }
+    } catch {}
+    await Bun.sleep(500)
+  }
+  if (!waitOk) {
+    // Proceed anyway with whatever tree/text is available
+  }
+
+  // Step 3 & 4: Get tree and/or text
+  const parts: string[] = []
+  let treeData = ""
+  let textContent = ""
+
+  if (!textOnly) {
+    const treeResult = await send(
+      { type: "get_a11y_tree", depth: 15, filter: "interactive", maxChars: 50000 },
+      tabId, useWs
+    )
+    treeData = textData(treeResult)
+  }
+
+  if (!treeOnly) {
+    const textResult = await send({ type: "extract_text" }, tabId, useWs)
+    textContent = textData(textResult)
+    if (!full) textContent = truncateText(textContent, 2000)
+  }
+
+  if (jsonMode) {
+    output(jsonMode, {
+      success: true,
+      data: { tabId, url, tree: treeData || undefined, text: textContent || undefined }
+    })
+    return
+  }
+
+  // Pretty output
+  parts.push(`Tab: ${tabId} | ${url}`)
+  if (treeData) {
+    parts.push("")
+    parts.push(treeData)
+  }
+  if (textContent && treeData) {
+    parts.push("")
+    parts.push("---")
+  }
+  if (textContent) {
+    parts.push(textContent)
+  }
+  console.log(parts.join("\n"))
+}
+
+// ── slop read [ref] ──────────────────────────────────────────────────────────
+
+export async function runRead(
+  filtered: string[],
+  globalTabId?: number,
+  jsonMode = false,
+  useWs = false
+): Promise<void> {
+  const treeOnly = filtered.includes("--tree-only")
+  const textOnly = filtered.includes("--text-only")
+  const full = filtered.includes("--full")
+  const filterIdx = filtered.indexOf("--filter")
+  const filterMode = filterIdx !== -1 ? filtered[filterIdx + 1] : "interactive"
+
+  // Check for optional ref argument (skip flags)
+  const refArg = filtered[1] && !filtered[1].startsWith("--") ? filtered[1] : undefined
+  const target = refArg ? parseElementTarget(refArg) : {}
+
+  const parts: string[] = []
+  let treeData = ""
+  let textContent = ""
+
+  if (!textOnly) {
+    const treeResult = await send(
+      { type: "get_a11y_tree", depth: 15, filter: filterMode, maxChars: 50000 },
+      globalTabId, useWs
+    )
+    treeData = textData(treeResult)
+  }
+
+  if (!treeOnly) {
+    const textAction: Action = { type: "extract_text", ...target }
+    const textResult = await send(textAction, globalTabId, useWs)
+    textContent = textData(textResult)
+    if (!full) textContent = truncateText(textContent, 2000)
+  }
+
+  if (jsonMode) {
+    output(jsonMode, {
+      success: true,
+      data: { tree: treeData || undefined, text: textContent || undefined }
+    })
+    return
+  }
+
+  if (treeData) parts.push(treeData)
+  if (textContent && treeData) {
+    parts.push("")
+    parts.push("---")
+  }
+  if (textContent) parts.push(textContent)
+  console.log(parts.join("\n"))
+}
+
+// ── slop act <ref> [value] ───────────────────────────────────────────────────
+
+export async function runAct(
+  filtered: string[],
+  globalTabId?: number,
+  jsonMode = false,
+  useWs = false
+): Promise<void> {
+  const ref = filtered[1]
+  if (!ref) {
+    console.error("error: slop act requires a ref. Usage: slop act <ref> [value]")
+    process.exit(1)
+  }
+
+  const useOs = filtered.includes("--os")
+  const append = filtered.includes("--append")
+  const noRead = filtered.includes("--no-read")
+  const keysIdx = filtered.indexOf("--keys")
+  const timeoutIdx = filtered.indexOf("--timeout")
+  const timeout = timeoutIdx !== -1 ? parseInt(filtered[timeoutIdx + 1]) : 2000
+
+  // Find value: everything after ref that isn't a flag
+  const flagSet = new Set(["--os", "--append", "--no-read", "--keys", "--timeout"])
+  const valueArgs: string[] = []
+  let skip = false
+  for (let i = 2; i < filtered.length; i++) {
+    if (skip) { skip = false; continue }
+    if (filtered[i] === "--timeout" || filtered[i] === "--keys") { skip = true; continue }
+    if (flagSet.has(filtered[i])) continue
+    valueArgs.push(filtered[i])
+  }
+  const value = valueArgs.length > 0 ? valueArgs.join(" ") : undefined
+
+  const target = parseElementTarget(ref)
+
+  // Step 1: Perform the action (may throw if click navigates the page)
+  let actionResult: Result
+  let actionNavigated = false
+
+  try {
+  if (keysIdx !== -1) {
+    const keys = filtered[keysIdx + 1]
+    if (useOs) {
+      const keyParts = keys.split("+")
+      const key = keyParts[keyParts.length - 1]
+      const modifiers = keyParts.slice(0, -1)
+      actionResult = await send({ type: "os_key", key, modifiers }, globalTabId, useWs)
+    } else {
+      actionResult = await send({ type: "send_keys", keys }, globalTabId, useWs)
+    }
+  } else if (value !== undefined) {
+    // Type
+    if (useOs) {
+      actionResult = await send({ type: "os_type", ...target, text: value }, globalTabId, useWs)
+    } else if (target.semantic) {
+      actionResult = await send(
+        { type: "find_and_type", name: target.semantic.name, role: target.semantic.role, inputText: value, clear: !append },
+        globalTabId, useWs
+      )
+    } else {
+      actionResult = await send(
+        { type: "input_text", ...target, text: value, clear: !append },
+        globalTabId, useWs
+      )
+    }
+  } else {
+    // Click
+    if (useOs) {
+      actionResult = await send({ type: "os_click", ...target }, globalTabId, useWs)
+    } else if (target.semantic) {
+      actionResult = await send(
+        { type: "find_and_click", name: target.semantic.name, role: target.semantic.role },
+        globalTabId, useWs
+      )
+    } else {
+      actionResult = await send({ type: "click", ...target }, globalTabId, useWs)
+    }
+  }
+
+  } catch (err) {
+    // Click succeeded but page navigated, breaking the response port
+    const msg = (err as Error).message || ""
+    if (msg.includes("back/forward cache") || msg.includes("message channel is closed") || msg.includes("timeout")) {
+      actionNavigated = true
+      actionResult = { success: true }
+    } else {
+      output(jsonMode, { success: false, error: msg })
+      return
+    }
+  }
+
+  if (!actionResult!.success) {
+    const errMsg = actionResult!.error || "action failed"
+    if (errMsg.includes("back/forward cache") || errMsg.includes("message channel is closed")) {
+      actionNavigated = true
+    } else {
+      output(jsonMode, { success: false, error: errMsg })
+      return
+    }
+  }
+
+  if (actionNavigated) {
+    if (jsonMode) {
+      output(jsonMode, { success: true, data: { action: "ok", note: "page navigated — use slop read to see the new page" } })
+    } else {
+      console.log("ok (page navigated — use slop read to see the new page)")
+    }
+    return
+  }
+
+  if (noRead) {
+    output(jsonMode, { success: true, data: "ok" })
+    return
+  }
+
+  // Step 2: Wait for DOM stability (may fail if page navigated)
+  let treeResult: Result = { success: false }
+  let diffResult: Result = { success: false }
+  try {
+    await send({ type: "wait_stable", ms: 200, timeout }, globalTabId, useWs)
+
+    // Step 3: Get updated tree + diff
+    treeResult = await send(
+      { type: "get_a11y_tree", depth: 15, filter: "interactive", maxChars: 50000 },
+      globalTabId, useWs
+    )
+    diffResult = await send({ type: "diff" }, globalTabId, useWs)
+  } catch {
+    // Page likely navigated — action succeeded but post-read failed
+    if (jsonMode) {
+      output(jsonMode, { success: true, data: { action: "ok", note: "page navigated, post-action read unavailable" } })
+    } else {
+      console.log("ok (page navigated — use slop read to see the new page)")
+    }
+    return
+  }
+
+  const treeData = textData(treeResult)
+  const diffData = textData(diffResult)
+
+  if (jsonMode) {
+    output(jsonMode, {
+      success: true,
+      data: { tree: treeData || undefined, diff: diffData || undefined }
+    })
+    return
+  }
+
+  const parts: string[] = []
+  if (treeData) parts.push(treeData)
+  if (diffData) {
+    parts.push("")
+    parts.push("--- diff ---")
+    parts.push(diffData)
+  }
+  console.log(parts.join("\n"))
+}
+
+// ── slop inspect ─────────────────────────────────────────────────────────────
+
+export async function runInspect(
+  filtered: string[],
+  globalTabId?: number,
+  jsonMode = false,
+  useWs = false
+): Promise<void> {
+  const netOnly = filtered.includes("--net-only")
+  const limitIdx = filtered.indexOf("--limit")
+  const limit = limitIdx !== -1 ? parseInt(filtered[limitIdx + 1]) : 10
+  const filterIdx = filtered.indexOf("--filter")
+  const filterPattern = filterIdx !== -1 ? filtered[filterIdx + 1] : undefined
+
+  const parts: string[] = []
+  let treeData = ""
+  let textContent = ""
+
+  if (!netOnly) {
+    const treeResult = await send(
+      { type: "get_a11y_tree", depth: 15, filter: "interactive", maxChars: 50000 },
+      globalTabId, useWs
+    )
+    treeData = textData(treeResult)
+
+    const textResult = await send({ type: "extract_text" }, globalTabId, useWs)
+    textContent = truncateText(textData(textResult), 2000)
+  }
+
+  const netLogResult = await send(
+    { type: "net_log", filter: filterPattern, limit },
+    globalTabId, useWs
+  )
+  const netHeadersResult = await send(
+    { type: "net_headers", filter: filterPattern },
+    globalTabId, useWs
+  )
+
+  const netLogData = textData(netLogResult)
+  const netHeadersData = textData(netHeadersResult)
+
+  if (jsonMode) {
+    output(jsonMode, {
+      success: true,
+      data: {
+        tree: treeData || undefined,
+        text: textContent || undefined,
+        netLog: netLogResult.success ? netLogResult.data : undefined,
+        netHeaders: netHeadersResult.success ? netHeadersResult.data : undefined
+      }
+    })
+    return
+  }
+
+  if (treeData) parts.push(treeData)
+  if (textContent) {
+    parts.push("")
+    parts.push("--- text ---")
+    parts.push(textContent)
+  }
+  if (netLogData) {
+    parts.push("")
+    parts.push("--- network log ---")
+    parts.push(netLogData)
+  }
+  if (netHeadersData) {
+    parts.push("")
+    parts.push("--- request headers ---")
+    parts.push(netHeadersData)
+  }
+  console.log(parts.join("\n"))
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function output(jsonMode: boolean, result: { success: boolean; error?: string; data?: unknown }): void {
+  if (jsonMode) {
+    console.log(JSON.stringify(result, null, 2))
+  } else if (!result.success) {
+    console.error(`error: ${result.error}`)
+    process.exit(1)
+  } else if (typeof result.data === "string") {
+    console.log(result.data)
+  } else if (result.data) {
+    console.log(JSON.stringify(result.data, null, 2))
+  } else {
+    console.log("ok")
+  }
+}
+
+// ── Dispatcher ───────────────────────────────────────────────────────────────
+
+export async function runCompoundCommand(
+  cmd: string,
+  filtered: string[],
+  opts: { jsonMode?: boolean; useWs?: boolean; globalTabId?: number; anyTab?: boolean }
+): Promise<void> {
+  switch (cmd) {
+    case "open":    return runOpen(filtered, opts.globalTabId, opts.jsonMode, opts.useWs)
+    case "read":    return runRead(filtered, opts.globalTabId, opts.jsonMode, opts.useWs)
+    case "act":     return runAct(filtered, opts.globalTabId, opts.jsonMode, opts.useWs)
+    case "inspect":  return runInspect(filtered, opts.globalTabId, opts.jsonMode, opts.useWs)
+    default:
+      console.error(`error: unknown compound command '${cmd}'`)
+      process.exit(1)
+  }
+}

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -1,5 +1,24 @@
 export const HELP = `slop — browser control CLI
 
+Compound (agent-optimized):
+  slop open <url>                     Open URL, wait, return tree + text
+  slop open <url> --tree-only         Skip text, return only tree
+  slop open <url> --text-only         Skip tree, return only text
+  slop open <url> --full              Full text instead of 2000-char summary
+  slop open <url> --timeout <ms>      Override wait-stable timeout (default 5000)
+  slop open <url> --no-wait           Return immediately after tab creation
+  slop read                           Tree + text for active tab
+  slop read <ref>                     Tree + text for element subtree
+  slop read --tree-only               Skip text
+  slop read --text-only               Skip tree
+  slop act <ref>                      Click + wait + return updated tree + diff
+  slop act <ref> "value"              Type into field + wait + return updated tree
+  slop act <ref> --os                 Use OS-level trusted input
+  slop act <ref> --keys "Enter"       Send keyboard shortcut instead
+  slop act <ref> --no-read            Skip post-action tree read
+  slop inspect                        Tree + text + network log + headers
+  slop inspect --net-only             Skip tree/text, return only network data
+
 State:
   slop state                          Current page DOM tree + metadata
   slop state --full                   Include static text content

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -18,6 +18,7 @@ import { parseMonitorCommand } from "./commands/monitor"
 import { parseSceneCommand } from "./commands/scene"
 import { parseSseCommand } from "./commands/sse"
 import { parseChatgptCommand } from "./commands/chatgpt"
+import { runCompoundCommand } from "./commands/compound"
 
 // Command → module routing
 const STATE_CMDS = new Set(["state", "tree", "diff", "find", "text", "html"])
@@ -35,6 +36,7 @@ const MONITOR_CMDS = new Set(["monitor"])
 const SCENE_CMDS = new Set(["scene"])
 const SSE_CMDS = new Set(["sse"])
 const CHATGPT_CMDS = new Set(["chatgpt"])
+const COMPOUND_CMDS = new Set(["open", "read", "act", "inspect"])
 
 // Commands that don't require a daemon connection
 const NO_DAEMON = new Set(["status", "help", "events", "session"])
@@ -76,6 +78,11 @@ async function main() {
 
   // Dispatch to command module
   let action: { type: string; [key: string]: unknown } | null
+
+  if (COMPOUND_CMDS.has(cmd)) {
+    await runCompoundCommand(cmd, filtered, { jsonMode, useWs, globalTabId, anyTab })
+    return
+  }
 
   if (STATE_CMDS.has(cmd))       action = parseStateCommand(filtered)
   else if (ACTION_CMDS.has(cmd)) action = parseActionsCommand(filtered)

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,4 +1,4 @@
-import { connectToHost, connectWsChannel, registerAlarmListener } from "./background/transport"
+import { connectToHost, connectWsChannel, registerAlarmListener, registerSwKeepaliveListener } from "./background/transport"
 import { registerCdpListeners } from "./background/cdp"
 import { registerTabGroupListeners, ensureSlopGroup } from "./background/tab-group"
 
@@ -6,6 +6,7 @@ import { registerTabGroupListeners, ensureSlopGroup } from "./background/tab-gro
 registerCdpListeners()
 registerTabGroupListeners()
 registerAlarmListener()
+registerSwKeepaliveListener()
 
 // Startup connections
 chrome.runtime.onInstalled.addListener(() => {

--- a/extension/src/background/transport.ts
+++ b/extension/src/background/transport.ts
@@ -165,6 +165,23 @@ export function connectWsChannel(): void {
   } catch {}
 }
 
+// --- SW Keepalive responder (content script heartbeat) ---
+let lastSwKeepalive = 0
+
+export function registerSwKeepaliveListener(): void {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type !== "sw_keepalive") return false
+    const now = Date.now()
+    if (now - lastSwKeepalive < 20_000) {
+      sendResponse({ leader: false })
+    } else {
+      lastSwKeepalive = now
+      sendResponse({ leader: true })
+    }
+    return false
+  })
+}
+
 export function registerAlarmListener(): void {
   chrome.alarms.create("keepalive", { periodInMinutes: 0.5 })
   chrome.alarms.onAlarm.addListener((alarm) => {

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -209,3 +209,16 @@ async function executeAction(action: Action): Promise<ActionResult> {
     return { success: false, error: (err as Error).message }
   }
 }
+
+// --- SW Keepalive Heartbeat (leader-elected, zero network) ---
+let _swKeepaliveLeader = true
+setInterval(() => {
+  if (!_swKeepaliveLeader) return
+  try {
+    chrome.runtime.sendMessage({ type: "sw_keepalive" })
+      .then((resp: { leader?: boolean } | undefined) => {
+        if (resp && resp.leader === false) _swKeepaliveLeader = false
+      })
+      .catch(() => {})
+  } catch {}
+}, 25_000)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "./scripts/build.sh",
-    "typecheck": "bunx tsc -p tsconfig.host.json && bunx tsc -p tsconfig.extension.json",
+    "typecheck": "bunx tsc -p tsconfig.host.json && bunx tsc -p tsconfig.extension.json && bunx tsc -p tsconfig.json",
     "daemon": "bun run daemon/index.ts",
     "cli": "bun run cli/index.ts"
   },


### PR DESCRIPTION
Add agent-optimized compound commands that collapse multi-step patterns into single CLI invocations:

- **`slop open`**: tab new + wait + tree + text in one call
- **`slop read`**: tree + text for current page or element subtree
- **`slop act`**: click/type + wait + return updated tree + diff
- **`slop inspect`**: tree + text + network log + headers

Also adds a service worker keepalive heartbeat from content script to prevent Chrome from suspending the extension background during long sessions.

Updates CLAUDE.md, README.md, and help text with compound command documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced four compound commands that consolidate multi-step workflows into single operations
  * Added command-line options for controlling data output format, synchronization behavior, and input modes

* **Documentation**
  * Updated guides with simplified workflow examples and comprehensive documentation for new command options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->