### PR TITLE
feat: DOM-render screenshot pipeline (no captureVisibleTab default)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,8 @@ On strict-CSP sites, page-world evaluation may require Interceptor's automatic r
 
 Use screenshots only when the task depends on rendered pixels, visual layout, chart appearance, image content, or screenshot output.
 
+The default `interceptor screenshot` is a DOM render and does NOT require the browser to be focused or visible — it works from a backgrounded Chrome on a different macOS Space. Use `--selector <css>` for a single element, `--region X,Y,W,H` for an arbitrary rect, `--element <ref>` for a refRegistry-tracked element. Use `--pixel` only when you need pixel-accurate compositor output (e.g., visual regression of compositor effects, hardware video frames); the `--pixel` path requires the browser window to be visible and focused. `--pixel --full` scrolls + stitches and is throttled to clear Chrome's `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota.
+
 ## Recovery Rules
 
 - If a ref fails, run `read` or `find` again and retry with the new ref.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,10 +251,39 @@ For screenshot saving, `interceptor-bridge/Sources/Domains/CaptureDomain.swift` 
 
 ---
 
+## Screenshot Pipeline
+
+Two distinct capture paths share the `interceptor screenshot` surface:
+
+### DOM render (default)
+
+The default path renders the page's DOM directly to a canvas inside the target tab — no `chrome.tabs.captureVisibleTab`, no `chrome.tabCapture`, no browser focus or visibility requirement.
+
+1. **Library injection.** `extension/src/screenshot-runner.ts` is a small bundle entry that imports a vendored copy of `html-to-image` and assigns it to `globalThis.__interceptor_h2i`. The bundle is built to `extension/dist/screenshot-runner.js` (~30 KB) and loaded on demand via `chrome.scripting.executeScript({ files: ["screenshot-runner.js"], world: "ISOLATED" })`. It is **not** registered as a `content_scripts` entry — pages that never get screenshotted pay no cost.
+2. **CORS clearance.** Before the render, the SW installs a `chrome.declarativeNetRequest` session rule (`extension/src/background/capabilities/screenshot-cors.ts`) scoped to `tabIds: [tabId]` and `resourceTypes: [image, font, media, stylesheet, xmlhttprequest]`. The rule sets `Access-Control-Allow-Origin: *`, removes `Access-Control-Allow-Credentials`, and sets `Cross-Origin-Resource-Policy: cross-origin` for the duration of the capture, then is removed in a `try/finally`. The rule lifecycle mirrors the CSP-bypass rule used by `evaluate.ts`.
+3. **Render.** `extension/src/content/dom-screenshot.ts` resolves the target node by mode (`full` → `document.documentElement`, `element` → refRegistry lookup, `selector` → `querySelector`, `region` → full + in-frame canvas crop) and calls `__interceptor_h2i.toPng`/`toJpeg`. Options include `cacheBust: true`, `imagePlaceholder` (a 1×1 transparent PNG), and `fetchRequestInit: { mode: "cors", cache: "no-cache" }`. If the first attempt throws a tainted-canvas error, the handler retries with a `filter` that excludes `<img>`, `<picture>`, `<video>`, and `<canvas>` so structural captures still succeed when third-party assets cannot be CORS-cleansed.
+4. **Region crop in-frame.** For `--region`, the content script renders the full page once and then crops via a regular `<canvas>.drawImage` + `toDataURL` inside the same frame, so the inter-process message back to the SW carries only the cropped result instead of a multi-MB full-page payload.
+
+### Pixel-true compositor capture (`--pixel`)
+
+`--pixel` opts into the legacy `chrome.tabs.captureVisibleTab` path. It produces compositor-accurate output (hardware video frames, GPU filters, exact compositor pixels) but requires the browser window to be visible and focused. Single-viewport captures complete in ~50 ms when the window is focused.
+
+`--pixel --full` scrolls the page and captures one viewport-sized strip per scroll position. Strip cadence is set above 1 second to clear Chrome's `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota (default 2/sec). Strips are stitched together inside the SW using `OffscreenCanvas` + `createImageBitmap` + `convertToBlob` — explicitly **not** routed through the offscreen-document `stitch` handler, because the IPC return path for multi-MB stitched results is unreliable.
+
+### Transport routing
+
+Screenshot responses can carry tens to hundreds of KB of base64 dataUrl. Empirical testing on Brave/Chromium showed the native-messaging port silently drops messages above ~50 KB despite the documented 1 MB cap, so the CLI auto-enables WebSocket transport for any `screenshot` invocation (`cli/index.ts`). `--no-ws` overrides if the user wants the native path.
+
+---
+
 ## Implementation Notes
 
 Recent major additions reflected in this document:
 
