### PR TITLE
feat: ship interceptor-bridge in DMG (PRD-35)

### DIFF
--- a/cli/commands/meta.ts
+++ b/cli/commands/meta.ts
@@ -37,13 +37,46 @@ export async function parseMetaCommand(filtered: string[], jsonMode = false): Pr
       if (daemonPid) statusLines.push(`pid: ${daemonPid}`)
       statusLines.push(`socket: ${sockExists ? SOCKET_PATH : "not found"}`)
       statusLines.push(`transport: ${transport}`)
+
+      // PRD-35: bridge health. The bridge powers `interceptor macos *` and is
+      // installed as a user LaunchAgent by the DMG installer.
+      const BRIDGE_PID_PATH = "/tmp/interceptor-bridge.pid"
+      const BRIDGE_SOCK_PATH = "/tmp/interceptor-bridge.sock"
+      const bridgeSockExists = !IS_WIN && existsSync(BRIDGE_SOCK_PATH)
+      let bridgePid: number | null = null
+      let bridgeAlive = false
+      if (existsSync(BRIDGE_PID_PATH)) {
+        try {
+          bridgePid = parseInt(readFileSync(BRIDGE_PID_PATH, "utf-8").trim())
+          if (!isNaN(bridgePid)) {
+            try { process.kill(bridgePid, 0); bridgeAlive = true } catch { bridgeAlive = false }
+          }
+        } catch {}
+      }
+      statusLines.push("")
+      statusLines.push(`bridge: ${bridgeAlive ? "running" : "not running"}`)
+      if (bridgePid) statusLines.push(`  pid: ${bridgePid}`)
+      statusLines.push(`  socket: ${bridgeSockExists ? BRIDGE_SOCK_PATH : "not found"}`)
+      if (!bridgeAlive) {
+        statusLines.push("  hint: 'interceptor macos *' commands require the bridge. If you installed")
+        statusLines.push("        via DMG, launchctl should auto-start it. Try 'launchctl load ~/Library/LaunchAgents/com.interceptor.bridge.plist'")
+      }
+
       if (!daemonAlive) {
         statusLines.push("")
         statusLines.push("hint: run any interceptor command and the daemon will auto-start.")
         statusLines.push("ensure Chrome/Brave has the Interceptor extension loaded for browser control.")
       }
       if (jsonMode) {
-        console.log(JSON.stringify({ daemon: daemonAlive, pid: daemonPid, socket: sockExists ? SOCKET_PATH : null, transport }, null, 2))
+        console.log(JSON.stringify({
+          daemon: daemonAlive,
+          pid: daemonPid,
+          socket: sockExists ? SOCKET_PATH : null,
+          transport,
+          bridge: bridgeAlive,
+          bridgePid,
+          bridgeSocket: bridgeSockExists ? BRIDGE_SOCK_PATH : null
+        }, null, 2))
       } else {
         console.log(statusLines.join("\n"))
       }

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -87,10 +87,28 @@ chmod +x "$PAYLOAD/daemon/interceptor-daemon"
 cp "$ROOT/dist/interceptor" "$PAYLOAD/dist/interceptor"
 chmod +x "$PAYLOAD/dist/interceptor"
 
+# Bridge binary (macOS native control) — PRD-35
+if [[ -f "$ROOT/dist/interceptor-bridge" ]]; then
+  cp "$ROOT/dist/interceptor-bridge" "$PAYLOAD/dist/interceptor-bridge"
+  chmod +x "$PAYLOAD/dist/interceptor-bridge"
+else
+  echo "ERROR: dist/interceptor-bridge not found — run scripts/build-bridge.sh first" >&2
+  echo "       (the DMG is for macOS; the bridge is required for 'interceptor macos *' commands)" >&2
+  exit 1
+fi
+
+# LaunchAgent plist template (installer.sh rewrites the path at install time) — PRD-35
+mkdir -p "$PAYLOAD/launch"
+cp "$ROOT/interceptor-bridge/com.interceptor.bridge.plist" "$PAYLOAD/launch/com.interceptor.bridge.plist"
+
 # Scripts
 cp "$ROOT/scripts/inject.py" "$PAYLOAD/scripts/inject.py"
 cp "$ROOT/scripts/installer.sh" "$PAYLOAD/scripts/installer.sh"
 chmod +x "$PAYLOAD/scripts/installer.sh"
