### PR TITLE
docs(readme): clarify status vs open <url> for first-run verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,17 +263,20 @@ bash scripts/uninstall.sh --bridge-only     # Remove only the macOS bridge (down
 #### Verify
 
 ```bash
-./dist/interceptor status
-# Browser-only install:
+./dist/interceptor status                     # Self-check (local pre-spawn) — does NOT start the daemon
+./dist/interceptor open https://example.com   # Canonical first-run check — spawns the daemon and exercises the full stack
+# Browser-only install reports:
 #   mode: browser-only
 #   daemon: running
 #   ...
-# Full install:
+# Full install reports:
 #   mode: full
 #   daemon: running
 #   bridge: running
 #   ...
 ```
+
+`daemon: not running` from `status` on a fresh install is normal — `status` is a local pre-spawn check that never starts the daemon. Run `interceptor open <url>` to spawn the daemon and verify the daemon, native messaging bridge, extension, and page together.
 
 In browser-only mode, running an `interceptor macos *` command returns a structured "requires full computer-use install" error within 1 second instead of timing out at 15 seconds.
 


### PR DESCRIPTION
## Summary
- Reframe `./dist/interceptor status` as the local pre-spawn self-check — explicitly note it does NOT start the daemon.
- Document `./dist/interceptor open <url>` as the canonical behavioural verify that exercises daemon, native messaging bridge, extension, and page together.
- Add a one-liner that `daemon: not running` from `status` on a fresh install is expected, not a failure.

Closes #45

## Test plan
- [ ] Updated README "Verify" section renders correctly on GitHub
- [ ] Wording matches the proposal in #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verification instructions to clarify that `interceptor status` performs only a local self-check and does not start the daemon.
  * Introduced a new canonical first-run verification command that spawns the daemon and exercises the full stack.
  * Added guidance explaining expected behavior for fresh installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->