+- DOM-render screenshot pipeline as the default capture path; `--pixel` retains the legacy `captureVisibleTab` route as an opt-in
+- per-tab CORS-clearance session DNR rule scoped to subresource fetches during a capture
+- in-SW `OffscreenCanvas` stitching for `--pixel --full` so multi-MB responses no longer round-trip through the offscreen document
+- automatic WebSocket routing for `screenshot` CLI invocations
 - CLI-first Brave install path through `scripts/install.sh --brave --profile <profile>`
 - frame-targeted `read --include-frames` with subtree refs preserved end-to-end
 - canvas observer summaries that filter `log` and `objects` by DOM canvas index

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,14 +246,25 @@ The rolling live event stream lives in `/tmp/interceptor-events.jsonl` (the same
 
 ## Screenshots
 
+Default capture is **DOM render** (no `chrome.tabs.captureVisibleTab` in the hot path) — works regardless of window focus, macOS Space, or SW activation context. Backed by a vendored `html-to-image` bundle injected on demand via `chrome.scripting.executeScript`, paired with a per-tab `declarativeNetRequest` session rule that grants CORS clearance to subresource fetches for the duration of the capture. A per-image fallback that excludes `<img>`/`<picture>`/`<video>`/`<canvas>` kicks in automatically if the page has tainted-canvas content the rule cannot un-taint. Use `--pixel` for compositor-accurate (true-pixel) capture via `captureVisibleTab` — that path requires the browser window to be visible and focused.
+
 ```bash
-interceptor screenshot                        # Viewport JPEG (returns data URL)
-interceptor screenshot --save                 # Save to disk as file
-interceptor screenshot --full                 # Full-page scroll+stitch
-interceptor screenshot --format png           # PNG format
+interceptor screenshot                        # Default DOM-render full-page (works without focus)
+interceptor screenshot --save                 # Also save to disk
+interceptor screenshot --selector "h1"        # Capture by CSS selector (off-screen elements supported)
+interceptor screenshot --element 5            # Capture by ref/index from a recent read
+interceptor screenshot --region X,Y,W,H       # Capture a region (renders + crops in content script)
+interceptor screenshot --scale 2              # Override pixel ratio (e.g. retina from a 1x display)
+interceptor screenshot --pixel                # Pixel-true compositor capture (legacy captureVisibleTab)
+interceptor screenshot --pixel --full         # Pixel-true full-page (scroll + in-SW stitch)
+interceptor screenshot --format png           # PNG format (default for DOM render)
 interceptor screenshot --quality 80           # JPEG quality 0-100
-interceptor screenshot --element 5            # Capture specific element
+interceptor screenshot --clip X,Y,W,H         # [deprecated] alias for --region
 ```
+
+The CLI auto-routes `screenshot` invocations through the WebSocket transport because base64 dataUrl payloads larger than ~50KB are unreliable over the native-messaging port on Brave/Chromium despite the documented 1MB limit. Override with `--no-ws` if needed.
+
+`--pixel --full` captures one strip per viewport, throttled to clear Chrome's 2-call/sec `captureVisibleTab` quota, and stitches the strips together inside the SW using `OffscreenCanvas` — no offscreen-document IPC hop, so multi-MB stitched results do not get truncated en route back to the daemon.
 
 ## LinkedIn Extraction
 

--- a/README.md
+++ b/README.md
@@ -445,14 +445,23 @@ interceptor click "button:Play"
 ```
 
 ### Screenshots
+
+Default capture is **DOM render** — no `chrome.tabs.captureVisibleTab` in the hot path. Works regardless of window focus, macOS Space, or service-worker activation context. A vendored `html-to-image` bundle is injected on demand and paired with a per-tab CORS-clearance DNR rule. Use `--pixel` for compositor-accurate capture (requires Chrome focused).
+
 ```bash
-interceptor screenshot                       # Viewport JPEG (returns data URL)
-interceptor screenshot --save                # Save to disk
-interceptor screenshot --full                # Full-page scroll+stitch
-interceptor screenshot --format png          # PNG format
+interceptor screenshot                       # Default DOM-render full-page (works without focus)
+interceptor screenshot --save                # Also save to disk
+interceptor screenshot --selector "h1"       # Capture matching element (off-screen supported)
+interceptor screenshot --element 5           # Capture by ref/index from a recent read
+interceptor screenshot --region X,Y,W,H      # Render full + crop to region in content script
+interceptor screenshot --scale 2             # Override pixel ratio
+interceptor screenshot --pixel               # Pixel-true compositor capture (legacy captureVisibleTab)
+interceptor screenshot --pixel --full        # Pixel-true full-page (scroll + in-SW stitch)
+interceptor screenshot --format png          # PNG (default for DOM render)
 interceptor screenshot --quality 80          # JPEG quality 0-100
-interceptor screenshot --element 5           # Capture element bounding box
 ```
+
+`screenshot` invocations are auto-routed through the WebSocket transport because base64 dataUrl responses larger than ~50KB are unreliable over the native-messaging port on Brave/Chromium. Override with `--no-ws` if needed.
 
 ### Data
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "interceptor-browser",
+      "dependencies": {
+        "html-to-image": "^1.11.13",
+      },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.9.0",
         "@types/bun": "latest",
@@ -37,6 +40,8 @@
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+
+    "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
 
     "ocrad.js": ["ocrad.js@0.0.1", "", {}, "sha512-4W8Kcf4ewFJUgEGIBH4FxEgusHPmk0dSzD+CBMaaZeOb1RPM1Rv0+cA177pHDlN2yK8Gelb4KTczxtbQmq+p/w=="],
 

--- a/cli/commands/screenshot.ts
+++ b/cli/commands/screenshot.ts
@@ -20,11 +20,22 @@ export function parseScreenshotCommand(filtered: string[]): Action {
       if (filtered.includes("--format")) ssAction.format = filtered[filtered.indexOf("--format") + 1]
       if (filtered.includes("--quality")) ssAction.quality = parseInt(filtered[filtered.indexOf("--quality") + 1])
       if (filtered.includes("--full")) ssAction.full = true
+      if (filtered.includes("--pixel")) ssAction.pixel = true
+      if (filtered.includes("--scale")) ssAction.scale = parseFloat(filtered[filtered.indexOf("--scale") + 1])
+      if (filtered.includes("--selector")) {
+        ssAction.selector = filtered[filtered.indexOf("--selector") + 1]
+      }
+      if (filtered.includes("--region")) {
+        const rp = filtered[filtered.indexOf("--region") + 1].split(",").map(Number)
+        ssAction.region = { x: rp[0], y: rp[1], width: rp[2], height: rp[3] }
+      }
       if (filtered.includes("--clip")) {
+        // --clip is a deprecated alias for --region (preserved for backward compat)
         const clipParts = filtered[filtered.indexOf("--clip") + 1].split(",").map(Number)
         ssAction.clip = { x: clipParts[0], y: clipParts[1], width: clipParts[2], height: clipParts[3] }
       }
       if (filtered.includes("--element")) ssAction.element = parseInt(filtered[filtered.indexOf("--element") + 1])
+      if (filtered.includes("--ref")) ssAction.ref = filtered[filtered.indexOf("--ref") + 1]
       return ssAction
     }
 

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -68,13 +68,16 @@ Tabs:
   interceptor tab switch <id>                Switch to tab
 
 Capture:
-  interceptor screenshot                     Viewport screenshot (returns data URL)
-  interceptor screenshot --save              Also save to disk
-  interceptor screenshot --format png        PNG format (default: jpeg)
-  interceptor screenshot --quality 80        JPEG quality 0-100 (default: 50)
-  interceptor screenshot --full              Full-page scroll+stitch capture
-  interceptor screenshot --clip X,Y,W,H     Capture region
-  interceptor screenshot --element N         Capture element bounding rect
+  interceptor screenshot                     Full-page DOM-render screenshot (default — works without focus)
+  interceptor screenshot --selector "h1"    Capture only the matching element
+  interceptor screenshot --element N         Capture element by ref (off-screen elements supported)
+  interceptor screenshot --region X,Y,W,H   Capture page region (rendered + cropped)
+  interceptor screenshot --scale 2           Override pixel ratio (e.g. retina from 1x display)
+  interceptor screenshot --pixel             Pixel-true compositor capture (legacy captureVisibleTab — requires Chrome focused)
+  interceptor screenshot --save              Save to disk in addition to returning data URL
+  interceptor screenshot --format png        PNG format (default: png for DOM render, jpeg for --pixel)
+  interceptor screenshot --quality 80        JPEG quality 0-100
+  interceptor screenshot --clip X,Y,W,H     [deprecated alias for --region]
   interceptor eval <code>                    Run JS in isolated world
   interceptor eval <code> --main             Run JS in page context
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -55,7 +55,13 @@ function unwrapResult(response: DaemonResponse): DaemonResult {
 async function main() {
   const args = process.argv.slice(2)
   const jsonMode = args.includes("--json")
-  const useWs = args.includes("--ws")
+  // PRD-44: screenshot responses can carry tens-to-hundreds of KB of base64
+  // dataUrl payloads. Native-messaging port-based responses for that size
+  // are unreliable on Brave/Chromium (messages are silently dropped despite
+  // the documented 1MB native-messaging limit). The WebSocket transport does
+  // not exhibit this issue, so we auto-route screenshot through it.
+  const isScreenshotCmd = args[0] === "screenshot"
+  const useWs = args.includes("--ws") || (isScreenshotCmd && !args.includes("--no-ws"))
   const anyTab = args.includes("--any-tab")
   const globalTabId = parseTabFlag(args)
 

--- a/extension/src/background/capabilities/screenshot-cors.ts
+++ b/extension/src/background/capabilities/screenshot-cors.ts
@@ -1,0 +1,74 @@
+// screenshot-cors.ts
+//
+// Per-tab session DNR rule that grants CORS clearance to subresource fetches
+// during the lifetime of a single screenshot operation. Mirrors the lifecycle
+// pattern used by `evaluate.ts`'s buildCspBypassRule / installCspBypassForTab,
+// just with a different rule-ID base and different header set.
+//
+// Lifecycle:
+//   const installed = await installScreenshotCorsRule(tabId)
+//   try { ... do the screenshot ... }
+//   finally { await uninstallScreenshotCorsRule(tabId) }
+//
+// Blast radius:
+//   - tabIds: [tabId] — only the tab being screenshotted is affected.
+//   - resourceTypes: image, font, media, stylesheet, xmlhttprequest — only
+//     subresources the screenshot library re-fetches. main_frame and sub_frame
+//     are intentionally excluded so the page's own CSP / COEP / frame-options
+//     behavior is not modified.
+//   - Session rule (not dynamic): the rule is in-memory only and does not
+//     persist across browser restarts.
+//
+// Tradeoff:
+//   - `Access-Control-Allow-Credentials` is removed (not set to "false")
+//     because spec-compliant browsers reject `ACAO: *` paired with
+//     `ACAC: true`. Sites with credentialed cross-origin XHRs in flight
+//     during the screenshot will see those requests behave as Origin-
+//     restricted for the duration of the capture.
+
+const SCREENSHOT_CORS_RULE_ID_BASE = 920_000
+
+export function buildScreenshotCorsRule(tabId: number): chrome.declarativeNetRequest.Rule {
+  return {
+    id: SCREENSHOT_CORS_RULE_ID_BASE + tabId,
+    priority: 10,
+    action: {
+      type: "modifyHeaders" as chrome.declarativeNetRequest.RuleActionType,
+      responseHeaders: [
+        { header: "access-control-allow-origin", operation: "set" as chrome.declarativeNetRequest.HeaderOperation, value: "*" },
+        { header: "access-control-allow-credentials", operation: "remove" as chrome.declarativeNetRequest.HeaderOperation },
+        { header: "cross-origin-resource-policy", operation: "set" as chrome.declarativeNetRequest.HeaderOperation, value: "cross-origin" }
+      ]
+    },
+    condition: {
+      tabIds: [tabId],
+      resourceTypes: [
+        "image" as chrome.declarativeNetRequest.ResourceType,
+        "font" as chrome.declarativeNetRequest.ResourceType,
+        "media" as chrome.declarativeNetRequest.ResourceType,
+        "stylesheet" as chrome.declarativeNetRequest.ResourceType,
+        "xmlhttprequest" as chrome.declarativeNetRequest.ResourceType
+      ]
+    }
+  }
+}
+
+export async function installScreenshotCorsRule(tabId: number): Promise<void> {
+  const rule = buildScreenshotCorsRule(tabId)
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: [rule.id],
+    addRules: [rule]
+  })
+}
+
+export async function uninstallScreenshotCorsRule(tabId: number): Promise<void> {
+  const ruleId = SCREENSHOT_CORS_RULE_ID_BASE + tabId
+  try {
+    await chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [ruleId]
+    })
+  } catch {
+    // best-effort teardown — never let a cleanup failure mask the original
+    // screenshot result
+  }
+}

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -1,7 +1,147 @@
 import { sendToContentScript } from "../content-bridge"
 import { sendToOffscreen } from "../offscreen"
+import { installScreenshotCorsRule, uninstallScreenshotCorsRule } from "./screenshot-cors"
 
 type ActionResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
+
+const CAPTURE_TIMEOUT_MS = 5000
+const DOM_RENDER_TIMEOUT_MS = 30_000
+const VISIBILITY_HINT = "Chrome/Brave window may not be visible — bring it to the front and retry, or pass --tab <id> of a tab in a visible window."
+
+class CaptureTimeoutError extends Error {
+  readonly operation: string
+  readonly timeoutMs: number
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms`)
+    this.name = "CaptureTimeoutError"
+    this.operation = operation
+    this.timeoutMs = timeoutMs
+  }
+}
+
+function withCaptureTimeout<T>(operation: string, p: Promise<T>, ms = CAPTURE_TIMEOUT_MS): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new CaptureTimeoutError(operation, ms)), ms)
+    p.then(
+      (val) => { clearTimeout(timer); resolve(val) },
+      (err) => { clearTimeout(timer); reject(err) }
+    )
+  })
+}
+
+async function stitchStripsInWorker(
+  strips: Array<{ dataUrl: string; y: number }>,
+  totalWidth: number,
+  totalHeight: number,
+  format: string,
+  quality: number
+): Promise<string | null> {
+  try {
+    const canvas = new OffscreenCanvas(totalWidth, totalHeight)
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return null
+    for (const strip of strips) {
+      const res = await fetch(strip.dataUrl)
+      const blob = await res.blob()
+      const bmp = await createImageBitmap(blob)
+      ctx.drawImage(bmp, 0, strip.y)
+      bmp.close?.()
+    }
+    const outBlob = await canvas.convertToBlob({
+      type: format === "png" ? "image/png" : "image/jpeg",
+      quality
+    })
+    const buf = await outBlob.arrayBuffer()
+    // base64-encode
+    let binary = ""
+    const bytes = new Uint8Array(buf)
+    const chunk = 0x8000
+    for (let i = 0; i < bytes.length; i += chunk) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+    }
+    const b64 = btoa(binary)
+    return `data:${format === "png" ? "image/png" : "image/jpeg"};base64,${b64}`
+  } catch (err) {
+    console.error("[stitchStripsInWorker] failed:", err)
+    return null
+  }
+}
+
+// ─── DOM render path (default) ────────────────────────────────────────────────
+
+type DomScreenshotMode = "full" | "element" | "selector" | "region"
+
+function resolveDomMode(action: { [key: string]: unknown }): DomScreenshotMode {
+  if (typeof action.selector === "string") return "selector"
+  if (action.element !== undefined || typeof action.ref === "string") return "element"
+  if (action.region || action.clip) return "region"
+  return "full"
+}
+
+async function injectScreenshotRunner(tabId: number): Promise<{ success: boolean; error?: string }> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "ISOLATED" as chrome.scripting.ExecutionWorld,
+      files: ["screenshot-runner.js"]
+    })
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: `failed to inject screenshot-runner.js: ${(err as Error).message}` }
+  }
+}
+
+async function handleDomRenderScreenshot(
+  action: { type: string; [key: string]: unknown },
+  tabId: number
+): Promise<ActionResult> {
+  const mode = resolveDomMode(action)
+  const format = (action.format as string) === "jpeg" ? "jpeg" : "png"
+  const quality = typeof action.quality === "number" ? (action.quality as number) : 92
+  const scale = typeof action.scale === "number" ? (action.scale as number) : undefined
+
+  const region = (action.region || action.clip) as { x: number; y: number; width: number; height: number } | undefined
+
+  const targetTab = await chrome.tabs.get(tabId).catch(() => null)
+  if (!targetTab) {
+    return { success: false, error: `tab ${tabId} not found` }
+  }
+
+  await installScreenshotCorsRule(tabId)
+  try {
+    const inject = await injectScreenshotRunner(tabId)
+    if (!inject.success) return { success: false, error: inject.error || "runner injection failed" }
+
+    const dsAction: { type: string; [key: string]: unknown } = { type: "dom_screenshot", mode, format, quality }
+    if (action.ref !== undefined) dsAction.ref = action.ref
+    if (action.element !== undefined) dsAction.index = action.element
+    if (action.selector !== undefined) dsAction.selector = action.selector
+    if (region) dsAction.region = region
+    if (scale !== undefined) dsAction.scale = scale
+
+    const renderResult = await sendToContentScript(tabId, dsAction) as { success: boolean; error?: string; data?: { dataUrl: string; format: string; width: number; height: number; pixelRatio: number; mode: string } }
+
+    if (!renderResult || !renderResult.success || !renderResult.data) {
+      return { success: false, error: renderResult?.error || "dom render returned no data" }
+    }
+
+    const dataUrl = renderResult.data.dataUrl
+    const width = renderResult.data.width
+    const height = renderResult.data.height
+
+    const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75)
+
+    if (action.save) {
+      return { success: true, data: { dataUrl, format, size: sizeBytes, width, height, mode, save: true } }
+    }
+
+    return { success: true, data: { dataUrl, format, size: sizeBytes, width, height, mode } }
+  } finally {
+    await uninstallScreenshotCorsRule(tabId)
+  }
+}
+
+// ─── Pixel-true path (--pixel escape hatch) ───────────────────────────────────
 
 export async function handleScreenshotBackground(
   action: { type: string; [key: string]: unknown },
@@ -10,33 +150,200 @@ export async function handleScreenshotBackground(
   const format = (action.format as string) === "png" ? "image/png" : "image/jpeg"
   const quality = ((action.quality as number) || 50) / 100
   try {
-    const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: tabId })
+    const streamId = await withCaptureTimeout(
+      "tabCapture.getMediaStreamId",
+      chrome.tabCapture.getMediaStreamId({ targetTabId: tabId })
+    )
     const contexts = await chrome.runtime.getContexts({
       contextTypes: ["OFFSCREEN_DOCUMENT" as chrome.runtime.ContextType]
     })
     if (contexts.length === 0) {
-      await chrome.offscreen.createDocument({
-        url: "offscreen.html",
-        reasons: ["USER_MEDIA" as chrome.offscreen.Reason],
-        justification: "Background tab screenshot via tabCapture"
-      })
+      await withCaptureTimeout(
+        "offscreen.createDocument",
+        chrome.offscreen.createDocument({
+          url: "offscreen.html",
+          reasons: ["USER_MEDIA" as chrome.offscreen.Reason],
+          justification: "Background tab screenshot via tabCapture"
+        })
+      )
     }
-    await new Promise<void>((resolve) => {
-      chrome.runtime.sendMessage({ target: "offscreen", type: "capture_start", streamId }, () => resolve())
-    })
+    await withCaptureTimeout(
+      "offscreen.capture_start",
+      new Promise<void>((resolve) => {
+        chrome.runtime.sendMessage({ target: "offscreen", type: "capture_start", streamId }, () => resolve())
+      })
+    )
     await new Promise(r => setTimeout(r, 300))
-    const frameResult = await sendToOffscreen({
-      type: "capture_frame", format, quality
-    }) as { success: boolean; data?: string; error?: string }
-    await sendToOffscreen({ type: "capture_stop" })
+    const frameResult = await withCaptureTimeout(
+      "offscreen.capture_frame",
+      sendToOffscreen({ type: "capture_frame", format, quality })
+    ) as { success: boolean; data?: string; error?: string }
+    await withCaptureTimeout(
+      "offscreen.capture_stop",
+      sendToOffscreen({ type: "capture_stop" })
+    ).catch(() => undefined)
     if (!frameResult.success) return { success: false, error: frameResult.error || "capture frame failed" }
     const dataUrl = frameResult.data!
     const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75)
     return { success: true, data: { dataUrl, format: action.format || "jpeg", size: sizeBytes, method: "tabCapture" } }
   } catch (err) {
+    if (err instanceof CaptureTimeoutError) {
+      return {
+        success: false,
+        error: `tabCapture timed out at ${err.operation} (${err.timeoutMs}ms)`,
+        data: { hint: VISIBILITY_HINT, layer: "tabCapture", timedOutAt: err.operation }
+      }
+    }
     return { success: false, error: `tabCapture failed: ${(err as Error).message}` }
   }
 }
