### PR TITLE
feat(open): add --reuse flag to navigate existing managed tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,10 @@ interceptor open https://example.com --full
 interceptor open https://example.com --tree-only
 interceptor open https://example.com --text-only
 interceptor open https://example.com --timeout 15000
+interceptor open https://example.com --reuse        # Long automation: navigate the most recent Interceptor-group tab instead of opening a new one
 ```
+
+For long-running automation that calls `open` many times in a single session — verification loops, batch inspections, repeated probes against the same surface — pass `--reuse` so each call navigates the same managed tab instead of leaving a dead tab behind. Without `--reuse`, every `open` creates a new tab and the browser fills with stale tabs over the course of a session. `--reuse` is opt-in to preserve existing scripts that depend on a fresh tab per call; it falls back to creating a new tab when the Interceptor group is empty or the candidate tab vanishes between query and navigation.
 
 Use `read` for current state. Use a ref to limit the read to a subtree.
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ interceptor open "https://example.com" --tree-only   # Skip text
 interceptor open "https://example.com" --text-only   # Skip tree
 interceptor open "https://example.com" --full        # Full text (no 2000-char limit)
 interceptor open "https://example.com" --no-wait     # Don't wait for load
+interceptor open "https://example.com" --reuse        # Reuse the most recent Interceptor-group tab (long automation: avoids tab accumulation)
 interceptor read                              # Tree + text for current page
 interceptor read e5                           # Tree + text for element subtree
 interceptor read --tree-only                  # Just tree

--- a/cli/commands/compound.ts
+++ b/cli/commands/compound.ts
@@ -113,6 +113,15 @@ export function buildReadTreeAction(opts: {
 
 // ── interceptor open <url> ──────────────────────────────────────────────────────────
 
+export function buildTabCreateAction(
+  filtered: string[],
+  url: string
+): { type: "tab_create"; url: string; reuse?: boolean } {
+  const action: { type: "tab_create"; url: string; reuse?: boolean } = { type: "tab_create", url }
+  if (filtered.includes("--reuse")) action.reuse = true
+  return action
+}
+
 export async function runOpen(
   filtered: string[],
   globalTabId?: number,
@@ -132,17 +141,19 @@ export async function runOpen(
   const timeoutIdx = filtered.indexOf("--timeout")
   const timeout = timeoutIdx !== -1 ? parseInt(filtered[timeoutIdx + 1]) : 5000
 
-  // Step 1: Create tab
-  const createResult = await send({ type: "tab_create", url }, globalTabId, useWs)
+  // Step 1: Create tab (or reuse an existing managed one when --reuse is set)
+  const createAction = buildTabCreateAction(filtered, url)
+  const createResult = await send(createAction, globalTabId, useWs)
   if (!createResult.success) {
     output(jsonMode, { success: false, error: createResult.error || "failed to create tab" })
     return
   }
   const dataObj = (typeof createResult.data === "object" && createResult.data) ? createResult.data as Record<string, unknown> : {}
   const tabId = (dataObj.tabId as number) || createResult.tabId || globalTabId
+  const reused = dataObj.reused === true
 
   if (noWait) {
-    output(jsonMode, { success: true, data: { tabId, url, message: "tab created (no-wait)" } })
+    output(jsonMode, { success: true, data: { tabId, url, reused, message: reused ? "tab reused (no-wait)" : "tab created (no-wait)" } })
     return
   }
 
@@ -196,7 +207,7 @@ export async function runOpen(
   if (jsonMode) {
     const result: { success: boolean; data?: unknown; warning?: string } = {
       success: true,
-      data: { tabId, url, tree: treeData || undefined, text: textContent || undefined }
+      data: { tabId, url, reused, tree: treeData || undefined, text: textContent || undefined }
     }
     if (aggregate.warnings?.length) result.warning = aggregate.warnings.join("; ")
     output(jsonMode, result)
@@ -206,7 +217,7 @@ export async function runOpen(
   if (aggregate.warnings?.length) console.error(`warning: ${aggregate.warnings.join("; ")}`)
 
   // Pretty output
-  parts.push(`Tab: ${tabId} | ${url}`)
+  parts.push(`Tab: ${tabId} | ${url}${reused ? " (reused)" : ""}`)
   if (treeData) {
     parts.push("")
     parts.push(treeData)

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -33,6 +33,7 @@ Compound (agent-optimized):
   interceptor open <url> --full              Full text instead of 2000-char summary
   interceptor open <url> --timeout <ms>      Override wait-stable timeout (default 5000)
   interceptor open <url> --no-wait           Return immediately after tab creation
+  interceptor open <url> --reuse             Navigate the most recent Interceptor-group tab instead of opening a new one (cleans up long automation runs)
   interceptor read                           Tree + text for active tab
   interceptor read <ref>                     Tree + text for element subtree
   interceptor read --tree-only               Skip text

--- a/extension/background.js
+++ b/extension/background.js
@@ -1582,12 +1582,32 @@ async function handleCanvasActions(action, tabId) {
 async function handleTabActions(action, tabId) {
   switch (action.type) {
     case "tab_create": {
-      const newTab = await chrome.tabs.create({ url: action.url || "about:blank" });
+      const targetUrl = action.url || "about:blank";
+      if (action.reuse) {
+        const groupId2 = await ensureInterceptorGroup();
+        if (groupId2 !== -1) {
+          const groupTabs = await chrome.tabs.query({ groupId: groupId2 });
+          if (groupTabs.length > 0) {
+            const sorted = groupTabs.filter((t) => typeof t.id === "number").sort((a, b) => b.id - a.id);
+            const candidate = sorted[0];
+            if (candidate?.id !== void 0) {
+              try {
+                const updated = await chrome.tabs.update(candidate.id, { url: targetUrl });
+                await waitForTabLoad(candidate.id);
+                await chrome.storage.session.set({ activeTabId: candidate.id });
+                return { success: true, data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId: groupId2, reused: true } };
+              } catch {
+              }
+            }
+          }
+        }
+      }
+      const newTab = await chrome.tabs.create({ url: targetUrl });
       if (newTab.id) {
         const groupId = await addTabToInterceptorGroup(newTab.id);
-        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId } };
+        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, reused: false } };
       }
-      return { success: true, data: { tabId: newTab.id, url: newTab.url } };
+      return { success: true, data: { tabId: newTab.id, url: newTab.url, reused: false } };
     }
     case "tab_close":
       await chrome.tabs.remove(action.tabId || tabId);

--- a/extension/src/background/capabilities/tabs.ts
+++ b/extension/src/background/capabilities/tabs.ts
@@ -9,7 +9,43 @@ export async function handleTabActions(
 ): Promise<ActionResult> {
   switch (action.type) {
     case "tab_create": {
-      const newTab = await chrome.tabs.create({ url: (action.url as string) || "about:blank" })
+      const targetUrl = (action.url as string) || "about:blank"
+      // When `reuse` is set, navigate the most recently created tab inside
+      // the Interceptor group instead of opening a new one. Long-running
+      // automations would otherwise leave a dead tab behind on every call
+      // (dora-cc#5). Falls back to creating a new tab if the group is empty
+      // or the candidate tab disappeared between query and update.
+      if (action.reuse) {
+        const groupId = await ensureInterceptorGroup()
+        if (groupId !== -1) {
+          const groupTabs = await chrome.tabs.query({ groupId })
+          if (groupTabs.length > 0) {
+            const sorted = groupTabs
+              .filter(t => typeof t.id === "number")
+              .sort((a, b) => (b.id as number) - (a.id as number))
+            const candidate = sorted[0]
+            if (candidate?.id !== undefined) {
+              try {
+                const updated = await chrome.tabs.update(candidate.id, { url: targetUrl })
+                await waitForTabLoad(candidate.id)
+                // Pin the reused tab as the auto-target for subsequent commands.
+                // Mirrors the new-tab path below: every successful tab_create
+                // — whether new or reused — must update activeTabId so a fresh
+                // CLI invocation (no --tab) routes here instead of a stale id
+                // or the user's foreground tab.
+                await chrome.storage.session.set({ activeTabId: candidate.id })
+                return {
+                  success: true,
+                  data: { tabId: candidate.id, url: updated?.url ?? targetUrl, groupId, reused: true }
+                }
+              } catch {
+                // Tab vanished between query and update — fall through to create.
+              }
+            }
+          }
+        }
+      }
+      const newTab = await chrome.tabs.create({ url: targetUrl })
       if (newTab.id) {
         const groupId = await addTabToInterceptorGroup(newTab.id)
         // Pin the newly-created tab as the auto-target for subsequent commands
@@ -17,9 +53,9 @@ export async function handleTabActions(
         // stale activeTabId or whatever Chrome reports as "active in currentWindow"
         // (which may be the user's foreground tab, not the one we just opened).
         await chrome.storage.session.set({ activeTabId: newTab.id })
-        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId } }
+        return { success: true, data: { tabId: newTab.id, url: newTab.url, groupId, reused: false } }
       }
-      return { success: true, data: { tabId: newTab.id, url: newTab.url } }
+      return { success: true, data: { tabId: newTab.id, url: newTab.url, reused: false } }
     }
 
     case "tab_close": {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -12,7 +12,7 @@ export type Action =
   | { type: "extract_html"; index?: number; ref?: string; frameId?: number }
   | { type: "evaluate"; code: string; world?: "MAIN" | "ISOLATED" }
   | { type: "screenshot"; format?: "png" | "jpeg" | "webp"; quality?: number; save?: boolean; clip?: { x: number; y: number; width: number; height: number }; element?: number; full?: boolean; target_max_long_edge?: number }
-  | { type: "tab_create"; url?: string }
+  | { type: "tab_create"; url?: string; reuse?: boolean }
   | { type: "tab_close"; tabId?: number }
   | { type: "tab_switch"; tabId: number }
   | { type: "tab_list" }

--- a/test/compound.test.ts
+++ b/test/compound.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { buildReadTreeAction } from "../cli/commands/compound"
+import { buildReadTreeAction, buildTabCreateAction } from "../cli/commands/compound"
 import { parseElementTarget } from "../cli/parse"
 
 describe("buildReadTreeAction", () => {
@@ -36,5 +36,29 @@ describe("buildReadTreeAction", () => {
       includeStyle: false,
       filter: "interactive"
     })
+  })
+})
+
+describe("buildTabCreateAction", () => {
+  test("omits reuse field by default — preserves existing create-new-tab semantics", () => {
+    const action = buildTabCreateAction(["open", "https://example.com"], "https://example.com")
+    expect(action).toEqual({ type: "tab_create", url: "https://example.com" })
+    expect("reuse" in action).toBe(false)
+  })
+
+  test("sets reuse: true when --reuse is present in filtered args", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--reuse"],
+      "https://example.com"
+    )
+    expect(action).toEqual({ type: "tab_create", url: "https://example.com", reuse: true })
+  })
+
+  test("does NOT set reuse when other open flags are present without --reuse", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--full", "--tree-only"],
+      "https://example.com"
+    )
+    expect(action.reuse).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Adds an opt-in `--reuse` flag to `interceptor open <url>` that navigates the most recently created tab in the Interceptor group instead of opening a new one. Long-running automation that calls `open` repeatedly used to leave a dead tab behind for every call — a session of forty inspects filled the browser with forty stale tabs.

## Why

Long-running agent workflows (PAI verification loops, batch inspections, repeated probes against the same surface) call `interceptor open` many times per session. Every call hits `chrome.tabs.create` and there is no escape hatch, so the only existing remediation is `interceptor tab close <id>` per tab — manual, brittle, and almost never done in practice.

Originally surfaced as [jdrolls/dora-cc#5](https://github.com/jdrolls/dora-cc/issues/5).

## How

CLI:
- `cli/commands/compound.ts` adds `--reuse` parsing and propagates it as `tab_create.reuse: true`
- Pretty output marks `(reused)` next to the tab id; JSON output exposes `reused: boolean`
- `buildTabCreateAction` extracted as a pure helper so flag handling has unit-test coverage
- `cli/help.ts` documents the flag in HELP and per-command help

Extension:
- `extension/src/types.ts` extends `tab_create` with optional `reuse?: boolean` (additive, no breaking change)
- `extension/src/background/capabilities/tabs.ts` `tab_create` handler queries the Interceptor group, sorts by tab id (monotonic in Chrome — highest = most recent), navigates the candidate via `chrome.tabs.update(tabId, { url })`, falls back to creating a new tab on group-empty / tab-vanished
- `extension/background.js` (the committed top-level service-worker bundle) gets the equivalent JS

Docs: AGENTS.md describes the long-automation use case; README.md adds the flag to the compound command index.

## Testing

- [x] `bun test test/compound.test.ts` — 5 pass / 0 fail (3 new `buildTabCreateAction` cases + 2 existing)
- [x] `bunx tsc -p tsconfig.host.json --noEmit` — clean
- [x] `bunx tsc -p tsconfig.extension.json --noEmit` — clean
- [x] `bash scripts/build.sh` — extension + host CLI build clean (Swift bridge has a pre-existing `LanguageModelSession` SDK gating issue on this checkout, unrelated)
- [x] Live browser probe against a patched extension:
  - `open https://example.com` (no `--reuse`) → tabId 1957902855, `reused: false`
  - `open https://example.org --reuse` → tabId **1957902855** (same), `reused: true`
  - `open https://example.net --reuse` → tabId **1957902855** (same), `reused: true`
  - Three sequential `--reuse` calls collapsed into a single tab as designed

## Related

Fixes the symptom tracked at https://github.com/jdrolls/dora-cc/issues/5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--reuse` flag to `interceptor open` to navigate and reuse the most recent managed Interceptor-group tab instead of creating new tabs.

* **Documentation**
  * Updated manual with `--reuse` behavior and fallback when a managed tab is unavailable.
  * Updated README with platform-specific Brave install notes and an example using `--reuse`; README now contains unresolved merge-conflict markers around the Brave/Chrome text.

* **Tests**
  * Added tests validating `--reuse` is set only when supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->