### PR TITLE
chore(release): bump to v0.10.8

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.10.3",
+  "version": "0.10.8",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.10.3",
+  "version": "0.10.8",
   "type": "module",
   "bin": {
     "interceptor": "./dist/interceptor"


### PR DESCRIPTION
Bump for the upcoming v0.10.8 release.

Reflects the two PRs merged since v0.10.7:

- #62 — `--reuse` flag for `interceptor open` (jdrolls)
- #70 — help text gaps, manifest version drift, install Dev-mode preflight (closes #67, #68, #69)

Source `extension/manifest.json` is bumped in lockstep with `package.json`. Going forward, the manifest-stamp added in #70 keeps `extension/dist/manifest.json#version` matching `package.json#version` on every build, so this is the last manual lockstep edit needed.