+
+async function handlePixelScreenshot(
+  action: { type: string; [key: string]: unknown },
+  tabId: number
+): Promise<ActionResult> {
+  const format = (action.format as string) === "png" ? "png" : "jpeg"
+  const quality = (action.quality as number) || 50
+
+  if (action.full) {
+    const dims = await sendToContentScript(tabId, { type: "get_page_dimensions" }) as {
+      success: boolean
+      data?: { scrollHeight: number; scrollWidth: number; viewportHeight: number; viewportWidth: number; scrollY: number; devicePixelRatio: number }
+    }
+    if (!dims.success || !dims.data) return { success: false, error: "failed to get page dimensions" }
+    const { scrollHeight, viewportHeight, viewportWidth, scrollY: origScrollY, devicePixelRatio } = dims.data
+    const stripCount = Math.ceil(scrollHeight / viewportHeight)
+    const strips: { dataUrl: string; y: number }[] = []
+
+    const fullTab = await chrome.tabs.get(tabId).catch(() => null)
+    if (!fullTab) return { success: false, error: `tab ${tabId} not found`, data: { hint: VISIBILITY_HINT } }
+    const fullWindow = await chrome.windows.get(fullTab.windowId, { populate: false }).catch(() => null)
+    if (fullWindow && fullWindow.state === "minimized") {
+      return {
+        success: false,
+        error: `window ${fullTab.windowId} is minimized — captureVisibleTab cannot capture minimized windows`,
+        data: { hint: VISIBILITY_HINT, layer: "preflight", windowState: fullWindow.state }
+      }
+    }
+
+    for (let i = 0; i < stripCount; i++) {
+      const scrollTo = i * viewportHeight
+      await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo })
+      await new Promise(r => setTimeout(r, 150))
+      let stripUrl: string
+      try {
+        stripUrl = await withCaptureTimeout(
+          `captureVisibleTab(strip ${i + 1}/${stripCount})`,
+          chrome.tabs.captureVisibleTab(fullTab.windowId, { format, quality })
+        )
+      } catch (err) {
+        await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
+        if (err instanceof CaptureTimeoutError) {
+          return {
+            success: false,
+            error: `full-page screenshot failed: ${err.operation} timed out after ${err.timeoutMs}ms`,
+            data: { hint: VISIBILITY_HINT, layer: "captureVisibleTab", strip: i + 1, totalStrips: stripCount, timedOutAt: err.operation }
+          }
+        }
+        return { success: false, error: `captureVisibleTab failed on strip ${i + 1}/${stripCount}: ${(err as Error).message}` }
+      }
+      strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) })
+      // Chrome rate-limits captureVisibleTab to MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND
+      // (default: 2/sec). 1100ms between strips clears the quota with margin.
+      if (i < stripCount - 1) await new Promise(r => setTimeout(r, 1100))
+    }
+
+    await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
+
+    // Stitch inline in the SW using OffscreenCanvas — avoids the
+    // SW ↔ offscreen-document IPC round-trip which silently drops
+    // multi-hundred-KB messages. The SW already has access to
+    // OffscreenCanvas + createImageBitmap (it's a Worker context).
+    const stitchedUrl = await stitchStripsInWorker(
+      strips,
+      Math.round(viewportWidth * devicePixelRatio),
+      Math.round(scrollHeight * devicePixelRatio),
+      format,
+      quality / 100
+    )
+    if (!stitchedUrl) return { success: false, error: "stitch failed (could not render strips into OffscreenCanvas)" }
+    const stitchedSize = Math.round((stitchedUrl.length - stitchedUrl.indexOf(",") - 1) * 0.75)
+    if (action.save) {
+      return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, save: true, strips: stripCount } }
+    }
+    return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, strips: stripCount } }
+  }
+
+  const targetTab = await chrome.tabs.get(tabId).catch(() => null)
+  if (!targetTab) {
+    return { success: false, error: `tab ${tabId} not found`, data: { hint: VISIBILITY_HINT } }
+  }
+  const targetWindow = await chrome.windows.get(targetTab.windowId, { populate: false }).catch(() => null)
+  if (targetWindow && targetWindow.state === "minimized") {
+    return {
+      success: false,
+      error: `window ${targetTab.windowId} is minimized — captureVisibleTab cannot capture minimized windows`,
+      data: { hint: VISIBILITY_HINT, layer: "preflight", windowState: targetWindow.state }
+    }
+  }
+
+  let dataUrl: string
+  try {
+    dataUrl = await withCaptureTimeout(
+      "captureVisibleTab",
+      chrome.tabs.captureVisibleTab(targetTab.windowId, { format, quality })
+    )
+  } catch (err) {
+    if (err instanceof CaptureTimeoutError) {
+      return {
+        success: false,
+        error: `captureVisibleTab timed out after ${err.timeoutMs}ms`,
+        data: { hint: VISIBILITY_HINT, layer: "captureVisibleTab", timedOutAt: err.operation }
+      }
+    }
+    const fallback = await handleScreenshotBackground(
+      { type: "screenshot_background", format: action.format, quality: action.quality },
+      tabId
+    )
+    if (fallback.success && fallback.data) {
+      (fallback.data as Record<string, unknown>).fallback = "tabCapture (captureVisibleTab failed)"
+    }
+    return fallback
+  }
+  const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75)
+
+  if (action.save) {
+    return { success: true, data: { dataUrl, format, size: sizeBytes, save: true } }
+  }
+
+  let clip = action.clip as { x: number; y: number; width: number; height: number } | undefined
+  if (!clip && action.element !== undefined) {
+    const elemResult = await sendToContentScript(tabId, {
+      type: "rect", index: action.element
+    }) as { success: boolean; data?: { x: number; y: number; width: number; height: number } }
+    if (elemResult.success && elemResult.data) clip = elemResult.data
+  }
+
+  if (clip) {
+    const cropResult = await sendToOffscreen({ type: "crop", dataUrl, clip }) as {
+      success: boolean; data?: string; error?: string
+    }
+    if (!cropResult.success) return { success: false, error: cropResult.error }
+    const croppedUrl = cropResult.data!
+    const croppedSize = Math.round((croppedUrl.length - croppedUrl.indexOf(",") - 1) * 0.75)
+    return { success: true, data: { dataUrl: croppedUrl, format, size: croppedSize, clip } }
+  }
+
+  if (format === "png" && sizeBytes > 800 * 1024) {
+    return {
+      success: true,
+      data: { dataUrl, format, size: sizeBytes, warning: "PNG exceeds 800KB — consider using JPEG for smaller responses" }
+    }
+  }
+  return { success: true, data: { dataUrl, format, size: sizeBytes } }
+}
+
+// ─── Public dispatcher ────────────────────────────────────────────────────────
 
 export async function handleScreenshotActions(
   action: { type: string; [key: string]: unknown },
@@ -53,92 +360,12 @@ export async function handleScreenshotActions(
     }
 
     case "screenshot": {
-      const format = (action.format as string) === "png" ? "png" : "jpeg"
-      const quality = (action.quality as number) || 50
-
-      if (action.full) {
-        const dims = await sendToContentScript(tabId, { type: "get_page_dimensions" }) as {
-          success: boolean
-          data?: { scrollHeight: number; scrollWidth: number; viewportHeight: number; viewportWidth: number; scrollY: number; devicePixelRatio: number }
-        }
-        if (!dims.success || !dims.data) return { success: false, error: "failed to get page dimensions" }
-        const { scrollHeight, viewportHeight, viewportWidth, scrollY: origScrollY, devicePixelRatio } = dims.data
-        const stripCount = Math.ceil(scrollHeight / viewportHeight)
-        const strips: { dataUrl: string; y: number }[] = []
-
-        for (let i = 0; i < stripCount; i++) {
-          const scrollTo = i * viewportHeight
-          await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo })
-          await new Promise(r => setTimeout(r, 150))
-          const stripUrl = await chrome.tabs.captureVisibleTab({ format, quality })
-          strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) })
-          if (i < stripCount - 1) await new Promise(r => setTimeout(r, 500))
-        }
-
-        await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY })
-
-        const stitchResult = await sendToOffscreen({
-          type: "stitch",
-          strips,
-          totalWidth: Math.round(viewportWidth * devicePixelRatio),
-          totalHeight: Math.round(scrollHeight * devicePixelRatio),
-          format,
-          quality: quality / 100
-        }) as { success: boolean; data?: string; error?: string }
-
-        if (!stitchResult.success) return { success: false, error: stitchResult.error }
-        const stitchedUrl = stitchResult.data!
-        const stitchedSize = Math.round((stitchedUrl.length - stitchedUrl.indexOf(",") - 1) * 0.75)
-        if (action.save) {
-          return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, save: true, strips: stripCount } }
-        }
-        return { success: true, data: { dataUrl: stitchedUrl, format, size: stitchedSize, strips: stripCount } }
+      // --pixel flag routes to the legacy captureVisibleTab path. Default
+      // path is the new DOM-render pipeline (PRD-44).
+      if (action.pixel === true) {
+        return handlePixelScreenshot(action, tabId)
       }
