### PR TITLE
Fix transport fallback and compound read errors

### DIFF
--- a/cli/commands/compound.ts
+++ b/cli/commands/compound.ts
@@ -11,6 +11,13 @@ import { parseElementTarget } from "../parse"
 
 type Action = { type: string; [key: string]: unknown }
 type Result = { success: boolean; error?: string; data?: unknown; tabId?: number }
+type ReadAggregate = {
+  success: boolean
+  tree?: string
+  text?: string
+  error?: string
+  warnings?: string[]
+}
 
 function unwrap(resp: DaemonResponse): Result {
   return resp.result
@@ -37,6 +44,41 @@ async function send(action: Action, tabId?: number, useWs = false): Promise<Resu
   } catch (err) {
     return { success: false, error: (err as Error).message }
   }
+}
+
+export function aggregateReadResults(opts: {
+  treeRequested: boolean
+  textRequested: boolean
+  treeResult?: Result
+  textResult?: Result
+  full?: boolean
+}): ReadAggregate {
+  const warnings: string[] = []
+  let tree = ""
+  let text = ""
+
+  if (opts.treeRequested) {
+    if (opts.treeResult?.success) tree = textData(opts.treeResult)
+    else if (opts.treeResult?.error) warnings.push(`tree: ${opts.treeResult.error}`)
+  }
+
+  if (opts.textRequested) {
+    if (opts.textResult?.success) {
+      text = textData(opts.textResult)
+      if (!opts.full) text = truncateText(text, 2000)
+    } else if (opts.textResult?.error) {
+      warnings.push(`text: ${opts.textResult.error}`)
+    }
+  }
+
+  const anyRequested = opts.treeRequested || opts.textRequested
+  const anySucceeded = (!!tree && opts.treeRequested) || (!!text && opts.textRequested)
+
+  if (anyRequested && !anySucceeded && warnings.length > 0) {
+    return { success: false, error: warnings.join("; "), warnings }
+  }
+
+  return { success: true, tree: tree || undefined, text: text || undefined, warnings }
 }
 
 // ── interceptor open <url> ──────────────────────────────────────────────────────────
