### PR TITLE
fix(meta): help text gaps, manifest version drift, install Dev-mode preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,11 @@ The recommended install path for end users is the signed `.pkg` documented in [I
 #### Prerequisites
 
 - [Bun](https://bun.sh/) runtime
-<<<<<<< HEAD
-- Brave Browser (or Chrome — see Chrome path below)
+- [Brave Browser](https://brave.com/download/) (or Chrome — see Chrome path below)
+  - **macOS:** `brew install --cask brave-browser`
+  - **Windows:** `winget install Brave.Brave` (or `choco install brave`)
+  - **Linux:** `sudo snap install brave` or `flatpak install flathub com.brave.Browser`. For native package-manager installs (apt/dnf/zypper/AUR), see the [official Linux guide](https://brave.com/linux/).
+- **Developer mode enabled** in the target Brave / Chrome profile. `--load-extension` is silently dropped by Chromium when Dev mode is off, leaving a dormant install with no error. `scripts/install.sh` preflights this and offers to flip it for you (Brave-closed only) or fail loudly with remediation steps. To enable manually: open `brave://extensions/` (or `chrome://extensions/`) and toggle Developer mode in the top-right.
 - Xcode command line tools (only required if you want to build the macOS bridge)
 
 #### Two install modes
@@ -204,12 +207,6 @@ The recommended install path for end users is the signed `.pkg` documented in [I
 | **`--full`** | Everything in browser-only **plus** the Swift bridge `.app`, the LaunchAgent, and the macOS subcommands | Screen Recording, Accessibility, Apple Events (per-target-app on first dispatch) | You need `interceptor macos *` (native AX tree, OS-level input, ScreenCaptureKit, Vision/Speech/NLP). macOS only. |
 
 If you don't pass either flag, the script prompts. The default in the prompt is `--full` on macOS, `--browser-only` everywhere else.
-=======
-- [Brave Browser](https://brave.com/download/)
-  - **macOS:** `brew install --cask brave-browser`
-  - **Windows:** `winget install Brave.Brave` (or `choco install brave`)
-  - **Linux:** `sudo snap install brave` or `flatpak install flathub com.brave.Browser`. For native package-manager installs (apt/dnf/zypper/AUR), see the [official Linux guide](https://brave.com/linux/).
->>>>>>> fb06399 (docs(readme): link Brave in Prerequisites and add platform install hints)
 
 #### Build and Install
 
@@ -284,6 +281,14 @@ bash scripts/uninstall.sh --bridge-only     # Remove only the macOS bridge (down
 ```
 
 `daemon: not running` from `status` on a fresh install is normal — `status` is a local pre-spawn check that never starts the daemon. Run `interceptor open <url>` to spawn the daemon and verify the daemon, native messaging bridge, extension, and page together.
+
+#### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `interceptor open <url>` returns `error: timeout: no response for 'tab_create' after 15s` | Browser extension is not loaded — most often because **Developer mode is off** in the target profile. Chromium silently drops `--load-extension` when Dev mode is off. | Open `brave://extensions/` or `chrome://extensions/`, toggle Developer mode ON. Quit the browser fully. Re-run `bash scripts/install.sh` (it will preflight Dev mode and re-launch). |
+| `interceptor status --verbose` says `extension: not reachable` | Same as above, or extension is registered but the Interceptor extension was disabled in the browser. | Open the extensions page, confirm Interceptor (ID `hkjbaciefhhgekldhncknbjkofbpenng`) is present and enabled. If missing, click **Load unpacked** and select `extension/dist/`. |
+| `chrome://extensions/` reports the extension as version `0.10.0` while `interceptor --version` reports a higher version | Extension manifest drift fixed in this release — rebuild from current source: `bash scripts/build.sh` then re-run `scripts/install.sh`. | Restart the browser after re-loading the extension so Chromium picks up the bumped manifest. |
 
 In browser-only mode, running an `interceptor macos *` command returns a structured "requires full computer-use install" error within 1 second instead of timing out at 15 seconds.
 

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -215,5 +215,9 @@ Recording (Session Monitor):
     --with-bodies                        (P1) Merge cached response bodies
 
 Meta:
+  interceptor init                           First-run preflight: verify daemon, bridge, and extension are reachable
+  interceptor init --verbose                 Same as 'init', plus a per-component reachability breakdown
   interceptor status                         Check daemon status (local — no connection needed)
+  interceptor status --verbose               Daemon + bridge + extension probe with per-component diagnostics
+  interceptor status --explain               Alias for --verbose with extra rationale per component
   interceptor help                           This help text`

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.10.0",
+  "version": "0.10.3",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,10 +27,20 @@ export const VERSION = "$pkg_version"
 export const BUILD_SHA = "$sha"
 export const BUILD_DATE = "$date"
 EOF
+  # Keep extension/manifest.json#version in lockstep with package.json so the
+  # extension reports the same version as the CLI / pkg / Sparkle artifacts.
+  # Source manifest is restored via `git checkout` after build (same shape as
+  # cli/version.ts). Without this, the manifest is whatever someone hand-bumped
+  # last and silently drifts every release that forgets to bump it.
+  if [[ -f extension/manifest.json ]]; then
+    sed -i.bak -E 's|("version":[[:space:]]*)"[^"]+"|\1"'"$pkg_version"'"|' extension/manifest.json
+    rm -f extension/manifest.json.bak
+  fi
 }
 
 restore_version() {
   git checkout cli/version.ts 2>/dev/null || true
+  git checkout extension/manifest.json 2>/dev/null || true
 }
 
 trap restore_version EXIT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -232,6 +232,63 @@ done
 # ── Step 3: Load extension into browser via --load-extension ──────────────────
 # Takes one arg: "chrome" | "brave". Reads $SKIP_EXTENSION, $PROFILE, $DRY_RUN,
 # $EXTENSION_DIR from the surrounding scope.
+
+# Resolve the profile root for a given browser target.
+profile_root_for() {
+  case "$1" in
+    brave)  echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
+    chrome) echo "$HOME/Library/Application Support/Google/Chrome" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read extensions.ui.developer_mode from a profile's Preferences JSON.
+# Echoes "true" / "false" / "unknown" (file missing, malformed, or key absent).
+read_developer_mode() {
+  local prefs="$1"
+  if [[ ! -f "$prefs" ]]; then echo "unknown"; return 0; fi
+  python3 - "$prefs" <<'PY' 2>/dev/null || echo "unknown"
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+    v = d.get("extensions", {}).get("ui", {}).get("developer_mode")
+    if v is True: print("true")
+    elif v is False: print("false")
+    else: print("unknown")
+except Exception:
+    print("unknown")
+PY
+}
+
+# Toggle extensions.ui.developer_mode = true in a profile's Preferences JSON.
+# Must NOT run while the browser owns the file — the browser overwrites on shutdown.
+# Returns 0 on success, non-zero on failure (file missing, malformed, browser running).
+write_developer_mode_true() {
+  local prefs="$1" browser_bin="$2"
+  if [[ ! -f "$prefs" ]]; then return 1; fi
+  if pgrep -f "$browser_bin" >/dev/null 2>&1; then return 2; fi
+  python3 - "$prefs" <<'PY' 2>/dev/null || return 3
+import json, sys, os, tempfile
+path = sys.argv[1]
+with open(path) as f:
+    d = json.load(f)
+d.setdefault("extensions", {}).setdefault("ui", {})["developer_mode"] = True
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path))
+with os.fdopen(fd, "w") as f:
+    json.dump(d, f, separators=(",", ":"))
+os.replace(tmp, path)
+PY
+}
+
+# Probe whether the just-launched extension is reachable. Returns 0 if yes.
+probe_extension_reachable() {
+  local interceptor_bin="$ROOT/dist/interceptor"
+  [[ -x "$interceptor_bin" ]] || return 0  # nothing to probe with; skip silently
+  # status --verbose ends with a per-component breakdown including "extension:"
+  "$interceptor_bin" status --verbose 2>/dev/null | grep -qE "^extension:[[:space:]]+reachable"
+}
+
 load_extension() {
   local target="$1"
 
@@ -268,6 +325,68 @@ load_extension() {
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "==> [browser] DRY: would launch $BROWSER_NAME --load-extension=$EXTENSION_DIR"
     return 0
+  fi
+
+  # ── Developer-mode preflight ─────────────────────────────────────────────────
+  # Chromium silently drops --load-extension when the target profile has Dev
+  # mode off — the launch reports success, the extension is dormant, and every
+  # subsequent browser-side command times out at 15s. Detect and surface this
+  # before launching, with both manual and (with Brave/Chrome closed) automatic
+  # remediation.
+  local PROFILE_DIR_NAME="${PROFILE:-Default}"
+  local PROFILE_PATH
+  PROFILE_PATH="$(profile_root_for "$target")/$PROFILE_DIR_NAME"
+  local PREFS_PATH="$PROFILE_PATH/Preferences"
+  local DEVMODE_STATE
+  DEVMODE_STATE="$(read_developer_mode "$PREFS_PATH")"
+
+  if [[ "$DEVMODE_STATE" == "false" || "$DEVMODE_STATE" == "unknown" ]]; then
+    echo ""
+    echo "==> [browser] $BROWSER_NAME profile '$PROFILE_DIR_NAME' has Developer mode OFF"
+    echo "    (or the profile has not been opened yet)."
+    echo ""
+    echo "    Without Developer mode, --load-extension is silently dropped by Chromium:"
+    echo "    the install reports success, the extension never registers, and every"
+    echo "    'interceptor open / read / act / …' will time out at 15s."
+    echo ""
+    echo "    Manual remediation:"
+    echo "      1. Quit $BROWSER_NAME entirely."
+    echo "      2. Re-launch $BROWSER_NAME, open $(case "$target" in brave) echo brave://extensions/ ;; chrome) echo chrome://extensions/ ;; esac), toggle Developer mode ON."
+    echo "      3. Quit $BROWSER_NAME again."
+    echo "      4. Re-run: bash scripts/install.sh ${MODE:+--$MODE} --$target${PROFILE:+ --profile \"$PROFILE\"}"
+
+    # Offer auto-remediation if and only if the browser is currently closed
+    # AND we have a Preferences file to write to. Editing while the browser
+    # runs is unsafe — the browser overwrites on shutdown.
+    local CAN_AUTO=0
+    if [[ -f "$PREFS_PATH" ]] && ! pgrep -f "$BROWSER_BIN" >/dev/null 2>&1; then
+      CAN_AUTO=1
+    fi
+
+    if [[ "$CAN_AUTO" == "1" && -t 0 ]]; then
+      echo ""
+      read -r -p "    Or: enable Developer mode now (writes Preferences while $BROWSER_NAME is closed)? [y/N] " ANSWER
+      if [[ "${ANSWER:-n}" == "y" || "${ANSWER:-n}" == "Y" ]]; then
+        if write_developer_mode_true "$PREFS_PATH" "$BROWSER_BIN"; then
+          echo "    Developer mode enabled in $PREFS_PATH."
+        else
+          echo "    Failed to write Preferences (browser may have launched, file missing, or JSON malformed)."
+          echo "    Use the manual path above."
+          exit 1
+        fi
+      else
+        echo "    Skipped auto-enable. Use the manual path above, then re-run."
+        exit 1
+      fi
+    elif [[ -t 0 ]]; then
+      echo ""
+      echo "    Auto-enable is unavailable (no Preferences file at '$PREFS_PATH'"
+      echo "    or $BROWSER_NAME is still running). Use the manual path."
+      exit 1
+    else
+      # Non-interactive: hard-fail loudly so a wrapper doesn't ship a dormant install.
+      exit 1
+    fi
   fi
 
   # Check if browser is already running
@@ -329,11 +448,44 @@ load_extension() {
 
   open -a "$BROWSER_APP" --args "${LAUNCH_ARGS[@]}"
 
+  # ── Post-launch reachability probe ──────────────────────────────────────────
+  # Wait briefly for the extension to initialize, then probe via
+  # `interceptor status --verbose`. If the extension is not reachable, the
+  # most likely cause is still a Developer-mode mismatch we couldn't detect
+  # (e.g. the Preferences file we read was for a different profile than the
+  # browser actually opened). Surface the symptom + remediation rather than
+  # report a silent success.
   echo ""
-  echo "==> Extension loaded into $BROWSER_NAME."
-  echo "    Extension ID: hkjbaciefhhgekldhncknbjkofbpenng"
-  if [[ -n "$PROFILE" ]]; then
-    echo "    Profile: $PROFILE"
+  echo "==> Verifying extension reachability (waits up to 8s)..."
+  local probed=0
+  for i in 1 2 3 4 5 6 7 8; do
+    sleep 1
+    if probe_extension_reachable; then probed=1; break; fi
+  done
+
+  if [[ "$probed" == "1" ]]; then
+    echo "==> Extension loaded into $BROWSER_NAME and reachable."
+    echo "    Extension ID: hkjbaciefhhgekldhncknbjkofbpenng"
+    [[ -n "$PROFILE" ]] && echo "    Profile: $PROFILE"
+  else
+    echo "==> WARNING: $BROWSER_NAME launched, but the extension is NOT reachable after 8s."
+    echo ""
+    echo "    Most common cause: Developer mode is off in the profile $BROWSER_NAME"
+    echo "    actually opened (which may differ from the profile this script targeted)."
+    echo ""
+    echo "    Verify in $BROWSER_NAME:"
+    case "$target" in
+      brave)  echo "      1. Open brave://extensions/" ;;
+      chrome) echo "      1. Open chrome://extensions/" ;;
+    esac
+    echo "      2. Confirm Developer mode is ON (top-right toggle)."
+    echo "      3. Confirm 'Interceptor' appears with ID hkjbaciefhhgekldhncknbjkofbpenng."
+    echo "      4. If the extension is missing, click 'Load unpacked' and select:"
+    echo "         $EXTENSION_DIR"
+    echo ""
+    echo "    Diagnose with: interceptor status --verbose"
+    echo ""
+    return 1
   fi
 }
 

--- a/test/cli-meta-additions.test.ts
+++ b/test/cli-meta-additions.test.ts
@@ -190,16 +190,14 @@ describe("formatStatus (#49 + #52)", () => {
 })
 
 describe("init command (#50)", () => {
-  test("init is a recognized command (not rejected as unknown)", () => {
+  test("init is a recognized command and --help returns its slice", () => {
     // We can't actually run init without potentially spawning the daemon,
     // but we can check that --help short-circuits cleanly: that confirms
-    // init is wired into the dispatcher.
+    // init is wired into the dispatcher AND has an entry in HELP.
     const r = runCli(["init", "--help"])
     expect(r.status).toBe(0)
-    // The per-command help lookup will return null for `init` (we don't
-    // have an `interceptor init` line in HELP yet — would-be future addition),
-    // so the CLI falls back to printing the full HELP. That still confirms
-    // the command was accepted by the dispatcher.
-    expect(r.stdout).toContain("interceptor — browser control CLI")
+    // Per-command slice header + at least one matching line.
+    expect(r.stdout).toContain("interceptor init — usage")
+    expect(r.stdout).toMatch(/interceptor init\s/)
   })
 })

--- a/test/version-sync.test.ts
+++ b/test/version-sync.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+import pkg from "../package.json"
+import manifest from "../extension/manifest.json"
+
+describe("version sync", () => {
+  test("extension/manifest.json#version matches package.json#version", () => {
+    expect(manifest.version).toBe(pkg.version)
+  })
+})


### PR DESCRIPTION
Closes #67. Closes #68. Closes #69.

Three independent fixes for v0.10.3-era loose ends, each with a focused commit.

## #67 — `init` and `status --verbose` missing from help text

`interceptor init` and `status --verbose` / `--explain` are real, working commands but had no entries in the HELP string. The slicer at `cli/help.ts:4-21` matches lines starting with `  interceptor <cmd> ` to build per-command slices; without those lines the slicer returned null and the dispatcher fell back to printing the full HELP (so `interceptor init --help` printed the global help instead of an init-specific block).

Fix: add `interceptor init`, `init --verbose`, `status --verbose`, `status --explain` lines to the Meta section. Update the existing init regression test (`test/cli-meta-additions.test.ts`) to assert the new slice rather than the old fallback behavior.

## #68 — extension manifest version drift

`extension/manifest.json#version` was hand-bumped at v0.10.0 and never moved since. v0.10.1 / v0.10.2 / v0.10.3 all shipped pkgs whose extension self-identified as `0.10.0` in `chrome://extensions/`, even though the CLI version, pkg name, and Sparkle channel all advanced per release.

Fix: mirror the existing `cli/version.ts` stamp pattern in `scripts/build.sh`. Read `package.json#version`, `sed`-replace into `extension/manifest.json` before `bun build`, restore via `git checkout` afterwards. The build always emits a matching `extension/dist/manifest.json#version`.

Adds `test/version-sync.test.ts` that imports both files and asserts their versions match — catches the next drift before it ships. Also bumps the committed source `extension/manifest.json` to `0.10.3` so the value at HEAD matches `package.json` regardless of build-time stamping.

## #69 — install.sh + README don't surface Brave Developer-mode prereq

Chromium silently drops `--load-extension` when the target profile has Developer mode off. The install reported success, the extension stayed dormant, and every subsequent `interceptor open / read / act / …` timed out at 15s with no actionable error.

Fix in two stages:

1. **Preflight (before launch).** Read the profile's `Preferences` JSON and inspect `extensions.ui.developer_mode`. If unset or false, print a clear warning with two remediation paths: manual (open `brave://extensions/`, toggle Dev mode, re-run) or automatic (when the browser is closed, write `Preferences` with `developer_mode = true` directly via Python). Non-interactive runs hard-fail rather than ship a dormant install.
2. **Post-launch reachability probe.** After launching, poll `interceptor status --verbose` for up to 8s; if the extension is still not reachable, surface the symptom plus the most-likely cause (Dev mode off in the actually-opened profile, which can differ from the targeted one) and exit non-zero.

README updates:

- Adds the Developer-mode prerequisite to the Developer Setup → Prerequisites list with both manual and auto-remediation paths.
- Adds a Troubleshooting subsection naming the dormant-extension symptom, the manifest drift fix, and the diagnostic command.
- Resolves a committed merge-conflict in the Brave install hints block (HEAD's two-modes section + fb06399's platform install hints, combined cleanly).

## Verification

- `bun run typecheck` — clean
- `bun test test/ extension/` — **123 pass / 0 fail / 383 expect()** (PR #62's three buildTabCreateAction tests + v0.10.7's six registry/matcher tests + the new version-sync test + everything pre-existing)
- `bash -n scripts/install.sh` — clean syntax
- Live: `interceptor help | grep init` returns the new lines; `interceptor init --help` returns the per-command slice; `bash scripts/build.sh` produces `extension/dist/manifest.json#version` matching `package.json#version`; the build's restore-via-`git checkout` reverts the source manifest cleanly.

## Out of scope

- The CDP escape hatch is intentionally not used (constitutional rule).
- The broader v0.10.7 / v0.10.3 mismatch (released pkg artifacts named with a higher version than committed `package.json`) is a separate release-process drift not in this PR.