-
-      let dataUrl: string
-      try {
-        dataUrl = await chrome.tabs.captureVisibleTab({ format, quality })
-      } catch {
-        const fallback = await handleScreenshotBackground(
-          { type: "screenshot_background", format: action.format, quality: action.quality },
-          tabId
-        )
-        if (fallback.success && fallback.data) {
-          (fallback.data as Record<string, unknown>).fallback = "tabCapture (captureVisibleTab failed)"
-        }
-        return fallback
-      }
-      const sizeBytes = Math.round((dataUrl.length - dataUrl.indexOf(",") - 1) * 0.75)
-
-      if (action.save) {
-        return { success: true, data: { dataUrl, format, size: sizeBytes, save: true } }
-      }
-
-      let clip = action.clip as { x: number; y: number; width: number; height: number } | undefined
-      if (!clip && action.element !== undefined) {
-        const elemResult = await sendToContentScript(tabId, {
-          type: "rect", index: action.element
-        }) as { success: boolean; data?: { x: number; y: number; width: number; height: number } }
-        if (elemResult.success && elemResult.data) clip = elemResult.data
-      }
-
-      if (clip) {
-        const cropResult = await sendToOffscreen({ type: "crop", dataUrl, clip }) as {
-          success: boolean; data?: string; error?: string
-        }
-        if (!cropResult.success) return { success: false, error: cropResult.error }
-        const croppedUrl = cropResult.data!
-        const croppedSize = Math.round((croppedUrl.length - croppedUrl.indexOf(",") - 1) * 0.75)
-        return { success: true, data: { dataUrl: croppedUrl, format, size: croppedSize, clip } }
-      }
-
-      if (format === "png" && sizeBytes > 800 * 1024) {
-        return {
-          success: true,
-          data: { dataUrl, format, size: sizeBytes, warning: "PNG exceeds 800KB — consider using JPEG for smaller responses" }
-        }
-      }
-      return { success: true, data: { dataUrl, format, size: sizeBytes } }
+      return handleDomRenderScreenshot(action, tabId)
     }
   }
   return { success: false, error: `unknown screenshot action: ${action.type}` }

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -27,6 +27,7 @@ import { handleRect, handleRegions } from "./content/inspection/rect"
 import { handleModals, handlePanels } from "./content/inspection/modals"
 import { handleFindElement, handleSemanticResolve, handleFindAndClick, handleFindAndType, handleFindAndCheck } from "./content/find"
 import { handleCanvasAction } from "./content/scene/engine"
