### PR TITLE
docs(readme): inline optional PATH symlink in 60-second install block

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ bash scripts/install.sh --brave --profile Default
 ./dist/interceptor status
 ```
 
-If Brave is already open, the install script asks before quitting and relaunching it with `extension/dist/` loaded. If you want `interceptor` on your `PATH`, symlink `dist/interceptor` into a directory already on your shell path; otherwise use `./dist/interceptor` from the repo.
+Optional — put `interceptor` on your `PATH` (binds the binary location to this repo):
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf "$PWD/dist/interceptor" ~/.local/bin/interceptor
+```
+
+If Brave is already open, the install script asks before quitting and relaunching it with `extension/dist/` loaded. Without the optional symlink, run commands as `./dist/interceptor` from the repo.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Inline `mkdir -p ~/.local/bin && ln -sf "$PWD/dist/interceptor" ~/.local/bin/interceptor` directly in the 60-second install block, framed as optional.
- Note that the symlink binds the binary location to the source repo.
- Tighten trailing prose so the block is paste-and-run for both repo-relative and PATH-installed use without scrolling further down the README.

Cross-link to a future dev-mode-vs-managed-install issue is omitted since that issue is not yet filed; happy to add it in a follow-up once it exists.

Closes #46

## Test plan
- [ ] Updated README "Install In 60 Seconds" section renders correctly on GitHub
- [ ] Acceptance criterion met: 60-second block is paste-and-run for both repo-relative and PATH-installed use, no scrolling required