+if [[ -f "$ROOT/scripts/uninstall.sh" ]]; then
+  cp "$ROOT/scripts/uninstall.sh" "$PAYLOAD/scripts/uninstall.sh"
+  chmod +x "$PAYLOAD/scripts/uninstall.sh"
+fi
 
 # Native messaging template
 mkdir -p "$PAYLOAD/daemon"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,16 +45,33 @@ build_windows() {
   bun build daemon/index.ts --compile --target=bun-windows-x64 --outfile=daemon/interceptor-daemon.exe
 }
 
+build_bridge() {
+  # Swift-only, macOS-only. Warn-and-continue on CI/linux hosts.
+  if ! command -v swift >/dev/null 2>&1; then
+    echo "Skipping interceptor-bridge (swift toolchain not found)"
+    return 0
+  fi
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "Skipping interceptor-bridge (not on macOS)"
+    return 0
+  fi
+  echo "Building interceptor-bridge (macOS native)..."
+  bash scripts/build-bridge.sh
+}
+
 build_extension
 
 if [[ "$BUILD_ALL" == "1" ]]; then
   build_host
   build_macos
   build_windows
+  build_bridge
 elif [[ "$TARGET" == "host" ]]; then
   build_host
+  build_bridge
 elif [[ "$TARGET" == "macos" ]]; then
   build_macos
+  build_bridge
 elif [[ "$TARGET" == "windows" ]]; then
   build_windows
 else

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -10,10 +10,12 @@ INJECT="$ROOT/scripts/inject.py"
 EXT_SRC="$ROOT/extension/dist"
 DAEMON_SRC="$ROOT/daemon/interceptor-daemon"
 CLI_SRC="$ROOT/dist/interceptor"
+BRIDGE_SRC="$ROOT/dist/interceptor-bridge"
+PLIST_SRC="$ROOT/launch/com.interceptor.bridge.plist"
 
 # ── Copy binaries to persistent location ──────────────────────────────────────
 INSTALL_DIR="$HOME/.interceptor"
-mkdir -p "$INSTALL_DIR/bin"
+mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/launch"
 cp -f "$DAEMON_SRC" "$INSTALL_DIR/bin/interceptor-daemon"
 chmod +x "$INSTALL_DIR/bin/interceptor-daemon"
 if [[ -f "$CLI_SRC" ]]; then
@@ -21,6 +23,31 @@ if [[ -f "$CLI_SRC" ]]; then
   chmod +x "$INSTALL_DIR/bin/interceptor"
 fi
 DAEMON="$INSTALL_DIR/bin/interceptor-daemon"
+
+# ── PRD-35: install the macOS bridge + LaunchAgent ───────────────────────────
+# The bridge powers all 'interceptor macos *' commands (AX tree, CGEvent input,
+# screenshots, vision/NLP). Without it, half the product is silently inert.
+BRIDGE_INSTALLED=0
+if [[ -f "$BRIDGE_SRC" ]]; then
+  cp -f "$BRIDGE_SRC" "$INSTALL_DIR/bin/interceptor-bridge"
+  chmod +x "$INSTALL_DIR/bin/interceptor-bridge"
+  BRIDGE_INSTALLED=1
+fi
+
+# LaunchAgent makes the bridge auto-start at login and respawn on crash.
+# The plist in-tree points at /usr/local/bin/interceptor-bridge — rewrite it
+# to point at the user's install path.
+PLIST_DST="$HOME/Library/LaunchAgents/com.interceptor.bridge.plist"
+if [[ "$BRIDGE_INSTALLED" == "1" && -f "$PLIST_SRC" ]]; then
+  mkdir -p "$HOME/Library/LaunchAgents"
+  sed "s|/usr/local/bin/interceptor-bridge|$INSTALL_DIR/bin/interceptor-bridge|g" \
+    "$PLIST_SRC" > "$INSTALL_DIR/launch/com.interceptor.bridge.plist"
+  cp -f "$INSTALL_DIR/launch/com.interceptor.bridge.plist" "$PLIST_DST"
+
+  # Unload any previous instance (idempotent on re-install), then load.
+  launchctl unload "$PLIST_DST" 2>/dev/null || true
+  launchctl load "$PLIST_DST" 2>/dev/null || true
+fi
 
 # ── Sanity checks ─────────────────────────────────────────────────────────────
 if [[ ! -f "$INJECT" ]]; then