+import { handleDomScreenshot } from "./content/dom-screenshot"
 
 type Action = { type: string; [key: string]: unknown }
 type ActionResult = { success: boolean; error?: string; warning?: string; data?: unknown; changes?: unknown }
@@ -149,6 +150,7 @@ async function executeAction(action: Action): Promise<ActionResult> {
         return diffResult
       }
       case "find_element":        return handleFindElement(action)
+      case "dom_screenshot":      return handleDomScreenshot(action as Parameters<typeof handleDomScreenshot>[0])
       case "modals":              return handleModals(action)
       case "panels":              return handlePanels(action)
       case "click_at":            return handleClickAt(action)

--- a/extension/src/content/dom-screenshot.ts
+++ b/extension/src/content/dom-screenshot.ts
@@ -1,0 +1,221 @@
+// dom-screenshot.ts
+//
+// Content-script handler for the DOM-render screenshot pipeline.
+// Driven by `case "dom_screenshot":` in content.ts.
+//
+// Pre-conditions:
+//   - The vendored html-to-image bundle must already be injected into this
+//     frame's ISOLATED world via chrome.scripting.executeScript({ files:
+//     ["screenshot-runner.js"], world: "ISOLATED" }). The runner sets
+//     globalThis.__interceptor_h2i.
+//   - The CORS DNR session rule must be active for the duration of this call
+//     so that third-party <img>, font, and <video> resources fetched (or
+//     re-fetched) by html-to-image come back with `Access-Control-Allow-Origin:
+//     *`. The SW handler installs and removes that rule in a try/finally.
+
+import { resolveElement } from "./input-simulation"
+
+type ActionResult = { success: boolean; error?: string; data?: unknown }
+
+type DomScreenshotAction = {
+  type: string
+  mode?: "full" | "element" | "selector" | "region"
+  ref?: string
+  index?: number
+  selector?: string
+  region?: { x: number; y: number; width: number; height: number }
+  format?: "png" | "jpeg"
+  quality?: number
+  scale?: number
+}
+
+type H2iLib = {
+  toPng: (node: HTMLElement, options?: Record<string, unknown>) => Promise<string>
+  toJpeg: (node: HTMLElement, options?: Record<string, unknown>) => Promise<string>
+}
+
+function getLibrary(): H2iLib | null {
+  return (globalThis as unknown as { __interceptor_h2i?: H2iLib }).__interceptor_h2i ?? null
+}
+
+async function cropDataUrl(
+  dataUrl: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  format: "png" | "jpeg",
+  quality: number
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      try {
+        const canvas = document.createElement("canvas")
+        canvas.width = w
+        canvas.height = h
+        const ctx = canvas.getContext("2d")
+        if (!ctx) { resolve(null); return }
+        ctx.drawImage(img, x, y, w, h, 0, 0, w, h)
+        const out = format === "jpeg"
+          ? canvas.toDataURL("image/jpeg", quality)
+          : canvas.toDataURL("image/png")
+        resolve(out)
+      } catch {
+        resolve(null)
+      }
+    }
+    img.onerror = () => resolve(null)
+    img.src = dataUrl
+  })
+}
+
+function resolveTarget(action: DomScreenshotAction): { node: HTMLElement | null; error?: string } {
+  const mode = action.mode || "full"
+  switch (mode) {
+    case "full":
+    case "region":
+      return { node: document.documentElement }
+    case "element": {
+      if (action.ref === undefined && action.index === undefined) {
+        return { node: null, error: "element mode requires ref or index" }
+      }
+      const el = resolveElement(action.index, action.ref)
+      if (!el) {
+        const label = String(action.ref ?? action.index ?? "unknown")
+        return { node: null, error: `stale element [${label}] — run interceptor state to refresh` }
+      }
+      if (!(el instanceof HTMLElement)) {
+        return { node: null, error: `target is not an HTMLElement (got ${el.constructor.name})` }
+      }
+      return { node: el }
+    }
+    case "selector": {
+      if (!action.selector) {
+        return { node: null, error: "selector mode requires selector string" }
+      }
+      const el = document.querySelector(action.selector)
+      if (!el) return { node: null, error: `selector not found: ${action.selector}` }
+      if (!(el instanceof HTMLElement)) {
+        return { node: null, error: `selector matched non-HTMLElement (got ${el.constructor.name})` }
+      }
+      return { node: el }
+    }
+    default:
+      return { node: null, error: `unknown screenshot mode: ${mode}` }
+  }
+}
+
+export async function handleDomScreenshot(action: DomScreenshotAction): Promise<ActionResult> {
+  const lib = getLibrary()
+  if (!lib) {
+    return {
+      success: false,
+      error: "html-to-image library not loaded into this frame — SW must inject screenshot-runner.js before dispatching dom_screenshot"
+    }
+  }
+
+  const { node, error } = resolveTarget(action)
+  if (!node) return { success: false, error: error || "no target resolved" }
+
+  const format = action.format === "jpeg" ? "jpeg" : "png"
+  const qualityPct = typeof action.quality === "number" ? Math.max(1, Math.min(100, action.quality)) : 92
+  const pixelRatio = typeof action.scale === "number" && action.scale > 0
+    ? action.scale
+    : (window.devicePixelRatio || 1)
+
+  // 1×1 transparent PNG used as a placeholder for any image that html-to-image
+  // can't fetch CORS-clean. Without a placeholder, the library falls back to
+  // drawing the page's already-loaded <img> element, which taints the canvas
+  // and breaks toDataURL().
+  const TRANSPARENT_1PX = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg=="
+
+  const opts: Record<string, unknown> = {
+    cacheBust: true,
+    pixelRatio,
+    quality: qualityPct / 100,
+    skipFonts: true,
+    imagePlaceholder: TRANSPARENT_1PX,
+    fetchRequestInit: { mode: "cors", cache: "no-cache" },
+  }
+
+  // First attempt: render as-is. Many image-heavy pages have third-party
+  // <img> or CSS background-images that html-to-image can't fetch
+  // CORS-clean even with our DNR rule (cached responses, server quirks),
+  // and drawing those onto a canvas taints it. If we hit a tainted-canvas
+  // error, retry with a filter that excludes <img> and <picture> elements
+  // so the structural render still succeeds (without images).
+  const renderWithOpts = async (effectiveOpts: Record<string, unknown>): Promise<string> => {
+    return format === "jpeg"
+      ? await lib.toJpeg(node, effectiveOpts)
+      : await lib.toPng(node, effectiveOpts)
+  }
+
+  // For "full" mode, force the node's effective dimensions to the document's
+  // scrollWidth/scrollHeight so html-to-image renders the whole page rather
+  // than just the viewport-clipped portion.
+  const isFull = (action.mode || "full") === "full" || (action.mode === "region")
+  if (isFull) {
+    opts.width = Math.max(document.documentElement.scrollWidth, document.body?.scrollWidth || 0)
+    opts.height = Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight || 0)
+    opts.canvasWidth = (opts.width as number) * pixelRatio
+    opts.canvasHeight = (opts.height as number) * pixelRatio
+  }
+
+  try {
+    let dataUrl: string
+    try {
+      dataUrl = await renderWithOpts(opts)
+    } catch (err) {
+      const msg = (err as Error).message || String(err)
+      const isTaint = /taint|cross-origin|may not be exported/i.test(msg)
+      if (!isTaint) throw err
+      // Retry without images
+      const filteredOpts: Record<string, unknown> = {
+        ...opts,
+        filter: (n: Node) => {
+          if (!(n instanceof Element)) return true
+          const tag = n.tagName?.toLowerCase()
+          return tag !== "img" && tag !== "picture" && tag !== "video" && tag !== "canvas"
+        }
+      }
+      dataUrl = await renderWithOpts(filteredOpts)
+    }
+
+    const rect = node.getBoundingClientRect()
+    let outWidth = Math.round((isFull ? (opts.width as number) : rect.width) * pixelRatio)
+    let outHeight = Math.round((isFull ? (opts.height as number) : rect.height) * pixelRatio)
+
+    // Region mode: crop directly here in the content script before sending
+    // the dataUrl back. The cropped image is much smaller than the full
+    // render, which keeps the inter-frame and SW→daemon messages well under
+    // any size limit.
+    if ((action.mode === "region") && action.region) {
+      const region = action.region
+      const cropX = Math.round(region.x * pixelRatio)
+      const cropY = Math.round(region.y * pixelRatio)
+      const cropW = Math.round(region.width * pixelRatio)
+      const cropH = Math.round(region.height * pixelRatio)
+      const cropped = await cropDataUrl(dataUrl, cropX, cropY, cropW, cropH, format, qualityPct / 100)
+      if (cropped) {
+        dataUrl = cropped
+        outWidth = cropW
+        outHeight = cropH
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        dataUrl,
+        format,
+        width: outWidth,
+        height: outHeight,
+        pixelRatio,
+        mode: action.mode || "full",
+      }
+    }
+  } catch (err) {
+    return { success: false, error: `dom render failed: ${(err as Error).message}` }
+  }
+}