@@ -92,28 +134,46 @@ export async function runOpen(
   const parts: string[] = []
   let treeData = ""
   let textContent = ""
+  let treeResult: Result | undefined
+  let textResult: Result | undefined
 
   if (!textOnly) {
-    const treeResult = await send(
+    treeResult = await send(
       { type: "get_a11y_tree", depth: 15, filter: "interactive", maxChars: 50000 },
       tabId, useWs
     )
-    treeData = textData(treeResult)
   }
 
   if (!treeOnly) {
-    const textResult = await send({ type: "extract_text" }, tabId, useWs)
-    textContent = textData(textResult)
-    if (!full) textContent = truncateText(textContent, 2000)
+    textResult = await send({ type: "extract_text" }, tabId, useWs)
   }
 
-  if (jsonMode) {
-    output(jsonMode, {
-      success: true,
-      data: { tabId, url, tree: treeData || undefined, text: textContent || undefined }
-    })
+  const aggregate = aggregateReadResults({
+    treeRequested: !textOnly,
+    textRequested: !treeOnly,
+    treeResult,
+    textResult,
+    full
+  })
+
+  if (!aggregate.success) {
+    output(jsonMode, { success: false, error: aggregate.error || "could not read page" })
     return
   }
+  treeData = aggregate.tree || ""
+  textContent = aggregate.text || ""
+
+  if (jsonMode) {
+    const result: { success: boolean; data?: unknown; warning?: string } = {
+      success: true,
+      data: { tabId, url, tree: treeData || undefined, text: textContent || undefined }
+    }
+    if (aggregate.warnings?.length) result.warning = aggregate.warnings.join("; ")
+    output(jsonMode, result)
+    return
+  }
+
+  if (aggregate.warnings?.length) console.error(`warning: ${aggregate.warnings.join("; ")}`)
 
   // Pretty output
   parts.push(`Tab: ${tabId} | ${url}`)
@@ -152,29 +212,47 @@ export async function runRead(
   const parts: string[] = []
   let treeData = ""
   let textContent = ""
+  let treeResult: Result | undefined
+  let textResult: Result | undefined
 
   if (!textOnly) {
-    const treeResult = await send(
+    treeResult = await send(
       { type: "get_a11y_tree", depth: 15, filter: filterMode, maxChars: 50000 },
       globalTabId, useWs
     )
-    treeData = textData(treeResult)
   }
 
   if (!treeOnly) {
     const textAction: Action = { type: "extract_text", ...target }
-    const textResult = await send(textAction, globalTabId, useWs)
-    textContent = textData(textResult)
-    if (!full) textContent = truncateText(textContent, 2000)
+    textResult = await send(textAction, globalTabId, useWs)
   }
 
-  if (jsonMode) {
-    output(jsonMode, {
-      success: true,
-      data: { tree: treeData || undefined, text: textContent || undefined }
-    })
+  const aggregate = aggregateReadResults({
+    treeRequested: !textOnly,
+    textRequested: !treeOnly,
+    treeResult,
+    textResult,
+    full
+  })
+
+  if (!aggregate.success) {
+    output(jsonMode, { success: false, error: aggregate.error || "could not read page" })
     return
   }
+  treeData = aggregate.tree || ""
+  textContent = aggregate.text || ""
+
+  if (jsonMode) {
+    const result: { success: boolean; data?: unknown; warning?: string } = {
+      success: true,
+      data: { tree: treeData || undefined, text: textContent || undefined }
+    }
+    if (aggregate.warnings?.length) result.warning = aggregate.warnings.join("; ")
+    output(jsonMode, result)
+    return
+  }
+
+  if (aggregate.warnings?.length) console.error(`warning: ${aggregate.warnings.join("; ")}`)
 
   if (treeData) parts.push(treeData)
   if (textContent && treeData) {

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -2,6 +2,7 @@ import { unlinkSync, existsSync, appendFileSync, statSync, readFileSync, writeFi
 import { execSync, spawn } from "node:child_process"
 import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-loader"
 import { IS_WIN, SOCKET_PATH, IPC_PORT, PID_PATH, LOG_PATH, EVENTS_PATH, WS_PORT, EVENTS_MAX_SIZE, transportLabel } from "../shared/platform"
+import { chooseOutboundTransport } from "./outbound-routing"
 
 // ── Native Bridge (interceptor-bridge) connection ────────────────────────────────
 const BRIDGE_SOCKET_PATH = "/tmp/interceptor-bridge.sock"
@@ -190,39 +191,43 @@ log(`daemon starting (mode: ${STANDALONE ? "standalone" : "native-messaging"})`)
 async function startNativeRelay(existingPid: number): Promise<never> {
   log(`relay mode: bridging native messaging to singleton (pid ${existingPid})`)
 
-  const connectOpts = IS_WIN
-    ? { hostname: "127.0.0.1", port: IPC_PORT }
-    : { unix: SOCKET_PATH }
-
   let singletonSocket: Bun.Socket<undefined> | null = null
 
   try {
-    singletonSocket = await Bun.connect<undefined>({
-      ...connectOpts,
-      socket: {
-        open(socket: Bun.Socket<undefined>) {
-          // Register as native relay — singleton routes traffic to handleNativeMessage
-          const reg = JSON.stringify({ type: "native-relay" })
-          const encoded = Buffer.from(reg, "utf-8")
-          const header = Buffer.alloc(4)
-          header.writeUInt32LE(encoded.byteLength, 0)
-          socket.write(Buffer.concat([header, encoded]))
-          log("relay: registered with singleton")
-        },
-        data(_socket: Bun.Socket<undefined>, raw: Buffer<ArrayBufferLike>) {
-          // Singleton → stdout (Chrome)
-          process.stdout.write(Buffer.from(raw))
-        },
-        close() {
-          log("relay: singleton disconnected — exiting")
-          process.exit(0)
-        },
-        error(_socket: Bun.Socket<undefined>, err: Error) {
-          log(`relay: socket error — ${err.message}`)
-          process.exit(1)
-        }
+    const relaySocketHandlers: Bun.SocketHandler<undefined> = {
+      open(socket: Bun.Socket<undefined>) {
+        // Register as native relay — singleton routes traffic to handleNativeMessage
+        const reg = JSON.stringify({ type: "native-relay" })
+        const encoded = Buffer.from(reg, "utf-8")
+        const header = Buffer.alloc(4)
+        header.writeUInt32LE(encoded.byteLength, 0)
+        socket.write(Buffer.concat([header, encoded]))
+        log("relay: registered with singleton")
+      },
+      data(_socket: Bun.Socket<undefined>, raw: Buffer<ArrayBufferLike>) {
+        // Singleton → stdout (Chrome)
+        process.stdout.write(Buffer.from(raw))
+      },
+      close() {
+        log("relay: singleton disconnected — exiting")
+        process.exit(0)
+      },
+      error(_socket: Bun.Socket<undefined>, err: Error) {
+        log(`relay: socket error — ${err.message}`)
+        process.exit(1)
       }
-    })
+    }
+
+    singletonSocket = IS_WIN
+      ? await Bun.connect<undefined>({
+        hostname: "127.0.0.1",
+        port: IPC_PORT,
+        socket: relaySocketHandlers
+      })
+      : await Bun.connect<undefined>({
+        unix: SOCKET_PATH,
+        socket: relaySocketHandlers
+      })
   } catch (err) {
     log(`relay: failed to connect to singleton — exiting: ${(err as Error).message}`)
     process.exit(1)
@@ -449,9 +454,24 @@ function drainWsOutboundQueue(): void {
 
 function sendNativeMessage(msg: unknown): void {
   const json = JSON.stringify(msg)
-  // Prefer native relay — ensures pong reaches Chrome via native messaging path
-  // (extensionWs drops pong because its handler only processes msg.id && msg.action)
-  if (nativeRelaySocket) {
+  const preferred = chooseOutboundTransport(msg, {
+    nativeRelayAvailable: !!nativeRelaySocket,
+    extensionWsAvailable: !!extensionWs,
+    stdinAlive,
+    standalone: STANDALONE
+  })
+
+  if (preferred === "ws" && extensionWs) {
+    log(`forwarding via ws: ${json.slice(0, 200)}`)
+    try {
+      extensionWs.send(json)
+      return
+    } catch (err) {
+      log(`ws send error: ${(err as Error).message}`)
+    }
+  }
+
+  if (preferred === "relay" && nativeRelaySocket) {
     log(`forwarding via relay: ${json.slice(0, 200)}`)
     try {
       socketWriteFramed(nativeRelaySocket, json)
@@ -461,27 +481,51 @@ function sendNativeMessage(msg: unknown): void {
       nativeRelaySocket = null
     }
   }
+
+  if (preferred === "native" && !STANDALONE && stdinAlive) {
+    log(`forwarding via native: ${json.slice(0, 200)}`)
+    const encoded = Buffer.from(json, "utf-8")
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(encoded.byteLength, 0)
+    const combined = Buffer.concat([header, encoded])
+    process.stdout.write(combined)
+    return
+  }
+
   if (extensionWs) {
-    log(`forwarding via ws: ${json.slice(0, 200)}`)
+    log(`fallback via ws: ${json.slice(0, 200)}`)
     try {
       extensionWs.send(json)
       return
     } catch (err) {
-      log(`ws send error: ${(err as Error).message}`)
+      log(`fallback ws send error: ${(err as Error).message}`)
     }
   }
-  if (STANDALONE || !stdinAlive) {
-    if (wsOutboundQueue.length >= WS_QUEUE_CAP) wsOutboundQueue.shift()
-    wsOutboundQueue.push(json)
-    log(`queued for ws (${wsOutboundQueue.length} pending): ${json.slice(0, 100)}`)
+
+  if (nativeRelaySocket) {
+    log(`fallback via relay: ${json.slice(0, 200)}`)
+    try {
+      socketWriteFramed(nativeRelaySocket, json)
+      return
+    } catch (err) {
+      log(`fallback relay send error: ${(err as Error).message}`)
+      nativeRelaySocket = null
+    }
+  }
+
+  if (!STANDALONE && stdinAlive) {
+    log(`fallback via native: ${json.slice(0, 200)}`)
+    const encoded = Buffer.from(json, "utf-8")
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(encoded.byteLength, 0)
+    const combined = Buffer.concat([header, encoded])
+    process.stdout.write(combined)
     return
   }
-  log(`forwarding via native: ${json.slice(0, 200)}`)
-  const encoded = Buffer.from(json, "utf-8")
-  const header = Buffer.alloc(4)
-  header.writeUInt32LE(encoded.byteLength, 0)
-  const combined = Buffer.concat([header, encoded])
-  process.stdout.write(combined)
+
+  if (wsOutboundQueue.length >= WS_QUEUE_CAP) wsOutboundQueue.shift()
+  wsOutboundQueue.push(json)
+  log(`queued for ws (${wsOutboundQueue.length} pending): ${json.slice(0, 100)}`)
 }
 
 let stdinAlive = !STANDALONE

--- a/daemon/outbound-routing.ts
+++ b/daemon/outbound-routing.ts
@@ -1,0 +1,27 @@
+export type OutboundTransport = "relay" | "ws" | "native" | "queue"
+
+export function isControlMessage(msg: unknown): boolean {
+  const candidate = msg as { type?: unknown }
+  return candidate?.type === "ping" || candidate?.type === "pong"
+}
+
+export function chooseOutboundTransport(
+  msg: unknown,
+  state: {
+    nativeRelayAvailable: boolean
+    extensionWsAvailable: boolean
+    stdinAlive: boolean
+    standalone: boolean
+  }
+): OutboundTransport {
+  if (isControlMessage(msg)) {
+    if (state.nativeRelayAvailable) return "relay"
+    if (!state.standalone && state.stdinAlive) return "native"
+    return "queue"
+  }
+
+  if (state.extensionWsAvailable) return "ws"
+  if (state.nativeRelayAvailable) return "relay"
+  if (!state.standalone && state.stdinAlive) return "native"
+  return "queue"
+}

--- a/extension/src/background/content-bridge.ts
+++ b/extension/src/background/content-bridge.ts
@@ -1,8 +1,26 @@
-export async function sendToContentScript(
+import { shouldRetryContentScript } from "../../../shared/content-script-retry"
+
+async function injectContentScript(
+  tabId: number,
+  frameId?: number
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const target = frameId !== undefined
+      ? { tabId, frameIds: [frameId] }
+      : { tabId }
+    await chrome.scripting.executeScript({ target, files: ["content.js"] })
+    await new Promise(resolve => setTimeout(resolve, 200))
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+async function sendToContentScriptOnce(
   tabId: number,
   action: { type: string; [key: string]: unknown },
   frameId?: number
-): Promise<unknown> {
+): Promise<{ success: boolean; error?: string; data?: unknown }> {
   return new Promise((resolve) => {
     const targetFrame = frameId !== undefined ? frameId : 0
     chrome.tabs.sendMessage(
@@ -18,6 +36,31 @@ export async function sendToContentScript(
       }
     )
   })
+}
+
+export async function sendToContentScript(
+  tabId: number,
+  action: { type: string; [key: string]: unknown },
+  frameId?: number
+): Promise<unknown> {
+  const first = await sendToContentScriptOnce(tabId, action, frameId)
+  if (first.success || !shouldRetryContentScript(first.error)) return first
+
+  const injected = await injectContentScript(tabId, frameId)
+  if (!injected.success) {
+    return {
+      success: false,
+      error: `content script unavailable on tab ${tabId} and reinjection failed: ${injected.error}`
+    }
+  }
+
+  const retried = await sendToContentScriptOnce(tabId, action, frameId)
+  if (retried.success) return retried
+
+  return {
+    success: false,
+    error: `content script re-injected on tab ${tabId} but action still failed: ${retried.error || "unknown error"}`
+  }
 }
 
 export async function sendNetDirect(

--- a/prd/PRD-31.md
+++ b/prd/PRD-31.md
@@ -1,0 +1,79 @@
+# PRD-31: Fix Native Transport Hangs, Compound Read False Success, and General Content-Script Recovery
+
+**Status:** Implemented
+**Author:** Codex
+**Date:** 2026-04-16
+**Priority:** P1-High
+**Effort:** M
+**Platform:** Chrome/Brave MV3
+**Category:** Reliability
+
+---
+
+## Goal
+
+Eliminate the intermittent Interceptor failures where the default CLI path times out even though the WebSocket path is healthy, compound read commands return empty success instead of surfacing errors, and ordinary content-script-backed actions do not recover from missing or disconnected content scripts.
+
+---
+
+## Problem Summary
+
+Three distinct defects combine into the observed "sometimes fails" behavior:
+
+1. `daemon/index.ts` prefers the native relay for all outbound extension traffic, even when the WebSocket channel is healthy and the relay/native path is wedged.
+2. `cli/commands/compound.ts` converts subcommand failures into empty strings, so `interceptor read` and `interceptor open` can return success with empty data.
+3. Generic content-script actions rely on one-shot `chrome.tabs.sendMessage()` and do not use the monitor-style reinject-and-retry recovery path.
+
+---
+
+## Implementation Checklist
+
+- [x] Expand the internal todo list before implementation.
+- [x] Create this PRD and keep the checklist current during execution.
+- [x] Fix daemon outbound routing so normal action requests prefer WebSocket when available, while handshake/control messages still use the native relay/native path.
+- [x] Preserve relay/native fallback behavior when WebSocket is unavailable.
+- [x] Add generic content-script reinjection and retry for non-monitor actions.
+- [x] Keep privileged-page failures explicit when reinjection is impossible.
+- [x] Fix compound `open`/`read` error handling so empty success is no longer possible when requested reads fail.
+- [x] Preserve successful partial output behavior only when at least one requested read succeeds.
+- [x] Add tests for outbound transport selection.
+- [x] Add tests for compound command failure surfacing.
+- [x] Run targeted tests and typecheck.
+- [x] Rebuild Interceptor artifacts.
+- [x] Verify the original repro commands on the default transport and on WebSocket.
+- [x] Update this checklist and final status when implementation is complete.
+
+---
+
+## Files Expected To Change
+
+- `daemon/index.ts`
+- `extension/src/background/content-bridge.ts`
+- `cli/commands/compound.ts`
+- `test/*`
+
+---
+
+## Verification Targets
+
+- `interceptor tabs --json` works on the default path when `interceptor tabs --ws --json` already works.
+- `interceptor text` / `tree` / `read` recover from content-script loss when recovery is possible.
+- `interceptor read --json` fails explicitly instead of returning `{ success: true, data: {} }` when both underlying reads fail.
+- `bun test`
+- `bun run typecheck`
+- `bash scripts/build.sh`
+
+---
+
+## Verification Snapshot
+
+- `bun test` passed: 44 tests, 0 failures.
+- `bun run typecheck` passed.
+- `bash scripts/build.sh` passed and rebuilt `extension/dist`, `dist/interceptor`, and `daemon/interceptor-daemon`.
+- Live sequential verification after restarting a single standalone daemon:
+  - `./dist/interceptor tabs --json` succeeded on the default path.
+  - `./dist/interceptor text --tab 1729164954` succeeded on the default path.
+  - `./dist/interceptor tree --filter all --tab 1729164954` succeeded on the default path.
+  - `./dist/interceptor read --json --tab 1729164954` succeeded on the default path and returned both tree and text.
+- Failure surfacing verification:
+  - Before stabilizing the daemon during validation, `./dist/interceptor read --json --tab 1729164954` returned an explicit error instead of false success when both subreads failed.

--- a/shared/content-script-retry.ts
+++ b/shared/content-script-retry.ts
@@ -1,0 +1,10 @@
+export function shouldRetryContentScript(error?: string): boolean {
+  if (!error) return false
+  return (
+    error.includes("Receiving end does not exist") ||
+    error.includes("Could not establish connection") ||
+    error.includes("disconnected port") ||
+    error.includes("message channel is closed") ||
+    error.includes("no response from content script")
+  )
+}

--- a/test/compound.test.ts
+++ b/test/compound.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { aggregateReadResults } from "../cli/commands/compound"
+
+describe("compound read aggregation", () => {
+  test("fails when all requested reads fail", () => {
+    const result = aggregateReadResults({
+      treeRequested: true,
+      textRequested: true,
+      treeResult: { success: false, error: "tree unavailable" },
+      textResult: { success: false, error: "text unavailable" },
+      full: false,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("tree unavailable")
+    expect(result.error).toContain("text unavailable")
+  })
+
+  test("returns partial success when one requested read succeeds", () => {
+    const result = aggregateReadResults({
+      treeRequested: true,
+      textRequested: true,
+      treeResult: { success: true, data: "tree data" },
+      textResult: { success: false, error: "text unavailable" },
+      full: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.tree).toBe("tree data")
+    expect(result.text).toBeUndefined()
+    expect(result.warnings).toContain("text: text unavailable")
+  })
+})
+

--- a/test/content-bridge.test.ts
+++ b/test/content-bridge.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { shouldRetryContentScript } from "../shared/content-script-retry"
+
+describe("content bridge retry classification", () => {
+  test("retries on missing or disconnected content-script errors", () => {
+    expect(shouldRetryContentScript("Could not establish connection. Receiving end does not exist.")).toBe(true)
+    expect(shouldRetryContentScript("Attempting to use a disconnected port object")).toBe(true)
+    expect(shouldRetryContentScript("message channel is closed")).toBe(true)
+    expect(shouldRetryContentScript("no response from content script")).toBe(true)
+  })
+
+  test("does not retry unrelated action errors", () => {
+    expect(shouldRetryContentScript("stale element [3]")).toBe(false)
+    expect(shouldRetryContentScript("tab is not in the interceptor group")).toBe(false)
+  })
+})

--- a/test/transport-routing.test.ts
+++ b/test/transport-routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { chooseOutboundTransport, isControlMessage } from "../daemon/outbound-routing"
+
+describe("daemon outbound transport routing", () => {
+  test("classifies ping/pong as control messages", () => {
+    expect(isControlMessage({ type: "ping" })).toBe(true)
+    expect(isControlMessage({ type: "pong" })).toBe(true)
+    expect(isControlMessage({ id: "1", action: { type: "tab_list" } })).toBe(false)
+  })
+
+  test("prefers websocket for normal action requests", () => {
+    const chosen = chooseOutboundTransport(
+      { id: "1", action: { type: "tab_list" } },
+      { nativeRelayAvailable: true, extensionWsAvailable: true, stdinAlive: false, standalone: true }
+    )
+    expect(chosen).toBe("ws")
+  })
+
+  test("prefers relay for control traffic", () => {
+    const chosen = chooseOutboundTransport(
+      { type: "pong" },
+      { nativeRelayAvailable: true, extensionWsAvailable: true, stdinAlive: false, standalone: true }
+    )
+    expect(chosen).toBe("relay")
+  })
+
+  test("falls back to native stdio when websocket is unavailable", () => {
+    const chosen = chooseOutboundTransport(
+      { id: "1", action: { type: "tab_list" } },
+      { nativeRelayAvailable: false, extensionWsAvailable: false, stdinAlive: true, standalone: false }
+    )
+    expect(chosen).toBe("native")
+  })
+})


### PR DESCRIPTION
## Summary
- route normal extension action traffic over a healthy WebSocket before falling back to relay/native
- retry generic content-script actions by re-injecting `content.js` when messaging fails due to missing/disconnected scripts
- make compound `open`/`read` fail explicitly when both requested reads fail instead of returning empty success
- add PRD-31 and targeted tests for routing, compound aggregation, and retry classification

## Verification
- `bun test`
- `bun run typecheck`
- `bash scripts/build.sh`
- live sequential verification of `interceptor tabs --json`, `text`, `tree`, and `read --json` against tab `1729164954`

Related to #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic message routing for more reliable command delivery
  * Automatic retry logic for failed content script communication

* **Bug Fixes**
  * Improved error handling in read operations to prevent false success reports
  * Better failure reporting with explicit error messages for partial outcomes
  * Enhanced reliability of background-to-content script communication

* **Tests**
  * Added test coverage for read aggregation, content script retry logic, and message routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->