### PR TITLE
docs(readme): link Brave in Prerequisites and add platform install hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The recommended install path for end users is the signed `.pkg` documented in [I
 #### Prerequisites
 
 - [Bun](https://bun.sh/) runtime
+<<<<<<< HEAD
 - Brave Browser (or Chrome — see Chrome path below)
 - Xcode command line tools (only required if you want to build the macOS bridge)
 
@@ -203,6 +204,12 @@ The recommended install path for end users is the signed `.pkg` documented in [I
 | **`--full`** | Everything in browser-only **plus** the Swift bridge `.app`, the LaunchAgent, and the macOS subcommands | Screen Recording, Accessibility, Apple Events (per-target-app on first dispatch) | You need `interceptor macos *` (native AX tree, OS-level input, ScreenCaptureKit, Vision/Speech/NLP). macOS only. |
 
 If you don't pass either flag, the script prompts. The default in the prompt is `--full` on macOS, `--browser-only` everywhere else.
+=======
+- [Brave Browser](https://brave.com/download/)
+  - **macOS:** `brew install --cask brave-browser`
+  - **Windows:** `winget install Brave.Brave` (or `choco install brave`)
+  - **Linux:** `sudo snap install brave` or `flatpak install flathub com.brave.Browser`. For native package-manager installs (apt/dnf/zypper/AUR), see the [official Linux guide](https://brave.com/linux/).
+>>>>>>> fb06399 (docs(readme): link Brave in Prerequisites and add platform install hints)
 
 #### Build and Install
 


### PR DESCRIPTION
## Summary
- Make `Brave Browser` a clickable link to https://brave.com/download/, matching the linked Bun entry above it.
- Add paste-and-run install hints for macOS (`brew`), Windows (`winget` / `choco`), and Linux (`snap` / `flatpak`).
- Link to the [official Linux guide](https://brave.com/linux/) for native package-manager installs (apt/dnf/zypper/AUR) rather than reproduce the repo-key dance inline.

Closes #47

## Test plan
- [ ] Updated README "Prerequisites" renders correctly on GitHub
- [ ] Acceptance criteria met: both prereq lines provide a one-click install path; Linux users have at least one paste-and-run option inline plus a link for native package managers