--- a/extension/src/screenshot-runner.ts
+++ b/extension/src/screenshot-runner.ts
@@ -1,0 +1,16 @@
+// screenshot-runner.ts
+//
+// Bundle entry that vendors html-to-image into the extension and exposes it on
+// globalThis for content.js to call. Loaded on demand via
+// chrome.scripting.executeScript({ files: ["screenshot-runner.js"] }) — NOT as
+// a content_scripts entry, so pages that never get screenshotted pay no cost.
+//
+// Runs in the ISOLATED world (per scripting.executeScript world: "ISOLATED"),
+// so it shares globalThis with the rest of the extension's content scripts on
+// the same frame. content.ts's `case "dom_screenshot":` reads
+// `globalThis.__interceptor_h2i` to call the library.
+
+import * as h2i from "html-to-image"
+
+;(globalThis as unknown as { __interceptor_h2i?: typeof h2i; __interceptor_h2i_loaded?: boolean }).__interceptor_h2i = h2i
+;(globalThis as unknown as { __interceptor_h2i?: typeof h2i; __interceptor_h2i_loaded?: boolean }).__interceptor_h2i_loaded = true

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "@types/chrome": "latest",
     "happy-dom": "^20.9.0",
     "ocrad.js": "^0.0.1"
+  },
+  "dependencies": {
+    "html-to-image": "^1.11.13"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,7 @@ build_extension() {
   bun build extension/src/content.ts --outdir=extension/dist --target=browser
   bun build extension/src/inject-net.ts --outdir=extension/dist --target=browser
   bun build extension/src/inject-canvas.ts --outdir=extension/dist --target=browser
+  bun build extension/src/screenshot-runner.ts --outdir=extension/dist --target=browser
   bun build extension/src/offscreen.ts --outfile=extension/dist/offscreen.js --target=browser
   cp extension/manifest.json extension/dist/
   cp extension/offscreen.html extension/dist/

--- a/scripts/install-bridge.sh
+++ b/scripts/install-bridge.sh
@@ -6,6 +6,13 @@ set -euo pipefail
 # Usage:
 #   bash scripts/build-bridge.sh
 #   bash scripts/install-bridge.sh
+#
+# Env overrides:
+#   INTERCEPTOR_BRIDGE_BIN   Absolute path to use as the bridge binary in the
+#                            generated LaunchAgent plist. When set, the binary
+#                            is NOT copied — the path is referenced as-is.
+#                            Useful for power users who symlink to the repo
+#                            build output instead of installing a copy.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -14,17 +21,41 @@ BINARY_SRC="$DIST_DIR/interceptor-bridge"
 
 PLIST_NAME="com.interceptor.bridge"
 PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME.plist"
-BINARY_DST="/usr/local/bin/interceptor-bridge"
+
+if [[ -n "${INTERCEPTOR_BRIDGE_BIN:-}" ]]; then
+  BINARY_DST="$INTERCEPTOR_BRIDGE_BIN"
+  USE_OVERRIDE=1
+else
+  BINARY_DST="$HOME/.local/bin/interceptor-bridge"
+  USE_OVERRIDE=0
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "ERROR: interceptor-bridge is macOS only."
   exit 1
 fi
 
-if [[ ! -f "$BINARY_SRC" ]]; then
-  echo "ERROR: bridge binary not found at $BINARY_SRC"
-  echo "Run: bash scripts/build-bridge.sh"
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  echo "ERROR: do not run install-bridge.sh with sudo." >&2
+  echo "       LaunchAgents are user-scoped — running as root installs them" >&2
+  echo "       under /var/root and tries to bootstrap into gui/0, which is not" >&2
+  echo "       a real domain (root has no GUI session). Re-run as your user:" >&2
+  echo "         bash scripts/install-bridge.sh" >&2
   exit 1
+fi
+
+if [[ "$USE_OVERRIDE" == "1" ]]; then
+  if [[ ! -e "$BINARY_DST" ]]; then
+    echo "ERROR: INTERCEPTOR_BRIDGE_BIN points to a path that does not exist:" >&2
+    echo "       $BINARY_DST" >&2
+    exit 1
+  fi
+else
+  if [[ ! -f "$BINARY_SRC" ]]; then
+    echo "ERROR: bridge binary not found at $BINARY_SRC"
+    echo "Run: bash scripts/build-bridge.sh"
+    exit 1
+  fi
 fi
 
 if launchctl list | grep -q "$PLIST_NAME" 2>/dev/null; then
@@ -38,9 +69,24 @@ if [[ -f /tmp/interceptor-bridge.pid ]]; then
   sleep 1
 fi
 
-echo "==> Installing bridge binary to $BINARY_DST..."
-cp "$BINARY_SRC" "$BINARY_DST"
-chmod +x "$BINARY_DST"
+if [[ "$USE_OVERRIDE" == "1" ]]; then
+  echo "==> Using bridge binary at $BINARY_DST (INTERCEPTOR_BRIDGE_BIN override; skipping copy)..."
+else
+  BINARY_PARENT="$(dirname "$BINARY_DST")"
+  mkdir -p "$BINARY_PARENT"
+  echo "==> Installing bridge binary to $BINARY_DST..."
+  cp "$BINARY_SRC" "$BINARY_DST"
+  chmod +x "$BINARY_DST"
+
+  case ":$PATH:" in
+    *":$BINARY_PARENT:"*) ;;
+    *)
+      echo "WARN: $BINARY_PARENT is not on your PATH. Add it so 'interceptor-bridge' is reachable directly:" >&2
+      echo "        echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc   # or ~/.bashrc" >&2
+      echo "      The LaunchAgent itself uses the absolute path and will run regardless." >&2
+      ;;
+  esac
+fi
 
 echo "==> Installing LaunchAgent plist..."
 mkdir -p "$HOME/Library/LaunchAgents"


