### PR TITLE
[codex] Harden extension transport resilience

### DIFF
--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -412,6 +412,7 @@ const socketWriteQueues = new Map<object, Buffer[]>()
 
 const LARGE_PAYLOAD_THRESHOLD = 16 * 1024
 const MAX_RESPONSE_CHARS = 50000
+const NATIVE_HOST_TO_CHROME_MAX_BYTES = 1024 * 1024
 
 function socketWriteFramed(socket: { write: (data: Buffer | string) => number }, json: string): boolean {
   try {
@@ -467,7 +468,13 @@ function drainSocketQueue(socket: { write: (data: Buffer | string) => number }) 
   if (!queue || queue.length === 0) return
   while (queue.length > 0) {
     const chunk = queue[0]
-    const wrote = socket.write(chunk)
+    let wrote = 0
+    try {
+      wrote = socket.write(chunk)
+    } catch (err) {
+      log(`socket drain error: ${(err as Error).message}`)
+      return
+    }
     if (wrote < chunk.byteLength) {
       queue[0] = chunk.subarray(wrote)
       return
@@ -600,6 +607,18 @@ function sendNativeMessage(msg: unknown): void {
     stdinAlive,
     standalone: STANDALONE
   })
+  const byteLength = Buffer.byteLength(json, "utf-8")
+
+  function failOversizedNativeMessage(transport: string): boolean {
+    if (byteLength <= NATIVE_HOST_TO_CHROME_MAX_BYTES) return false
+    const id = (msg as { id?: unknown } | null)?.id
+    const error = `native message too large for ${transport}: ${byteLength} bytes exceeds ${NATIVE_HOST_TO_CHROME_MAX_BYTES}`
+    log(error)
+    if (typeof id === "string") {
+      handleNativeMessage({ id, result: { success: false, error } })
+    }
+    return true
+  }
 
   if (preferred === "ws" && extensionWs) {
     log(`forwarding via ws: ${json.slice(0, 200)}`)
@@ -612,6 +631,7 @@ function sendNativeMessage(msg: unknown): void {
   }
 
   if (preferred === "relay" && nativeRelaySocket) {
+    if (failOversizedNativeMessage("native relay")) return
     log(`forwarding via relay: ${json.slice(0, 200)}`)
     try {
       socketWriteFramed(nativeRelaySocket, json)
@@ -623,6 +643,7 @@ function sendNativeMessage(msg: unknown): void {
   }
 
   if (preferred === "native" && !STANDALONE && stdinAlive) {
+    if (failOversizedNativeMessage("native stdio")) return
     log(`forwarding via native: ${json.slice(0, 200)}`)
     const encoded = Buffer.from(json, "utf-8")
     const header = Buffer.alloc(4)
@@ -643,6 +664,7 @@ function sendNativeMessage(msg: unknown): void {
   }
 
   if (nativeRelaySocket) {
+    if (failOversizedNativeMessage("fallback native relay")) return
     log(`fallback via relay: ${json.slice(0, 200)}`)
     try {
       socketWriteFramed(nativeRelaySocket, json)
@@ -654,6 +676,7 @@ function sendNativeMessage(msg: unknown): void {
   }
 
   if (!STANDALONE && stdinAlive) {
+    if (failOversizedNativeMessage("fallback native stdio")) return
     log(`fallback via native: ${json.slice(0, 200)}`)
     const encoded = Buffer.from(json, "utf-8")
     const header = Buffer.alloc(4)

--- a/extension/src/background/native-port-lifecycle.ts
+++ b/extension/src/background/native-port-lifecycle.ts
@@ -1,0 +1,28 @@
+import { safePortPost } from "./safe-port-post"
+
+export type NativePortLike = {
+  postMessage(msg: unknown): void
+  disconnect?: () => void
+}
+
+export function safeNativePortPost(port: NativePortLike | null | undefined, msg: unknown): { posted: boolean; error?: string } {
+  return safePortPost(port, msg)
+}
+
+export function safeNativePortPing(port: NativePortLike | null | undefined): { posted: boolean; error?: string } {
+  return safeNativePortPost(port, { type: "ping" })
+}
+
+export function safeNativePortDisconnect(port: Pick<NativePortLike, "disconnect"> | null | undefined): { disconnected: boolean; error?: string } {
+  if (!port?.disconnect) return { disconnected: false, error: "no disconnect" }
+  try {
+    port.disconnect()
+    return { disconnected: true }
+  } catch (err) {
+    return { disconnected: false, error: (err as Error).message }
+  }
+}
+
+export function shouldSkipNativeKeepalive(now: number, lastNativeActivityAt: number, graceMs: number): boolean {
+  return now - lastNativeActivityAt < graceMs
+}

--- a/extension/src/background/pending-request-recovery.ts
+++ b/extension/src/background/pending-request-recovery.ts
@@ -1,0 +1,32 @@
+export type RecoveryDeliveryResult = "sent" | "queued" | "failed"
+
+export type RecoverablePendingRequest = {
+  action: string
+  timer: ReturnType<typeof setTimeout>
+}
+
+type LogFn = (message?: unknown, ...optionalParams: unknown[]) => void
+
+export function recoverPendingRequestsAfterNativeDisconnect(
+  pending: Iterable<[string, RecoverablePendingRequest]>,
+  deliver: (msg: unknown) => RecoveryDeliveryResult,
+  clearTimer: (timer: ReturnType<typeof setTimeout>) => void = clearTimeout,
+  logError: LogFn = console.error
+): { recovered: number; failed: number } {
+  let recovered = 0
+  let failed = 0
+
+  for (const [id, req] of pending) {
+    clearTimer(req.timer)
+    logError(`orphaned request ${id} (${req.action}) — native port disconnected`)
+    const delivery = deliver({ id, result: { success: false, error: "native port disconnected" } })
+    if (delivery === "failed") {
+      failed += 1
+      logError(`final delivery failure for orphaned request ${id} (${req.action})`)
+    } else {
+      recovered += 1
+    }
+  }
+
+  return { recovered, failed }
+}

--- a/extension/src/background/transport.ts
+++ b/extension/src/background/transport.ts
@@ -1,8 +1,9 @@
 import { handleDaemonMessage, drainMessageQueue, pendingRequests } from "./message-dispatch"
-import { ensureInterceptorGroup } from "./tab-group"
-import { safePortPost } from "./safe-port-post"
+import { safeNativePortDisconnect, safeNativePortPing, safeNativePortPost, shouldSkipNativeKeepalive } from "./native-port-lifecycle"
+import { recoverPendingRequestsAfterNativeDisconnect } from "./pending-request-recovery"
 
 type ActiveTransport = "none" | "native" | "websocket"
+export type HostDeliveryResult = "sent" | "queued" | "failed"
 
 export let nativePort: chrome.runtime.Port | null = null
 export let activeTransport: ActiveTransport = "none"
@@ -13,43 +14,106 @@ let wsChannel: WebSocket | null = null
 let wsReady = false
 let wsKeepAliveTimer: ReturnType<typeof setInterval> | null = null
 let keepalivePongTimer: ReturnType<typeof setTimeout> | null = null
+let pendingHandshakePort: chrome.runtime.Port | null = null
+let lastNativeActivityAt = 0
 const WS_URL = "ws://localhost:19222"
+export const NATIVE_KEEPALIVE_PONG_TIMEOUT_MS = 15_000
+export const RECENT_NATIVE_ACTIVITY_GRACE_MS = 10_000
+const OUTBOUND_RECOVERY_QUEUE_CAP = 50
+const outboundRecoveryQueue: unknown[] = []
+
+function describeOutboundMessage(msg: unknown): string {
+  const candidate = msg as { id?: unknown; result?: { error?: unknown } } | null
+  if (candidate && typeof candidate.id === "string") {
+    const error = typeof candidate.result?.error === "string" ? ` (${candidate.result.error})` : ""
+    return `${candidate.id}${error}`
+  }
+  return JSON.stringify(msg).slice(0, 200)
+}
 
 function emitEvent(event: string, data: Record<string, unknown> = {}) {
   sendToHost({ type: "event", event, ...data })
 }
 
-function postNative(msg: unknown): boolean {
-  const port = nativePort
+function clearNativeStateFor(port: chrome.runtime.Port | null): void {
+  if (nativePort === port) nativePort = null
+  if (pendingHandshakePort === port) pendingHandshakePort = null
+  if (activeTransport === "native") activeTransport = "none"
+}
+
+function disconnectNativePort(port: chrome.runtime.Port | null): void {
+  if (!port) return
+  safeNativePortDisconnect(port)
+  if (keepalivePongTimer) {
+    clearTimeout(keepalivePongTimer)
+    keepalivePongTimer = null
+  }
+  clearNativeStateFor(port)
+}
+
+function postNative(msg: unknown, port = nativePort): boolean {
   if (!port) return false
-  const res = safePortPost(port, msg)
+  const res = safeNativePortPost(port, msg)
   if (res.posted) return true
   console.error("nativePort.postMessage threw (port disconnected before onDisconnect fired):", res.error)
-  if (nativePort === port) nativePort = null
-  if (activeTransport === "native") activeTransport = "none"
+  clearNativeStateFor(port)
   return false
 }
 
-export function sendToHost(msg: unknown, forceWs?: boolean): void {
-  if (forceWs && wsReady && wsChannel) {
-    try { wsChannel.send(JSON.stringify(msg)) } catch {}
-    return
+function isWsOpen(): boolean {
+  if (!wsReady || !wsChannel || wsChannel.readyState !== WebSocket.OPEN) return false
+  return true
+}
+
+function sendWs(msg: unknown): boolean {
+  const channel = wsChannel
+  if (!wsReady || !channel || channel.readyState !== WebSocket.OPEN) return false
+  try {
+    channel.send(JSON.stringify(msg))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function enqueueOutboundRecovery(msg: unknown): HostDeliveryResult {
+  if (outboundRecoveryQueue.length >= OUTBOUND_RECOVERY_QUEUE_CAP) {
+    const dropped = outboundRecoveryQueue.shift()
+    console.error("final delivery failure for queued outbound message:", describeOutboundMessage(dropped))
+  }
+  outboundRecoveryQueue.push(msg)
+  return "queued"
+}
+
+function drainOutboundRecoveryQueue(): void {
+  while (outboundRecoveryQueue.length > 0) {
+    const msg = outboundRecoveryQueue[0]
+    if (!sendWs(msg)) return
+    outboundRecoveryQueue.shift()
+  }
+}
+
+export function sendToHost(msg: unknown, forceWs?: boolean, allowQueue = false): HostDeliveryResult {
+  if (forceWs) {
+    if (sendWs(msg)) return "sent"
+    return allowQueue ? enqueueOutboundRecovery(msg) : "failed"
   }
   if (activeTransport === "native" && nativePort) {
-    if (postNative(msg)) return
+    if (postNative(msg)) return "sent"
     // fall through to ws channel if native postMessage failed
   }
   if (activeTransport === "websocket" && wsReady && wsChannel) {
-    try { wsChannel.send(JSON.stringify(msg)) } catch {}
-    return
+    if (sendWs(msg)) return "sent"
+    return allowQueue ? enqueueOutboundRecovery(msg) : "failed"
   }
   if (nativePort) {
-    if (postNative(msg)) return
+    if (postNative(msg)) return "sent"
     // fall through to ws channel if native postMessage failed
   }
   if (wsReady && wsChannel) {
-    try { wsChannel.send(JSON.stringify(msg)) } catch {}
+    if (sendWs(msg)) return "sent"
   }
+  return allowQueue ? enqueueOutboundRecovery(msg) : "failed"
 }
 
 export function connectToHost(): void {
@@ -60,7 +124,7 @@ export function connectToHost(): void {
 
   const handshakeTimer = setTimeout(() => {
     console.error("native host handshake timeout (10s)")
-    port.disconnect()
+    disconnectNativePort(port)
   }, 10000)
 
   port.onMessage.addListener((msg: {
@@ -69,42 +133,43 @@ export function connectToHost(): void {
     tabId?: number
   }) => {
     if (msg.type === "pong") {
-      clearTimeout(handshakeTimer)
-      activeTransport = "native"
-      reconnectDelay = 1000
-      isConnecting = false
-      console.log("native host connected (pong received)")
-      emitEvent("connection_established")
-      drainMessageQueue()
+      lastNativeActivityAt = Date.now()
+      if (pendingHandshakePort === port) {
+        clearTimeout(handshakeTimer)
+        pendingHandshakePort = null
+        activeTransport = "native"
+        reconnectDelay = 1000
+        isConnecting = false
+        console.log("native host connected (pong received)")
+        emitEvent("connection_established")
+        drainMessageQueue()
+      }
       if (keepalivePongTimer) {
         clearTimeout(keepalivePongTimer)
         keepalivePongTimer = null
       }
       return
     }
+    lastNativeActivityAt = Date.now()
     handleDaemonMessage(msg)
   })
 
   port.onDisconnect.addListener(() => {
-    const dyingPort = nativePort
+    const disconnectedPort = port
     isConnecting = false
     const lastError = chrome.runtime.lastError
     if (lastError) console.error("native host disconnected:", lastError.message)
     console.log("connection_lost", lastError?.message)
-    nativePort = null
-    if (wsReady && wsChannel) {
+    clearNativeStateFor(disconnectedPort)
+    if (isWsOpen()) {
       activeTransport = "websocket"
       console.log("native host down but ws channel active, switching to websocket")
       return
     }
-    if (activeTransport === "native") activeTransport = "none"
-    for (const [id, req] of pendingRequests) {
-      clearTimeout(req.timer)
-      console.error(`orphaned request ${id} (${req.action}) — native port disconnected`)
-      if (dyingPort) {
-        try { dyingPort.postMessage({ id, result: { success: false, error: "native port disconnected" } }) } catch {}
-      }
-    }
+    recoverPendingRequestsAfterNativeDisconnect(
+      pendingRequests,
+      (msg) => sendToHost(msg, true, true)
+    )
     pendingRequests.clear()
     const jitter = Math.random() * reconnectDelay * 0.3
     setTimeout(connectToHost, reconnectDelay + jitter)
@@ -112,7 +177,13 @@ export function connectToHost(): void {
   })
 
   nativePort = port
-  port.postMessage({ type: "ping" })
+  pendingHandshakePort = port
+  const ping = safeNativePortPing(port)
+  if (!ping.posted) {
+    clearTimeout(handshakeTimer)
+    clearNativeStateFor(port)
+    isConnecting = false
+  }
 }
 
 function startWsKeepAlive(): void {
@@ -149,6 +220,7 @@ export function connectWsChannel(): void {
         console.log("connection ready via ws channel")
         drainMessageQueue()
       }
+      drainOutboundRecoveryQueue()
     }
     ws.onmessage = (event) => {
       try {
@@ -201,11 +273,18 @@ export function registerAlarmListener(): void {
     if (!nativePort) connectToHost()
     if (!wsChannel || wsChannel.readyState === WebSocket.CLOSED) connectWsChannel()
     if (activeTransport === "native" && nativePort) {
-      nativePort.postMessage({ type: "ping" })
+      if (shouldSkipNativeKeepalive(Date.now(), lastNativeActivityAt, RECENT_NATIVE_ACTIVITY_GRACE_MS)) return
+      const port = nativePort
+      const res = safeNativePortPing(port)
+      if (!res.posted) {
+        console.error("native keepalive ping failed:", res.error)
+        clearNativeStateFor(port)
+        return
+      }
       keepalivePongTimer = setTimeout(() => {
-        console.error("keepalive pong timeout (5s) — forcing reconnect")
-        if (nativePort) nativePort.disconnect()
-      }, 5000)
+        console.error(`keepalive pong timeout (${NATIVE_KEEPALIVE_PONG_TIMEOUT_MS / 1000}s) — forcing reconnect`)
+        disconnectNativePort(port)
+      }, NATIVE_KEEPALIVE_PONG_TIMEOUT_MS)
     }
   })
 }

--- a/test/native-port-lifecycle.test.ts
+++ b/test/native-port-lifecycle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { safeNativePortDisconnect, safeNativePortPing, shouldSkipNativeKeepalive } from "../extension/src/background/native-port-lifecycle"
+
+describe("native port lifecycle helpers", () => {
+  test("keepalive ping is posted through the safe port wrapper", () => {
+    const received: unknown[] = []
+    const res = safeNativePortPing({
+      postMessage(msg: unknown) { received.push(msg) },
+      disconnect() {}
+    })
+
+    expect(res.posted).toBe(true)
+    expect(received).toEqual([{ type: "ping" }])
+  })
+
+  test("stale keepalive ping does not throw and disconnects the port", () => {
+    let disconnectCalled = false
+    const res = safeNativePortPing({
+      postMessage() {
+        throw new Error("Attempting to use a disconnected port object")
+      },
+      disconnect() { disconnectCalled = true }
+    })
+
+    expect(res.posted).toBe(false)
+    expect(res.error).toContain("disconnected port")
+    expect(disconnectCalled).toBe(true)
+  })
+
+  test("stale disconnect is trapped", () => {
+    const res = safeNativePortDisconnect({
+      disconnect() {
+        throw new Error("Attempting to use a disconnected port object")
+      }
+    })
+
+    expect(res.disconnected).toBe(false)
+    expect(res.error).toContain("disconnected port")
+  })
+
+  test("recent native activity suppresses keepalive pings", () => {
+    expect(shouldSkipNativeKeepalive(11_000, 2_000, 10_000)).toBe(true)
+    expect(shouldSkipNativeKeepalive(12_001, 2_000, 10_000)).toBe(false)
+  })
+})

--- a/test/pending-request-recovery.test.ts
+++ b/test/pending-request-recovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import { recoverPendingRequestsAfterNativeDisconnect } from "../extension/src/background/pending-request-recovery"
+
+describe("pending request recovery", () => {
+  test("queues native disconnect errors with original request ids", () => {
+    const clearedTimers: number[] = []
+    const delivered: unknown[] = []
+    const logs: unknown[][] = []
+    const pending = new Map([
+      ["relay-request-1", { action: "extract_text", timer: 101 as unknown as ReturnType<typeof setTimeout> }],
+      ["relay-request-2", { action: "tab_switch", timer: 202 as unknown as ReturnType<typeof setTimeout> }]
+    ])
+
+    const summary = recoverPendingRequestsAfterNativeDisconnect(
+      pending,
+      (msg) => {
+        delivered.push(msg)
+        return "queued"
+      },
+      (timer) => { clearedTimers.push(timer as unknown as number) },
+      (...args) => { logs.push(args) }
+    )
+
+    expect(summary).toEqual({ recovered: 2, failed: 0 })
+    expect(clearedTimers).toEqual([101, 202])
+    expect(delivered).toEqual([
+      { id: "relay-request-1", result: { success: false, error: "native port disconnected" } },
+      { id: "relay-request-2", result: { success: false, error: "native port disconnected" } }
+    ])
+    expect(logs.map((entry) => String(entry[0]))).toEqual([
+      "orphaned request relay-request-1 (extract_text) — native port disconnected",
+      "orphaned request relay-request-2 (tab_switch) — native port disconnected"
+    ])
+  })
+
+  test("logs final delivery failures for unrecoverable requests", () => {
+    const logs: unknown[][] = []
+    const pending = new Map([
+      ["relay-request-3", { action: "tab_list", timer: 303 as unknown as ReturnType<typeof setTimeout> }]
+    ])
+
+    const summary = recoverPendingRequestsAfterNativeDisconnect(
+      pending,
+      () => "failed",
+      () => {},
+      (...args) => { logs.push(args) }
+    )
+
+    expect(summary).toEqual({ recovered: 0, failed: 1 })
+    expect(logs.map((entry) => String(entry[0]))).toEqual([
+      "orphaned request relay-request-3 (tab_list) — native port disconnected",
+      "final delivery failure for orphaned request relay-request-3 (tab_list)"
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Harden extension native-port ping/disconnect paths with safe wrappers.
- Separate handshake pongs from keepalive pongs and add WebSocket recovery for orphaned responses.
- Guard daemon native outbound messages against Chrome size limits and harden Bun socket drain behavior.
- Add focused tests for stale native ports and pending request recovery.

## Root Cause
The keepalive alarm called `nativePort.postMessage` directly and disconnect recovery attempted responses through a dying port, allowing Chrome to drop responses while the daemon/CLI waited for timeout.

## Validation
- `bun run typecheck`
- `bun test`
- `bun run build`
- `git diff --check`
- `./dist/interceptor status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message queuing capability when host communication channels are unavailable.

* **Bug Fixes**
  * Improved oversized message handling with proper error responses instead of sending invalid data.
  * Enhanced socket error resilience to prevent crashes during message transmission.
  * Strengthened request recovery after host disconnections with better failure tracking.
  * Refined keepalive timeout detection to prevent premature disconnects.

* **Tests**
  * Added comprehensive test coverage for native port lifecycle and request recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->