@@ -171,5 +198,26 @@ case "$BROWSER" in
 esac
 
 osascript -e 'display notification "Interceptor installed successfully! Your browser is starting." with title "Interceptor" sound name "Glass"' 2>/dev/null || true
+
+# ── PRD-35: first-run macOS permission walkthrough ────────────────────────────
+# The bridge needs three Privacy toggles to do its job. Point the user there
+# explicitly — otherwise they see "error: interceptor-bridge not running" the
+# first time they run an `interceptor macos *` command.
+if [[ "$BRIDGE_INSTALLED" == "1" ]]; then
+  WALK_MSG="Interceptor can now control your Mac, not just the browser.
+
+To enable that, grant these three permissions to interceptor-bridge in System Settings → Privacy & Security:
+
+• Accessibility — AX tree + OS-level clicks & keys
+• Input Monitoring — trusted keyboard/mouse input
+• Screen Recording — screenshots, OCR, Vision APIs
+
+Click Open to jump to Privacy & Security now."
+
+  CHOICE=$(osascript -e "display dialog \"$WALK_MSG\" buttons {\"Later\", \"Open\"} default button \"Open\" with title \"Interceptor — macOS Permissions\"" 2>/dev/null | sed 's/button returned://')
+  if [[ "$CHOICE" == "Open" ]]; then
+    open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" 2>/dev/null || true
+  fi
+fi
 
 exit 0

--- a/scripts/release-dmg.sh
+++ b/scripts/release-dmg.sh
@@ -107,10 +107,9 @@ PAYLOAD="$APP_DIR/Contents/Resources/interceptor"
 # can lose the signature or touch mtime). Doing this here is belt-and-suspenders.
 sign_one "$PAYLOAD/dist/interceptor"             "com.hackervalley.interceptor-cli"
 sign_one "$PAYLOAD/daemon/interceptor-daemon"    "com.hackervalley.interceptor-daemon"
-# Bridge is not embedded in the DMG (it installs separately) but if a future
-# change adds it, sign here too.
-[[ -f "$PAYLOAD/dist/interceptor-bridge" ]] && \
-  sign_one "$PAYLOAD/dist/interceptor-bridge" "com.hackervalley.interceptor-bridge"
+# PRD-35: bridge is now embedded in the DMG. Re-sign the payload copy so the
+# signature survives cp + the .app deep-sign below treats it as already valid.
+sign_one "$PAYLOAD/dist/interceptor-bridge"      "com.hackervalley.interceptor-bridge"
 
 # Sign the .app bundle itself (deep, so any nested Mach-Os are covered)
 echo "    Signing .app bundle (deep)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# ── Interceptor Uninstaller ───────────────────────────────────────────────────