### PR DESCRIPTION
Closes #43.

## Summary

- Replace the default `interceptor screenshot` path with a DOM-to-canvas render via a vendored `html-to-image` bundle injected on demand. No `chrome.tabs.captureVisibleTab` in the hot path.
- Per-tab `declarativeNetRequest` session rule grants ACAO clearance to subresource fetches during a capture; removed in `try/finally`. Mirrors the CSP-bypass lifecycle in `evaluate.ts`.
- Legacy compositor path retained behind `--pixel`. `--pixel --full` strip cadence raised above 1s to clear `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND`; strips are stitched in-SW via `OffscreenCanvas` rather than round-tripping through the offscreen-document handler.
- New flags: `--selector <css>`, `--region X,Y,W,H`, `--scale <n>`, `--pixel`. `--clip` preserved as deprecated alias.
- CLI auto-routes `screenshot` invocations through WebSocket transport because base64 dataUrl payloads above ~50 KB are unreliable over native messaging on Brave/Chromium despite the documented 1 MB cap. Override with `--no-ws`.
- Carryover from the prior `install-bridge.sh` audit: default install path moves to `$HOME/.local/bin/interceptor-bridge` with `mkdir -p`, sudo guard, PATH warning, and `INTERCEPTOR_BRIDGE_BIN` env override.
- Docs updated: `README.md`, `CLAUDE.md`, `AGENTS.md`, `ARCHITECTURE.md` (new "Screenshot Pipeline" section).

## Anti-criteria honored

- No changes to `message-dispatch.ts`, `transport.ts`, `router.ts`, or `content-bridge.ts`.
- No daemon changes; no bridge changes.
- No CDP / `chrome.debugger` use added.
- No new manifest permissions.
- `screenshot_background` and `page_capture` action types preserved.

## Test plan

- [x] `bash scripts/build.sh` clean.
- [x] `bun test` — 78/78 pass, 221 expect() calls.
- [x] `bun run typecheck` — clean across host, extension, root tsconfigs.
- [x] `interceptor screenshot --save` end-to-end on a normal-CSS page (e.g. example.com) with Brave **not** focused: returns a valid PNG.
- [x] `interceptor screenshot --selector "h1" --save` and `--region X,Y,W,H --save` produce correct partial captures.
- [x] Three consecutive `interceptor screenshot` calls all succeed; subsequent `interceptor tabs` returns in < 50ms — proves no SW wedge.
- [x] `interceptor screenshot --pixel --full --save` produces a stitched JPEG on an image-heavy page (multi-viewport scroll, in-SW stitch).
- [x] `interceptor screenshot` on a page whose third-party assets cannot be CORS-cleansed falls through to the structural-only render automatically.
- [ ] CI green on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Default screenshot mode now renders via DOM, eliminating browser focus requirements and working with backgrounded windows.
  * Added command options: `--selector` for CSS targeting, `--region` for coordinate-based cropping, `--scale` for pixel-ratio adjustment, and `--element` for off-screen element capture.
  * Introduced `--pixel` mode for compositor-accurate full-page captures with stitching support.
  * Large screenshot payloads now route via WebSocket by default for improved reliability.

* **Documentation**
  * Updated all documentation to reflect new default capture behavior and expanded command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->