+# Removes the bridge LaunchAgent, installed binaries, and user install dir.
+# Does NOT remove the browser extension — that must be done per-browser at
+# brave://extensions or chrome://extensions (Secure Preferences HMAC install
+# cannot be cleanly reversed from outside the browser).
+
+INSTALL_DIR="$HOME/.interceptor"
+PLIST_DST="$HOME/Library/LaunchAgents/com.interceptor.bridge.plist"
+
+echo "==> Unloading bridge LaunchAgent..."
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+
+echo "==> Removing LaunchAgent plist..."
+rm -f "$PLIST_DST"
+
+echo "==> Killing any running interceptor processes..."
+pkill -f "interceptor-daemon" 2>/dev/null || true
+pkill -f "interceptor-bridge" 2>/dev/null || true
+
+echo "==> Removing install dir ($INSTALL_DIR)..."
+rm -rf "$INSTALL_DIR"
+
+echo "==> Removing stale runtime files..."
+rm -f /tmp/interceptor.sock /tmp/interceptor.pid
+rm -f /tmp/interceptor-bridge.sock /tmp/interceptor-bridge.pid
+
+echo ""
+echo "✓ Interceptor uninstalled."
+echo ""
+echo "The browser extension was NOT removed automatically — remove it manually:"
+echo "  • Brave:   open brave://extensions/ and click Remove on Interceptor"
+echo "  • Chrome:  open chrome://extensions/ and click Remove on Interceptor"
+echo ""
+echo "Also revoke Privacy permissions (Accessibility / Input Monitoring /"
+echo "Screen Recording) for interceptor-bridge via System Settings → Privacy & Security"
+echo "if you want a fully clean system."


### PR DESCRIPTION
## Summary

Closes the biggest gap surfaced during v0.7.0 live testing: the DMG shipped CLI + daemon but never the bridge, so every \`interceptor macos *\` command silently failed on fresh installs. Now the bridge is packaged, installed, auto-started via LaunchAgent, and the first-run dialog walks users through the three Privacy & Security toggles it needs.

## Changes

| File | Change |
|---|---|
| \`scripts/build.sh\` | New \`build_bridge\` step. Warn-and-continue on non-macOS / no-Swift hosts. |
| \`scripts/build-dmg.sh\` | Stage \`dist/interceptor-bridge\` and the LaunchAgent plist template into the DMG payload. Hard error if the bridge binary is missing. |
| \`scripts/installer.sh\` | Copy bridge to \`~/.interceptor/bin/\`, template plist to the user's install path, \`launchctl load\` it (idempotent). First-run osascript walkthrough for Accessibility / Input Monitoring / Screen Recording with a one-click "Open Privacy & Security" button. |
| \`scripts/release-dmg.sh\` Phase 4 | Always re-sign the payload bridge copy (was guarded behind "if exists"). |
| \`scripts/uninstall.sh\` (new) | Unload LaunchAgent, remove plist, pkill stray processes, wipe \`~/.interceptor\`. Documents the browser-extension removal caveat. |
| \`cli/commands/meta.ts\` | \`interceptor status\` now reports a second block for the bridge — pid, socket, hint if missing. Text and \`--json\` both carry the new fields. |

## Verification

- \`bun test\` — 54 pass / 0 fail / 157 expect() calls.
- \`bun run typecheck\` — exit 0.
- \`scripts/release-dmg.sh\` ran end-to-end: bridge built and signed, payload staged, \`.app\` deep-signed, DMG signed, submitted to Apple notary → **Accepted**, \`xcrun stapler validate\` OK.
- New DMG SHA-256: \`f3303fa3d38985819c46f6e4b57373f3cb401f5dd5a81d56c5215e83ff93b36e\`.
- Asset uploaded to existing v0.7.0 release via \`gh release upload v0.7.0 --clobber\`. Same download URL, new binary.

## Test plan

- [x] Fresh build green (tests + typecheck)
- [x] DMG signed + notarized + stapled
- [x] v0.7.0 release asset replaced
- [ ] (follow-up) Fresh-install regression on a clean machine: \`~/.interceptor/bin/interceptor-bridge\` lands, \`launchctl list | grep interceptor\` returns one entry, \`interceptor macos app activate "Finder"\` works after granting Accessibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridge service status now displays in the status command output.
  * Installation process sets up a background service on macOS with guided permissions setup.
  * Added complete uninstall capability to remove all Interceptor components and revoke associated permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->