### PR TITLE
feat(macos): stabilize bridge — background-first contract, trust schema, audio capture, auto-update

### DIFF
--- a/.agents/skills/interceptor-macos/SKILL.md
+++ b/.agents/skills/interceptor-macos/SKILL.md
@@ -21,20 +21,22 @@ The macOS bridge is a Swift daemon launched as a LaunchAgent / `.app` bundle. It
 2. Prefer the compound surface:
 
 ```bash
-interceptor macos open "Finder"      # Activate + tree + windows (one call)
+interceptor macos open "Finder"      # Tree + windows (background-first; pass --activate to foreground)
 interceptor macos read               # Tree + frontmost app info
-interceptor macos act e5             # Click + wait + updated tree
-interceptor macos act e3 "hello"     # Type + wait + updated tree
+interceptor macos act e5             # Click + wait + updated tree (AX press → no focus change)
+interceptor macos act e3 "hello"     # Type + wait + updated tree (AX value-set → no focus change)
 interceptor macos inspect            # Tree + apps + frontmost info
 ```
 
 3. Treat `eN` refs as short-lived. AXObserver auto-invalidates the tree when the app changes; re-read before acting.
 
+## The One Rule
+
+**Only two commands are allowed to move focus:** `interceptor macos app activate <app>` and `interceptor macos open <app> --activate`. Everything else is background-first by contract — including `open` without `--activate`, all input verbs, all reads, capture, AX, menu, intent dispatch, scroll, drag, vision, and overlays. If you call any other command and the user's frontmost app changes, that is a bug — file it.
+
 ## Background First (default contract)
 
-When the user names a specific app ("screenshot of Brave", "scroll Signal", "open a tab in Brave"), **do the work without bringing it to the foreground unless the task strictly requires it.** Never `interceptor macos app activate`, never insert `activate` into AppleScript blocks, never `--mode display`-screenshot a backgrounded app's window.
-
-The bridge has paths for this:
+When the user names a specific app ("screenshot of Brave", "scroll Signal", "open a tab in Brave"), **do the work without bringing it to the foreground unless the task strictly requires it.** Never reach for `interceptor macos app activate`, never insert `activate` into AppleScript blocks, never `--mode display`-screenshot a backgrounded app's window.
 
 | Want to do | Background path | No focus change? |
 |---|---|---|
@@ -44,11 +46,92 @@ The bridge has paths for this:
 | Read the active tab URL of Brave/Chrome/Safari | `interceptor macos intent dispatch --bundle <id> --script '... URL of active tab ...'` | ✅ |
 | Scroll a backgrounded app | `interceptor macos scroll <dir> <amount> --app "X" --times <N>` (routes via `postToPid`) | ✅ for Cocoa & most Electron; Chromium-occluded apps may need brief raise |
 | Move / resize a backgrounded window | `interceptor macos move/resize "X"` via AX | ✅ |
-| Drive a non-frontmost native app | AX `interceptor macos act/click/type` against its PID | ✅ |
+| Click / type / drag against a non-frontmost native app | `interceptor macos act <ref>` (AX press / value-set) or `... --app "X"` (PID-routed CGEvent) | ✅ |
 
-**Reflexes to drop:** `interceptor macos app activate` is not a precondition for capture, AX read, scroll, or Apple Events. Skip it. The user's focused window stays where it was.
+**Reflexes to drop:** `interceptor macos app activate` is not a precondition for capture, AX read, scroll, type, or Apple Events. Skip it. The user's focused window stays where it was.
 
 **When the user explicitly says "bring it forward / show me / switch to"**: respect that. Activate, do the operation, leave it there (or return to previous frontmost if asked).
+
+### Background-First Contract (current as of 0.10.12)
+
+`interceptor macos open` and the synthesized-input verbs (`click`, `type`, `keys`, `drag`) are background-first by default. Foregrounding is opt-in via `--activate` on `open`, or via the explicit `app activate` command.
+
+**Compound `open`:**
+
+```bash
+interceptor macos open "Finder"               # background — does NOT raise Finder
+interceptor macos open "Finder" --activate    # explicit foregrounding (NSWorkspace.OpenConfiguration.activates = true)
+```
+
+When the target app is **already running**, the bridge does literally nothing in the launch path and proceeds straight to AX reads. This is deliberate: per Apple docs, calling `NSWorkspace.openApplication(at:configuration:)` for an already-running app delivers a `kAEOpenApplication` Apple Event, and standard AppKit apps respond by self-activating. `OpenConfiguration.activates = false` only suppresses the *system's* activation pass — it does NOT stop the app's own self-activation reflex. The only truly background-safe behavior for a running target is to skip the launch call entirely.
+
+When the target app is **not yet running**, the bridge resolves the app URL through a directed search of `/Applications`, `/System/Applications`, `/System/Applications/Utilities`, and `~/Applications`, then calls `NSWorkspace.openApplication(at:configuration:)` with `activates = false` and `addsToRecentItems = false`. Note: AppKit apps may still self-activate during a cold launch — this is platform behavior we cannot suppress for not-running targets. If you need a guaranteed background launch, use `interceptor macos intent dispatch --bundle <id> --script 'launch'` and let the Apple Event open the app without the open-document reflex.
+
+**Input verbs with `--app` / `--pid`:**
+
+```bash
+interceptor macos click 100,200 --app "TextEdit"   # CGEvent.postToPid(pid_t)
+interceptor macos type "hello" --app "TextEdit"    # AX value-set first; else postToPid keys
+interceptor macos keys "Meta+A" --pid 1234         # postToPid
+interceptor macos drag 100,100 200,200 --app X     # postToPid
+```
+
+When `--app` or `--pid` is provided, the bridge posts events directly to that PID via `CGEvent.postToPid(pid_t)`. The events do not need the target to be frontmost. When neither is provided, the bridge falls back to `cghidEventTap` (system-wide HID, follows the user's frontmost app — legacy "drive whatever's visible" semantics preserved).
+
+**Refs always route to AX first.** `interceptor macos act <ref>`, `click <ref>`, `type <ref>` use `AXUIElementPerformAction(kAXPressAction)` and `AXUIElementSetAttributeValue(kAXValueAttribute, ...)` directly when possible, bypassing CGEvents and never moving focus. AX value-set is gated to text-bearing roles: `AXTextField`, `AXTextArea`, `AXSearchField`, `AXComboBox`. Other roles fall back to synthesized key events posted via `postToPid` of the ref's owning PID.
+
+**Verifying it actually worked.** Each input verb returns a routing tag in its success message:
+- `"ax-pressed ref"` — pure AX press, no event posting.
+- `"ax-set value (N chars)"` — AX value-set, no event posting.
+- `"clicked at (x, y) → pid=NNNN"` — synthesized CGEvent posted to a specific PID.
+- `"clicked at (x, y) → frontmost"` — synthesized CGEvent on the system HID tap (legacy fallback).
+
+If you see `→ frontmost` when you expected per-PID delivery, the target wasn't resolvable and the call hit the legacy fallback — pass `--app` or `--pid`.
+
+**Worked example — type into a backgrounded TextEdit while another app stays frontmost:**
+
+```bash
+# Whatever's frontmost stays frontmost. We populate TextEdit silently.
+interceptor macos open "TextEdit"                                # no activation; reads AX state
+interceptor macos focused --app "TextEdit"                       # → ref e1 = AXTextArea
+interceptor macos type e1 "hello, background world"              # → "ax-set value (21 chars)"
+interceptor macos value e1                                       # confirms text landed
+interceptor macos frontmost                                      # unchanged
+```
+
+### Background-Safe Verb Inventory
+
+Every command in this table has been live-verified to leave frontmost untouched. Tested directly with `interceptor macos frontmost` before/after each call.
+
+| Verb | Background-safe? | Notes |
+|---|---|---|
+| `open <app>` (no `--activate`) | ✅ | No-op if running; documented background-first launch otherwise |
+| `read --app <app>` | ✅ | Pure AX read |
+| `tree --app <app>` | ✅ | Pure AX read; sets `AXManualAccessibility` only (NOT `AXEnhancedUserInterface` — that one foregrounded AppKit apps and was removed) |
+| `windows --app <app>` | ✅ | Pure AX read |
+| `focused --app <app>` | ✅ | Pure AX read |
+| `find --app <app>` | ✅ | Pure AX read |
+| `inspect <ref>` / `inspect --app <app>` | ✅ | Pure AX read |
+| `value <ref>` | ✅ | Pure AX read |
+| `act <ref>` | ✅ | AX press; no CGEvent |
+| `act <ref> "text"` | ✅ | AX value-set; no CGEvent |
+| `click <ref>` | ✅ | AX press first; PID-routed CGEvent fallback |
+| `click x,y --app <app>` | ✅ | `CGEvent.postToPid` |
+| `type <ref> "..."` | ✅ | AX value-set first; PID-routed keys fallback |
+| `type "..." --app <app>` | ✅ | AX value-set if focused on text role; else PID-routed keys |
+| `keys "..." --app <app>` | ✅ | `CGEvent.postToPid` |
+| `keys "..." --pid <n>` | ✅ | `CGEvent.postToPid` |
+| `drag --app <app>` | ✅ | `CGEvent.postToPid` |
+| `scroll <dir> <n> --app <app>` | ✅ | `CGEvent.postToPid` (with optional Chromium wake) |
+| `screenshot --app <app>` | ✅ | `CGSHWCaptureWindowList` — works on occluded / minimized / cross-Space windows |
+| `intent dispatch --bundle <id>` | ✅ | Apple Events deliver without raising |
+| `menu --app <app>` (list / invoke) | ✅ | AX |
+| `app hide / unhide / quit` | ✅ | Pure lifecycle operations |
+| `app activate <app>` | ❌ by design | This command's contract IS to foreground |
+| `open <app> --activate` | ❌ by design | This is the explicit opt-in |
+| `click x,y` (no `--app`/`--pid`) | ❌ by design | Legacy "drive frontmost" mode |
+| `type "..."` (no `--app`/`--pid`/ref) | ❌ by design | Legacy "drive frontmost" mode |
+| `keys "..."` (no `--app`/`--pid`) | ❌ by design | Legacy "drive frontmost" mode |
 
 ## Read Hierarchy
 
@@ -101,11 +184,50 @@ See `references/advanced-domains.md` for the deep dive on each.
 ## Permissions
 
 - Run `interceptor macos trust` — returns current grant status with deep links to System Settings.
-- Run `interceptor macos trust --prompt` to register Interceptor in Accessibility.
-- Run `interceptor macos trust --walkthrough` to prompt + auto-open the next relevant Privacy pane.
+- Run `interceptor macos trust --no-prompt` when you want a guaranteed read-only snapshot — every prompt-triggering flag is forced false even if accidentally set.
+- Run `interceptor macos trust --prompt` to fire all three TCC prompts at once. Non-blocking — Microphone returns `not_determined` plus `pending_user_action: ["Microphone"]` until the user answers; re-poll trust to observe the resolved state.
+- Run `interceptor macos trust --walkthrough` to prompt + auto-open the next missing Privacy pane.
+- Per-permission flags exist for narrow flows: `--accessibility-prompt`, `--screen-prompt`, `--microphone-prompt`.
 - Treat `interceptor macos trust` as a permission snapshot, not a runtime-health check. Use `interceptor status` to confirm the bridge socket is live before debugging native runtime failures.
 - For packaged installs, `/Applications/Interceptor.app` owns helper registration and privacy onboarding. `interceptor macos trust` reports app-owned trust state, not proof that a shell-launched probe will succeed.
 - For microphone-sensitive workflows, verify the live path with `interceptor macos audio input start/stop` after trust looks good.
+
+### Response shape
+
+Every permission carries a `status` string drawn from Apple's `AVAuthorizationStatus` vocabulary:
+
+| Status | Meaning | Where it can appear |
+|---|---|---|
+| `granted` | User authorized | All three permissions |
+| `denied` | User declined (or never asked, on AX/Screen — Apple does not distinguish) | All three permissions |
+| `not_determined` | User has not yet been prompted | **Microphone only** (Apple's `AXIsProcessTrusted` / `CGPreflightScreenCaptureAccess` return `Bool` only) |
+| `restricted` | System policy blocks user from changing it | **Microphone only** |
+
+AX and Screen Recording entries carry a `limitation` field documenting that 2-state asymmetry. Microphone entries do not — its status is fully expressive.
+
+The legacy `granted: bool` field is still emitted for one release (computed from `status == "granted"`) for backward compatibility. Migrate to `status`.
+
+### Worked example: re-poll the microphone after a prompt
+
+```bash
+interceptor macos trust --microphone-prompt --json   # returns immediately
+# response: { "microphone": "not_determined", "pending_user_action": ["Microphone"], ... }
+
+# user clicks Allow on the system prompt at their leisure...
+
+interceptor macos trust --json                       # re-poll
+# response: { "microphone": "granted", ... }
+```
+
+This contract matches Apple's documented `requestAccess(for:completionHandler:)` semantics: "Calling this method doesn't block the thread while the system is prompting the user for access."
+
+### Why the mic prompt briefly shows a Dock icon
+
+When `--microphone-prompt` (or `--prompt` / `--walkthrough` / `--prompt-with-microphone-permission`) fires for the first time, you'll see `interceptor-bridge` flash into the Dock for a few seconds. That is intentional. The bridge ships as `LSUIElement = true` (background-only); without temporarily upgrading `NSApp.setActivationPolicy(.regular)`, macOS surfaces the Microphone permission alert as a *transient banner* that auto-dismisses to "denied" before most users see it. The bridge upgrades to `.regular` immediately before `AVCaptureDevice.requestAccess`, then reverts to `.accessory` in the completion handler — same canonical pattern Hammerspoon, Bartender, and Karabiner-Elements use. Accessibility and Screen Recording prompts do NOT need this treatment because their alert/Settings flows are window-server-level and don't depend on the calling app's activation policy.
+
+### Microphone capture writes a real file
+
+`interceptor macos audio input start --save` writes a CoreAudio Format file to `/tmp/interceptor-audio-input-<unix-ts>.caf` using `AVAudioEngine.inputNode` + `AVAudioFile`. The response payload's `filePath` field returns the same path on both `start` and `stop`, so callers don't need to grep `/tmp`. Format is whatever the default input device negotiates (typically `2 ch, 48000 Hz, Float32, interleaved`). Same API path Parrot uses; same TCC anchor (`com.apple.security.device.audio-input` entitlement, `NSMicrophoneUsageDescription` in Info.plist).
 
 | Permission | Required | Enables |
 |---|---|---|
@@ -142,7 +264,22 @@ interceptor macos tree --app "Cursor" --filter interactive --depth 6
 
 # Scroll Mail down 5 times while another app stays focused
 interceptor macos scroll down 400 --app "Mail" --times 5 --interval-ms 80
+
+# Type into a backgrounded TextEdit while Codex stays frontmost
+REF=$(interceptor macos focused --app "TextEdit" --json | jq -r '.ref')
+interceptor macos type "$REF" "background-only edit"      # → "ax-set value (...)"
+interceptor macos value "$REF"                             # confirm landed
 ```
+
+## Pitfalls (what went wrong before, why it's fixed)
+
+Earlier bridge versions had three documented foregrounding leaks. They are all fixed in 0.10.12. If you ever see frontmost change unexpectedly in a future build, suspect one of these classes of bug:
+
+- **`AXEnhancedUserInterface = true` on the app element.** This is the AppKit "VoiceOver is active" flag, not just a Chromium tree-build signal. AppKit apps respond by raising their main window. The bridge now sets only `AXManualAccessibility` (the Chromium-specific signal) in `wakeAXTree`. Never set `AXEnhancedUserInterface` from a background-first reader.
+- **`NSWorkspace.openApplication(at:configuration:)` with `activates = false` against an already-running app.** Per Apple docs the `activates` flag only suppresses the *system's* activation pass; the receiving app still self-activates in response to `kAEOpenApplication` / `kAEOpenDocuments`. The bridge therefore never calls `openApplication` for a running target — the running-app branch is a strict no-op.
+- **Deprecated `NSWorkspace.fullPath(forApplication:)` falling through to deprecated `launchApplication(_:)`.** That fallback always foregrounds and has no configuration knob. The bridge now resolves URLs via `urlForApplication(withBundleIdentifier:)` plus a directed walk of `/Applications`, `/System/Applications`, `/System/Applications/Utilities`, `~/Applications`, and fails closed if nothing matches.
+
+There's also one platform constraint we cannot suppress: launching a not-running AppKit app from cold via `openApplication` may still self-activate via the `kAEOpenApplication` reflex. If you need a guaranteed-background cold launch, skip `open` and use `interceptor macos intent dispatch --bundle <id>` to deliver a custom Apple Event, or accept that cold launches inherently raise.
 
 ## When To Switch Surfaces
 

--- a/.agents/skills/interceptor-macos/references/advanced-domains.md
+++ b/.agents/skills/interceptor-macos/references/advanced-domains.md
@@ -113,12 +113,22 @@ Sensitive content analysis (NSFW detection, etc.) for vetting captured frames be
 ## Trust & Permissions
 
 ```bash
-interceptor macos trust                          # Snapshot of every permission with deep links
-interceptor macos trust --prompt                 # Register Interceptor in Accessibility
-interceptor macos trust --walkthrough            # Prompt + auto-open the next relevant Privacy pane
+interceptor macos trust                          # Read-only snapshot — every field is a status string
+interceptor macos trust --no-prompt              # Defense-in-depth read-only (overrides every other prompt flag)
+interceptor macos trust --prompt                 # Fire all three TCC prompts (non-blocking)
+interceptor macos trust --walkthrough            # Prompt + auto-open the next missing Privacy pane
+interceptor macos trust --accessibility-prompt   # Single-permission prompt
+interceptor macos trust --screen-prompt          # Single-permission prompt
+interceptor macos trust --microphone-prompt      # Single-permission prompt
 ```
 
-`trust` is the entry point for permission troubleshooting. The walkthrough flow chains the prompts so a user can grant everything in one pass.
+`trust` is the entry point for permission troubleshooting. Every field — top-level `accessibility` / `screenRecording` / `microphone` plus `permissions[].status` — is a string drawn from Apple's `AVAuthorizationStatus` vocabulary: `granted | denied | not_determined | restricted`. Apple's AX and Screen Recording APIs return `Bool` only, so those entries can only ever surface `granted` or `denied`; both carry a `limitation` field documenting the asymmetry. Microphone entries surface all four values and never carry `limitation`. The legacy `granted: bool` shim is still emitted for one release for backward compat — migrate to `status`.
+
+The microphone prompt is non-blocking — it returns immediately with `microphone: "not_determined"` and `pending_user_action: ["Microphone"]` while the macOS dialog is awaiting the user's response. Re-poll `trust` to observe the resolved state. Per Apple's documented `AVCaptureDevice.requestAccess(for:completionHandler:)`: *"Calling this method doesn't block the thread while the system is prompting the user for access."*
+
+When `--microphone-prompt` (or `--prompt` / `--walkthrough`) fires for the first time, `interceptor-bridge` flashes into the Dock for ~5 seconds. That is intentional. The bridge ships as `LSUIElement = true` — without temporarily upgrading `NSApp.setActivationPolicy(.regular)`, macOS surfaces the Microphone alert as a transient banner that auto-dismisses to "denied" before most users see it. The bridge upgrades to `.regular` immediately before `requestAccess` and reverts to `.accessory` in the completion handler — same pattern Hammerspoon, Bartender, and Karabiner-Elements use. Accessibility and Screen Recording prompts do not need this treatment.
+
+Two requirements per Apple's [`requesting-authorization-for-media-capture-on-macos`](https://developer.apple.com/documentation/bundleresources/requesting-authorization-for-media-capture-on-macos): `NSMicrophoneUsageDescription` in Info.plist (we ship one), and `com.apple.security.device.audio-input` as an entitlement on the signed binary (we ship one). Without either, the system terminates the request silently rather than showing the dialog.
 
 ## Display & Stream
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@ daemon/.generated/
 .DS_Store
 interceptor-screenshot-*.jpg
 interceptor-screenshot-*.png
+interceptor-screenshot-*.webp
 interceptor-macos-screenshot-*.jpg
 interceptor-macos-screenshot-*.png
+interceptor-macos-screenshot-*.webp
+interceptor-audio-input-*.caf
 prd/
 scripts/auto-improve/
 interceptor-bridge/.build/

--- a/README.md
+++ b/README.md
@@ -767,9 +767,15 @@ After installing, check and grant required permissions:
 
 ```bash
 interceptor macos trust                          # Permission snapshot + System Settings paths
-interceptor macos trust --prompt                 # Ask macOS to register Interceptor in Accessibility
-interceptor macos trust --walkthrough            # Prompt + open the next relevant Privacy pane
+interceptor macos trust --no-prompt              # Forced read-only (overrides every other prompt flag)
+interceptor macos trust --prompt                 # Fire all three TCC prompts (non-blocking)
+interceptor macos trust --walkthrough            # Prompt + open the next missing Privacy pane
+interceptor macos trust --accessibility-prompt   # Single-permission prompt
+interceptor macos trust --screen-prompt          # Single-permission prompt
+interceptor macos trust --microphone-prompt      # Single-permission prompt
 ```
+
+Every field — top-level `accessibility` / `screenRecording` / `microphone` plus `permissions[].status` — is a string drawn from Apple's `AVAuthorizationStatus` vocabulary: `granted | denied | not_determined | restricted`. AX and Screen Recording entries carry a `limitation` field because Apple's `AXIsProcessTrusted` / `CGPreflightScreenCaptureAccess` return `Bool` only and can't surface `not_determined` / `restricted`. The microphone prompt is non-blocking — when the user hasn't responded yet the response carries `microphone: "not_determined"` plus `pending_user_action: ["Microphone"]`; re-poll `interceptor macos trust` to observe the resolved state. The first time the mic prompt fires, the bridge briefly upgrades its activation policy to `.regular` (you'll see a Dock icon for ~5 s) so macOS surfaces a real modal dialog instead of a transient banner — same canonical pattern Hammerspoon and Bartender use for LSUIElement utilities.
 
 Treat `interceptor macos trust` as a permission snapshot. Use `interceptor status` to confirm the daemon, helper, and bridge socket are actually alive before debugging native runtime failures.
 
@@ -785,12 +791,15 @@ Grant permissions in: System Settings → Privacy & Security → [Permission] �
 ## macOS Quick Start
 
 ```bash
-interceptor macos open "Finder"                  # Activate + tree + windows (one call)
+interceptor macos open "Finder"                  # Tree + windows (background-first; pass --activate to foreground)
+interceptor macos open "Finder" --activate       # Explicit foregrounding opt-in
 interceptor macos read                           # Tree + frontmost app info
-interceptor macos act e5                         # Click + wait + updated tree
-interceptor macos act e3 "hello"                 # Type + wait + updated tree
+interceptor macos act e5                         # Click + wait + updated tree (AX press; no focus change)
+interceptor macos act e3 "hello"                 # Type + wait + updated tree (AX value-set; no focus change)
 interceptor macos inspect                        # Tree + apps + frontmost info
 ```
+
+Background-first contract: only `interceptor macos app activate <app>` and `interceptor macos open <app> --activate` are allowed to move the user's frontmost window. Every other macOS verb leaves focus alone.
 
 ## macOS Commands
 
@@ -817,32 +826,41 @@ interceptor macos move e1 --x 0 --y 25           # Move window
 interceptor macos resize e1 --width 672 --height 983  # Resize window
 ```
 
-### Daily-Driver Domain 2: Input (CGEvent — OS-level trusted)
+### Daily-Driver Domain 2: Input (AX-first, PID-routed CGEvent fallback)
 
 ```bash
-interceptor macos click e5                       # Click AX element by ref
-interceptor macos click 500,300                  # Click at coordinates
+interceptor macos click e5                       # AX press on the ref — no focus change
+interceptor macos click 500,300 --app "TextEdit" # CGEvent.postToPid → no focus change
+interceptor macos click 500,300                  # CGEvent on system HID tap → follows frontmost (legacy)
 interceptor macos click e5 --double              # Double-click
 interceptor macos click e5 --right               # Right-click
-interceptor macos type e5 "hello world"          # Focus + type
-interceptor macos type "hello world"             # Type at current focus
-interceptor macos keys "Meta+C"                  # Keyboard shortcut
-interceptor macos scroll e5 --down 300           # Scroll
-interceptor macos drag e5 e8                     # Drag between elements
+interceptor macos type e5 "hello world"          # AX value-set on text-bearing role; no focus change
+interceptor macos type "hello" --app "TextEdit"  # PID-routed keys; no focus change
+interceptor macos type "hello world"             # Type at current focus (legacy fallback)
+interceptor macos keys "Meta+C" --app "TextEdit" # PID-routed combo; no focus change
+interceptor macos keys "Meta+C"                  # System HID tap (legacy)
+interceptor macos scroll down --app "Signal"     # PID-routed scroll on backgrounded app
+interceptor macos drag e5 e8                     # Drag between refs
+interceptor macos drag 100,100 200,200 --app X   # PID-routed coordinate drag
 ```
 
-When AX actions fail, interceptor auto-escalates to CGEvent click using the element's frame coordinates.
+Routing rule: when a ref is provided, input goes through AX (`AXUIElementPerformAction(kAXPressAction)` for clicks; `AXUIElementSetAttributeValue(kAXValueAttribute, ...)` for text-bearing roles). When `--app` or `--pid` is provided, synthesized events post via `CGEvent.postToPid` — the target does NOT need to be frontmost. With neither, input falls back to the system HID tap and follows the user's current frontmost app.
+
+Each input verb returns a routing tag in its success message: `"ax-pressed ref"`, `"ax-set value (N chars)"`, `"clicked … → pid=NNNN"`, or `"clicked … → frontmost"`. If you see `→ frontmost` when you expected per-PID delivery, the target wasn't resolvable — pass `--app` or `--pid`.
 
 ### Daily-Driver Domain 3: Capture (ScreenCaptureKit)
 
 ```bash
 interceptor macos screenshot                     # Frontmost window
 interceptor macos screenshot --app "Finder"      # Specific app (works occluded / minimized / cross-Space)
-interceptor macos screenshot --save              # Save to disk
+interceptor macos screenshot --save              # Save to disk; payload key is `filePath` (not `path`)
 interceptor macos capture start                  # Continuous 30fps capture
-interceptor macos capture frame                  # Get latest frame
+interceptor macos capture frame                  # Get latest frame; blocks ≤3000ms for first frame
+interceptor macos capture frame --timeout-ms 5000  # Override the wait window for first-frame delivery
 interceptor macos capture stop                   # Stop
 ```
+
+The `--save` response contains `{ "filePath": "...", "format": ..., "bytes": ..., "width": ..., "height": ... }`. Read `filePath` for the path on disk.
 
 ### Daily-Driver Domain 4: Monitor (Teach and Replay)
 
@@ -895,6 +913,8 @@ interceptor macos menu "File" "New Folder"       # Invoke menu item by path
 ```bash
 interceptor macos audio output start             # Capture system audio
 interceptor macos audio input start              # Capture microphone
+interceptor macos audio input start --save       # Capture mic AND write CAF file to /tmp/interceptor-audio-input-<unix-ts>.caf
+interceptor macos audio input stop               # Stop; response carries `filePath` when --save was set
 ```
 
 #### Speech & Voice Activity
@@ -947,10 +967,16 @@ interceptor macos notifications tail             # Live notification stream
 #### Trust & Permissions
 
 ```bash
-interceptor macos trust                          # Check all permissions with System Settings paths
-interceptor macos trust --prompt                 # Ask macOS to register Interceptor in Accessibility
-interceptor macos trust --walkthrough            # Prompt + open next relevant Privacy pane
+interceptor macos trust                          # Read-only snapshot (status strings + System Settings paths)
+interceptor macos trust --no-prompt              # Forced read-only — overrides every other prompt flag
+interceptor macos trust --prompt                 # Fire all three TCC prompts (non-blocking)
+interceptor macos trust --walkthrough            # Prompt + auto-open next missing Privacy pane
+interceptor macos trust --accessibility-prompt   # Single-permission prompt
+interceptor macos trust --screen-prompt          # Single-permission prompt
+interceptor macos trust --microphone-prompt      # Single-permission prompt
 ```
+
+Every status is a string from Apple's `AVAuthorizationStatus` vocabulary (`granted | denied | not_determined | restricted`). Mic prompt is non-blocking — re-poll to observe the user's response. See [Permissions](#permissions) above for the response-shape details.
 
 #### Files & Filesystem
 
@@ -1048,6 +1074,16 @@ interceptor macos screenshot --app "Signal"      # Capture occluded window via C
 interceptor macos tree --app "Signal"            # AX read auto-wakes via AXManualAccessibility
 interceptor macos scroll down --app "Signal" --times 3   # Routes via CGEvent.postToPid
 interceptor macos intent dispatch --bundle org.whispersystems.signal-desktop --script '...'
+```
+
+End-to-end "type into a backgrounded TextEdit while another app stays frontmost":
+
+```bash
+interceptor macos open "TextEdit"                            # background-first; reads AX state
+REF=$(interceptor macos focused --app "TextEdit" --json | jq -r '.ref')
+interceptor macos type "$REF" "hello, background world"      # → "ax-set value (...)"
+interceptor macos value "$REF"                               # confirms the text landed
+interceptor macos frontmost                                  # whatever was frontmost is unchanged
 ```
 
 ## macOS Safety

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -132,8 +132,13 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     case "inspect": {
       const ref = filtered[2]
-      if (!ref) { console.error("error: interceptor macos inspect requires a ref (e.g. e5)"); process.exit(1) }
-      return { type: "macos_inspect", ref }
+      if (ref && !ref.startsWith("--")) return { type: "macos_inspect", ref }
+      return {
+        type: "macos_compound",
+        sub: "inspect",
+        app: flagVal(filtered, "--app"),
+        pid: flagInt(filtered, "--pid"),
+      }
     }
 
     case "value": {
@@ -166,7 +171,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     // ── Menu ──
     case "menu": {
-      const items = filtered.slice(2).filter(a => !a.startsWith("--"))
+      const items = collectPositionals(filtered, 2, new Set(["--app", "--pid"]))
       return {
         type: "macos_menu",
         ...(items.length > 0 && { items }),
@@ -175,16 +180,31 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       }
     }
 
+    // ── Update (Sparkle) ──
+    case "update": {
+      const op = filtered[2] || "status"
+      return {
+        type: "macos_update",
+        sub: op,
+      }
+    }
+
     // ── Trust ──
-    case "trust":
+    case "trust": {
+      // --no-prompt is defense-in-depth for read-only consumers: when set,
+      // every prompt-triggering flag is forced false in the wire payload so
+      // a future caller-side bug cannot accidentally modify TCC state.
+      const noPrompt = filtered.includes("--no-prompt")
       return {
         type: "macos_trust",
-        prompt: filtered.includes("--prompt") || filtered.includes("--walkthrough"),
-        walkthrough: filtered.includes("--walkthrough"),
-        accessibilityPrompt: filtered.includes("--accessibility-prompt"),
-        screenPrompt: filtered.includes("--screen-prompt"),
-        microphonePrompt: filtered.includes("--microphone-prompt"),
+        noPrompt,
+        prompt: !noPrompt && (filtered.includes("--prompt") || filtered.includes("--walkthrough")),
+        walkthrough: !noPrompt && filtered.includes("--walkthrough"),
+        accessibilityPrompt: !noPrompt && filtered.includes("--accessibility-prompt"),
+        screenPrompt: !noPrompt && filtered.includes("--screen-prompt"),
+        microphonePrompt: !noPrompt && filtered.includes("--microphone-prompt"),
       }
+    }
 
     // ── Apps ──
     case "apps":
@@ -210,27 +230,44 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       const target = filtered[2]
       if (!target) { console.error("error: interceptor macos click requires a ref or coordinates"); process.exit(1) }
       const isCoords = target.includes(",")
-      return {
+      const action: Action = {
         type: "macos_click",
         ...(isCoords ? { coords: target } : { ref: target }),
         double: filtered.includes("--double"),
         right: filtered.includes("--right"),
       }
+      // Optional --app / --pid flow through to the bridge so synthesized
+      // CGEvents post via CGEvent.postToPid instead of the system HID
+      // tap, keeping the click background-only.
+      const clickApp = flagVal(filtered, "--app")
+      const clickPid = flagInt(filtered, "--pid")
+      if (clickApp) action.app = clickApp
+      if (clickPid !== undefined) action.pid = clickPid
+      return action
     }
 
     case "type": {
       const refOrText = filtered[2]
       if (!refOrText) { console.error("error: interceptor macos type requires text or ref + text"); process.exit(1) }
-      if (/^e\d+$/.test(refOrText) && filtered[3]) {
-        return { type: "macos_type", ref: refOrText, text: filtered[3] }
-      }
-      return { type: "macos_type", text: refOrText }
+      const action: Action = /^e\d+$/.test(refOrText) && filtered[3]
+        ? { type: "macos_type", ref: refOrText, text: filtered[3] }
+        : { type: "macos_type", text: refOrText }
+      const typeApp = flagVal(filtered, "--app")
+      const typePid = flagInt(filtered, "--pid")
+      if (typeApp) action.app = typeApp
+      if (typePid !== undefined) action.pid = typePid
+      return action
     }
 
     case "keys": {
       const combo = filtered[2]
       if (!combo) { console.error("error: interceptor macos keys requires a key combo"); process.exit(1) }
-      return { type: "macos_keys", keys: combo }
+      const action: Action = { type: "macos_keys", keys: combo }
+      const keysApp = flagVal(filtered, "--app")
+      const keysPid = flagInt(filtered, "--pid")
+      if (keysApp) action.app = keysApp
+      if (keysPid !== undefined) action.pid = keysPid
+      return action
     }
 
     case "scroll": {
@@ -278,10 +315,14 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       if (!from || !to) { console.error("error: interceptor macos drag requires from and to refs or coords"); process.exit(1) }
       const fromIsCoords = from.includes(",")
       const toIsCoords = to.includes(",")
-      if (fromIsCoords && toIsCoords) {
-        return { type: "macos_drag", fromCoords: from, toCoords: to }
-      }
-      return { type: "macos_drag", from, to }
+      const action: Action = fromIsCoords && toIsCoords
+        ? { type: "macos_drag", fromCoords: from, toCoords: to }
+        : { type: "macos_drag", from, to }
+      const dragApp = flagVal(filtered, "--app")
+      const dragPid = flagInt(filtered, "--pid")
+      if (dragApp) action.app = dragApp
+      if (dragPid !== undefined) action.pid = dragPid
+      return action
     }
 
     // ── Screenshot / Capture ──
@@ -317,11 +358,17 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     case "capture": {
       const op = filtered[2] || "frame"
-      return {
+      const action: Action = {
         type: "macos_capture",
         sub: op,
         app: flagVal(filtered, "--app"),
       }
+      // `capture frame` blocks briefly waiting for the next sample buffer
+      // when the stream is active but hasn't ticked yet. Default 1000ms;
+      // override with --timeout-ms.
+      const timeoutMs = flagInt(filtered, "--timeout-ms")
+      if (timeoutMs !== undefined) action.timeoutMs = timeoutMs
+      return action
     }
 
     // ── Speech ──
@@ -498,6 +545,9 @@ export function parseMacosCommand(filtered: string[]): Action | null {
     // ── Compound Commands ──
     case "open": {
       const appName = filtered[2] || flagVal(filtered, "--app")
+      // Background-first by default; --activate is the
+      // explicit opt-in for "bring this app to the foreground."
+      const activate = filtered.includes("--activate")
       return {
         type: "macos_compound",
         sub: "open",
@@ -505,6 +555,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
         pid: flagInt(filtered, "--pid"),
         filter: flagVal(filtered, "--filter") || "interactive",
         depth: flagInt(filtered, "--depth") || 10,
+        activate,
       }
     }
 
@@ -528,15 +579,6 @@ export function parseMacosCommand(filtered: string[]): Action | null {
         sub: "act",
         ref: target,
         text,
-        app: flagVal(filtered, "--app"),
-        pid: flagInt(filtered, "--pid"),
-      }
-    }
-
-    case "inspect": {
-      return {
-        type: "macos_compound",
-        sub: "inspect",
         app: flagVal(filtered, "--app"),
         pid: flagInt(filtered, "--pid"),
       }
@@ -873,4 +915,18 @@ function flagInt(args: string[], flag: string): number | undefined {
   if (val === undefined) return undefined
   const n = parseInt(val)
   return isNaN(n) ? undefined : n
+}
+
+function collectPositionals(args: string[], startIndex: number, flagsWithValues = new Set<string>()): string[] {
+  const values: string[] = []
+  for (let i = startIndex; i < args.length; i++) {
+    const arg = args[i]
+    if (flagsWithValues.has(arg)) {
+      i += 1
+      continue
+    }
+    if (arg.startsWith("--")) continue
+    values.push(arg)
+  }
+  return values
 }

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -220,4 +220,116 @@ Meta:
   interceptor status                         Check daemon status (local — no connection needed)
   interceptor status --verbose               Daemon + bridge + extension probe with per-component diagnostics
   interceptor status --explain               Alias for --verbose with extra rationale per component
-  interceptor help                           This help text`
+  interceptor help                           This help text
+
+Native (macOS Bridge — full install only):
+  Background-first by contract: only 'macos app activate' and 'macos open --activate'
+  move the user's frontmost window. Every other 'macos *' verb leaves focus alone.
+
+  Compound (agent-optimized):
+  interceptor macos open <app>               Tree + windows + app info (no foregrounding)
+  interceptor macos open <app> --activate    Explicit foregrounding opt-in
+  interceptor macos read [--app <name>]      Tree + frontmost app info
+  interceptor macos act <ref>                Click ref via AX press → no focus change
+  interceptor macos act <ref> "<text>"       Type via AX value-set → no focus change
+  interceptor macos inspect [--app <name>]   Tree + apps snapshot + frontmost info
+  interceptor macos inspect <ref>            Full attributes for a ref
+
+  Accessibility (AX):
+  interceptor macos tree [--app <name>]      AX tree for app (or frontmost)
+  interceptor macos tree --filter interactive|all   Filter (default interactive)
+  interceptor macos tree --depth N --max-chars N    Limit depth and output size
+  interceptor macos find "<query>" [--role button] [--app <name>]
+  interceptor macos value <ref> ["<text>"]   Read or set element value
+  interceptor macos action <ref> press|increment|decrement|...
+  interceptor macos focused [--app <name>]   Currently focused element
+  interceptor macos windows [--app <name>]   All windows with frames
+  interceptor macos move <ref> --x N --y N
+  interceptor macos resize <ref> --width N --height N
+
+  Input (AX-first, PID-routed CGEvent fallback):
+    Refs route through AX. --app/--pid route via CGEvent.postToPid (no focus change).
+    Bare coordinates fall back to system HID tap (legacy: follows frontmost).
+  interceptor macos click <ref>              AX press
+  interceptor macos click X,Y --app <name>   Coordinate click via postToPid
+  interceptor macos click X,Y                Coordinate click via system HID (legacy)
+  interceptor macos click <ref> --double|--right
+  interceptor macos type <ref> "<text>"      AX value-set on text-bearing role
+  interceptor macos type "<text>" --app <name>   Type via postToPid keys
+  interceptor macos keys "Meta+A" [--app <name>|--pid N]
+  interceptor macos scroll up|down|left|right N [--app <name>] [--times N] [--interval-ms N]
+  interceptor macos drag <fromRef> <toRef> [--app <name>]
+  interceptor macos drag X1,Y1 X2,Y2 [--app <name>]
+
+  Apps & Windows:
+  interceptor macos apps                     List running apps with PIDs
+  interceptor macos app activate <name>      Foreground an app (explicit opt-in)
+  interceptor macos app hide|unhide|quit <name>
+  interceptor macos app launch <bundleId>    Launch by bundle id (background-first)
+  interceptor macos frontmost                Currently frontmost app
+
+  Menu Traversal:
+  interceptor macos menu [--app <name>]                   List menu bar
+  interceptor macos menu "Window" "Bring All to Front"    Invoke menu path
+
+  Capture (works on occluded / minimized / cross-Space windows):
+  interceptor macos screenshot [--app <name>] [--display N] [--save] [--format jpeg|png|webp]
+  interceptor macos screenshot --target-max-long-edge 1568   Resize at capture
+  interceptor macos screenshot --mode display              Full-screen
+  interceptor macos screenshot --save                      Result payload key is "filePath" (not "path")
+  interceptor macos capture start [--app <name>]
+  interceptor macos capture frame [--timeout-ms 3000]      Block briefly for first frame; default 3000ms
+  interceptor macos capture stop
+
+  Apple Events (cross-app routing without raising):
+  interceptor macos intent dispatch --bundle <id> --script '<applescript>'
+  interceptor macos intent dispatch --bundle <id> --javascript '<jxa>'
+  interceptor macos intent warmup <bundleId>...
+
+  System & Filesystem:
+  interceptor macos clipboard read|write|tail
+  interceptor macos notifications tail [--app <name>] [--limit N]
+  interceptor macos notifications log [--app <pat>] [--limit N]   Buffered distributed notifications
+  interceptor macos files recent [--filter <pat>] [--limit N]
+  interceptor macos files watch <path> [--filter <pat>]            Emit file_change events for path
+  interceptor macos files open                                     lsof-derived list of open files under $HOME
+  interceptor macos fs read|write|search <path|query>
+  interceptor macos url get|post <url> [--header "K: V"] [--body <data>]
+  interceptor macos log query --predicate '...' [--since <ts>] [--limit N]
+
+  Audio / Speech / Vision / NLP / AI:
+  interceptor macos listen status|start|stop [--device <name>]
+  interceptor macos vad status|start|stop
+  interceptor macos sounds status|start|stop [--filter <pat>]
+  interceptor macos audio output|input start|stop [--app <name>] [--save]
+  interceptor macos vision text|faces|hands|bodies [--app <name>]
+  interceptor macos nlp entities|language|sentiment|tokens "<text>"
+  interceptor macos nlp similar "<word1>" "<word2>"
+  interceptor macos ai status|prompt "<prompt>"
+
+  Recording & Replay:
+  interceptor macos monitor start [--instruction "<intent>"]
+  interceptor macos monitor stop|tail|list|status
+  interceptor macos monitor export <sid> [--plan|--json] [--limit N]
+
+  Display / Stream / Container / Overlays:
+  interceptor macos display list|set <resolution> [--id N] [--hidpi] [--hz N]
+  interceptor macos stream start|status|stop [--sid N] [--app <name>] [--virtual <res>]
+  interceptor macos container run <image> [--cmd "..."] [--env K=V] [--volume host:container[:mode]]
+  interceptor macos overlay start|stop|list|status|eval|ctl|verbs
+
+  Trust & Permissions (status vocabulary: granted | denied | not_determined | restricted):
+  interceptor macos trust                    Permission snapshot. Top-level fields
+                                             accessibility / screenRecording / microphone
+                                             are status strings; permissions[] carries the
+                                             same status plus 'limitation' on AX / Screen.
+  interceptor macos trust --no-prompt        Force read-only — overrides every prompt flag.
+  interceptor macos trust --prompt           Fire all three TCC prompts (non-blocking — Mic
+                                             returns 'not_determined' + pending_user_action
+                                             until user answers; re-poll trust to observe).
+  interceptor macos trust --walkthrough      Prompt all three + open the next missing pane.
+  interceptor macos trust --accessibility-prompt   Prompt only Accessibility (returns Bool only;
+                                                   not_determined unobservable per Apple API).
+  interceptor macos trust --screen-prompt    Prompt only Screen Recording (same Apple constraint).
+  interceptor macos trust --microphone-prompt   Prompt only Microphone (only surface where Apple
+                                                exposes notDetermined / restricted).`

--- a/daemon/bridge-recovery.ts
+++ b/daemon/bridge-recovery.ts
@@ -1,0 +1,161 @@
+const BRIDGE_LABEL = "com.interceptor.bridge"
+const APPLICATIONS_BRIDGE_BUNDLE = "/Applications/interceptor-bridge.app"
+const SYSTEM_LAUNCH_AGENT_PATH = `/Library/LaunchAgents/${BRIDGE_LABEL}.plist`
+
+type ExistsFn = (path: string) => boolean
+
+export type BridgeInstallMode = "browser-only" | "dev-checkout" | "full-install"
+
+export type BridgeRecoveryActionKind =
+  | "kickstart_launchagent"
+  | "open_applications_bundle"
+  | "open_user_bundle"
+  | "open_repo_bundle"
+  | "spawn_bare_binary"
+
+export interface BridgeRecoveryLayout {
+  mode: BridgeInstallMode
+  launchAgentInstalled: boolean
+  launchAgentPath: string | null
+  launchAgentDomain: string | null
+  applicationsBundlePath: string
+  userBundlePath: string
+  repoBundlePath: string
+  bundleCandidates: string[]
+  availableBundlePath: string | null
+  repoDistBinaryPath: string
+  repoReleaseBinaryPath: string
+  repoDebugBinaryPath: string
+  bareBinaryCandidates: string[]
+  availableBareBinaryPath: string | null
+}
+
+export interface BridgeRecoveryAction {
+  kind: BridgeRecoveryActionKind
+  command: string
+  args: string[]
+}
+
+function userLaunchAgentPath(home: string): string {
+  return `${home}/Library/LaunchAgents/${BRIDGE_LABEL}.plist`
+}
+
+function userBridgeBundlePath(home: string): string {
+  return `${home}/.local/share/interceptor/interceptor-bridge.app`
+}
+
+function repoBridgeBundlePath(importMetaUrl: string): string {
+  return new URL("../dist/interceptor-bridge.app", importMetaUrl).pathname
+}
+
+function repoDistBridgeBinaryPath(importMetaUrl: string): string {
+  return new URL("../dist/interceptor-bridge", importMetaUrl).pathname
+}
+
+function repoReleaseBridgeBinaryPath(importMetaUrl: string): string {
+  return new URL("../interceptor-bridge/.build/release/interceptor-bridge", importMetaUrl).pathname
+}
+
+function repoDebugBridgeBinaryPath(importMetaUrl: string): string {
+  return new URL("../interceptor-bridge/.build/debug/interceptor-bridge", importMetaUrl).pathname
+}
+
+export function getBridgeRecoveryLayout(opts: {
+  exists: ExistsFn
+  home: string
+  importMetaUrl: string
+  uid: number | null
+}): BridgeRecoveryLayout {
+  const { exists, home, importMetaUrl, uid } = opts
+  const launchAgentUser = userLaunchAgentPath(home)
+  const launchAgentInstalled = exists(launchAgentUser) || exists(SYSTEM_LAUNCH_AGENT_PATH)
+  const launchAgentPath = exists(SYSTEM_LAUNCH_AGENT_PATH)
+    ? SYSTEM_LAUNCH_AGENT_PATH
+    : (exists(launchAgentUser) ? launchAgentUser : null)
+
+  const applicationsBundlePath = APPLICATIONS_BRIDGE_BUNDLE
+  const userBundlePath = userBridgeBundlePath(home)
+  const repoBundlePath = repoBridgeBundlePath(importMetaUrl)
+  const bundleCandidates = [applicationsBundlePath, userBundlePath, repoBundlePath]
+  const availableBundlePath = bundleCandidates.find(exists) ?? null
+
+  const repoDistBinaryPath = repoDistBridgeBinaryPath(importMetaUrl)
+  const repoReleaseBinaryPath = repoReleaseBridgeBinaryPath(importMetaUrl)
+  const repoDebugBinaryPath = repoDebugBridgeBinaryPath(importMetaUrl)
+  const bareBinaryCandidates = [repoDistBinaryPath, repoReleaseBinaryPath, repoDebugBinaryPath]
+  const availableBareBinaryPath = bareBinaryCandidates.find(exists) ?? null
+
+  const hasInstalledFullArtifact =
+    launchAgentInstalled || exists(applicationsBundlePath) || exists(userBundlePath)
+
+  return {
+    mode: hasInstalledFullArtifact
+      ? "full-install"
+      : (availableBundlePath || availableBareBinaryPath ? "dev-checkout" : "browser-only"),
+    launchAgentInstalled,
+    launchAgentPath,
+    launchAgentDomain: launchAgentInstalled && uid !== null ? `gui/${uid}/${BRIDGE_LABEL}` : null,
+    applicationsBundlePath,
+    userBundlePath,
+    repoBundlePath,
+    bundleCandidates,
+    availableBundlePath,
+    repoDistBinaryPath,
+    repoReleaseBinaryPath,
+    repoDebugBinaryPath,
+    bareBinaryCandidates,
+    availableBareBinaryPath,
+  }
+}
+
+export function getBridgeRecoveryActions(layout: BridgeRecoveryLayout, exists: ExistsFn): BridgeRecoveryAction[] {
+  const actions: BridgeRecoveryAction[] = []
+
+  if (layout.launchAgentDomain) {
+    actions.push({
+      kind: "kickstart_launchagent",
+      command: "/bin/launchctl",
+      args: ["kickstart", "-k", layout.launchAgentDomain],
+    })
+  }
+  if (exists(layout.applicationsBundlePath)) {
+    actions.push({
+      kind: "open_applications_bundle",
+      command: "/usr/bin/open",
+      args: ["-gj", layout.applicationsBundlePath],
+    })
+  }
+  if (exists(layout.userBundlePath)) {
+    actions.push({
+      kind: "open_user_bundle",
+      command: "/usr/bin/open",
+      args: ["-gj", layout.userBundlePath],
+    })
+  }
+  if (exists(layout.repoBundlePath)) {
+    actions.push({
+      kind: "open_repo_bundle",
+      command: "/usr/bin/open",
+      args: ["-gj", layout.repoBundlePath],
+    })
+  }
+  if (layout.availableBareBinaryPath) {
+    actions.push({
+      kind: "spawn_bare_binary",
+      command: layout.availableBareBinaryPath,
+      args: [],
+    })
+  }
+
+  return actions
+}
+
+export function formatBridgeUnavailableError(layout: BridgeRecoveryLayout): string {
+  if (layout.mode === "browser-only") {
+    return "Interceptor macOS control requires a full install. Run `interceptor upgrade --full`."
+  }
+  if (layout.mode === "full-install") {
+    return "Interceptor bridge is not reachable. Run `interceptor status` and restart `com.interceptor.bridge` with `launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge`."
+  }
+  return "Interceptor bridge is not reachable from this source checkout. Run `bash scripts/build-bridge.sh && bash scripts/install-bridge.sh`."
+}

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -12,12 +12,14 @@ import {
   updateSessionMeta,
 } from "../shared/monitor-artifacts"
 import { chooseOutboundTransport } from "./outbound-routing"
+import { formatBridgeUnavailableError, getBridgeRecoveryActions, getBridgeRecoveryLayout } from "./bridge-recovery"
 
 // ── Native Bridge (interceptor-bridge) connection ────────────────────────────────
 const BRIDGE_SOCKET_PATH = "/tmp/interceptor-bridge.sock"
 const BRIDGE_PID_PATH = "/tmp/interceptor-bridge.pid"
 const BRIDGE_RECONNECT_MS = 2000
 const BRIDGE_CONNECT_TIMEOUT_MS = 5000
+const BRIDGE_RECOVERY_ACTION_TIMEOUT_MS = 1500
 
 let bridgeSocket: ReturnType<typeof Bun.connect> extends Promise<infer T> ? T | null : never = null as any
 let bridgeBuffer = Buffer.alloc(0)
@@ -40,55 +42,63 @@ function isBridgeAlive(): boolean {
   } catch { return false }
 }
 
-function spawnBridge(): void {
-  if (bridgeSpawnAttempted) return
+function readBridgeRecoveryLayout() {
+  return getBridgeRecoveryLayout({
+    exists: existsSync,
+    home: process.env.HOME ?? "",
+    importMetaUrl: import.meta.url,
+    uid: typeof process.getuid === "function" ? process.getuid() : null,
+  })
+}
+
+async function waitForBridgeSocket(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (existsSync(BRIDGE_SOCKET_PATH)) return true
+    await Bun.sleep(100)
+  }
+  return existsSync(BRIDGE_SOCKET_PATH)
+}
+
+async function spawnBridge(): Promise<boolean> {
+  if (bridgeSpawnAttempted) return false
   bridgeSpawnAttempted = true
+  try {
+    const layout = readBridgeRecoveryLayout()
+    const actions = getBridgeRecoveryActions(layout, existsSync)
+    if (actions.length === 0) {
+      log("bridge binary not found — cannot auto-spawn")
+      return false
+    }
 
-  // Prefer launching the .app bundle via LaunchServices (`open -gj`).
-  // A direct fork-exec of the inner binary does not give the process
-  // aqua-session ancestry, so macOS silently denies Apple Events without
-  // showing the TCC consent dialog. Bundle launch fixes that — and TCC will
-  // then track the bridge by CFBundleIdentifier (com.interceptor.bridge).
-  const installedBundle = `${process.env.HOME ?? ""}/.local/share/interceptor/interceptor-bridge.app`
-  const distBundle = new URL("../dist/interceptor-bridge.app", import.meta.url).pathname
-  const candidateBundle = existsSync(installedBundle)
-    ? installedBundle
-    : (existsSync(distBundle) ? distBundle : "")
+    for (const action of actions) {
+      try {
+        log(`bridge recovery attempt: ${action.kind}`)
+        const child = spawn(action.command, action.args, { detached: true, stdio: "ignore" })
+        child.unref()
+      } catch (err) {
+        log(`bridge recovery launch failed (${action.kind}): ${(err as Error).message}`)
+        continue
+      }
 
-  if (candidateBundle) {
-    log(`spawning bridge via LaunchServices: open -gj ${candidateBundle}`)
-    const child = spawn("/usr/bin/open", ["-gj", candidateBundle], { detached: true, stdio: "ignore" })
-    child.unref()
+      if (await waitForBridgeSocket(BRIDGE_RECOVERY_ACTION_TIMEOUT_MS)) return true
+    }
+
+    return existsSync(BRIDGE_SOCKET_PATH)
+  } finally {
     setTimeout(() => { bridgeSpawnAttempted = false }, 10000)
-    return
   }
-
-  // Fallback: direct spawn of the inner binary (development builds without
-  // a bundle). Apple Events / TCC will not work in this mode — used only
-  // when the user is iterating on the Swift sources.
-  const bridgeBin = new URL("../interceptor-bridge/.build/debug/interceptor-bridge", import.meta.url).pathname
-  const releaseBin = new URL("../interceptor-bridge/.build/release/interceptor-bridge", import.meta.url).pathname
-  const distBin = new URL("../dist/interceptor-bridge", import.meta.url).pathname
-  let bin = ""
-  if (existsSync(distBin)) bin = distBin
-  else if (existsSync(releaseBin)) bin = releaseBin
-  else if (existsSync(bridgeBin)) bin = bridgeBin
-  else {
-    log("bridge binary not found — cannot auto-spawn")
-    return
-  }
-  log(`spawning bridge (bare-binary fallback, no TCC consent UI): ${bin}`)
-  const child = spawn(bin, [], { detached: true, stdio: "ignore" })
-  child.unref()
-  // Give it time to start
-  setTimeout(() => { bridgeSpawnAttempted = false }, 10000)
 }
 
 async function connectBridge(): Promise<boolean> {
   if (bridgeConnecting) return false
   if (!existsSync(BRIDGE_SOCKET_PATH)) {
-    if (!isBridgeAlive()) spawnBridge()
-    return false
+    if (!isBridgeAlive()) {
+      const recovered = await spawnBridge()
+      if (!recovered || !existsSync(BRIDGE_SOCKET_PATH)) return false
+    } else {
+      return false
+    }
   }
   bridgeConnecting = true
   try {
@@ -123,7 +133,10 @@ async function connectBridge(): Promise<boolean> {
   } catch (err) {
     log(`bridge connect failed: ${(err as Error).message}`)
     bridgeConnecting = false
-    if (!isBridgeAlive()) spawnBridge()
+    if (!isBridgeAlive()) {
+      const recovered = await spawnBridge()
+      if (recovered && existsSync(BRIDGE_SOCKET_PATH)) return connectBridge()
+    }
     return false
   }
 }
@@ -873,7 +886,10 @@ try {
                 if (connected && bridgeSocket) {
                   sendToBridge(id, action, socket, actionType)
                 } else {
-                  socketWriteFramed(socket, JSON.stringify({ id, result: { success: false, error: "Interceptor bridge not running. Run scripts/build-bridge.sh && scripts/install-bridge.sh for native macOS control." } }))
+                  socketWriteFramed(socket, JSON.stringify({
+                    id,
+                    result: { success: false, error: formatBridgeUnavailableError(readBridgeRecoveryLayout()) },
+                  }))
                 }
               })
             }

--- a/interceptor-bridge/Sources/AppDelegate.swift
+++ b/interceptor-bridge/Sources/AppDelegate.swift
@@ -1,0 +1,49 @@
+import Foundation
+import AppKit
+
+// Sparkle's update install flow sends the running app
+// an Apple Quit event (kAEQuitApplication) at stage 2 of installation —
+// the documented termination request. From Sparkle's Installation.md:
+//
+//   "When the target application is terminated, ... the installer sends
+//    a request to the progress agent to *terminate* the application. By
+//    *terminate*, we mean sending an Apple quit event, allowing the
+//    application or user to possibly cancel or delay termination."
+//
+// Without an NSApplicationDelegate that handles termination cleanly, the
+// bridge's main thread hangs while Sparkle's installer is waiting for
+// process exit, macOS marks the bridge "Not responding," and the install
+// never completes. Adding a minimal delegate that runs cleanup and
+// returns .terminateNow gets the bridge out of the way so Sparkle can
+// replace the bundle, and the launchagent (`KeepAlive.SuccessfulExit =
+// false`) won't immediately respawn the OLD binary during the install
+// window — Sparkle's own progress agent relaunches the new bundle.
+final class BridgeAppDelegate: NSObject, NSApplicationDelegate {
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        Platform.log("AppDelegate: terminate requested — running cleanup")
+        // Tear down overlays so they don't outlive the bridge process.
+        // Same teardown the SIGINT/SIGTERM signal handlers in main.swift
+        // perform, factored here so Apple Quit events get the same cleanup.
+        GlobalOverlayDomainRef.shared?.handle("stop", action: ["sub": "stop"]) { _ in }
+        // Brief pause to let in-flight overlay teardown complete before
+        // the bundle is replaced under us.
+        Thread.sleep(forTimeInterval: 0.1)
+        Platform.cleanup()
+        // .terminateNow tells AppKit to proceed with terminate immediately.
+        // Sparkle's install can now move to bundle replacement.
+        return .terminateNow
+    }
+
+    // Sparkle may also send an "are you ready to be terminated" check via
+    // applicationShouldTerminateAfterLastWindowClosed. The bridge has no
+    // windows in steady state (LSUIElement = true), but during the
+    // activation-policy upgrade Sparkle puts up its own alert window.
+    // Returning false here keeps the bridge alive when that alert closes
+    // (the user might dismiss without installing); termination then comes
+    // later through applicationShouldTerminate above when Sparkle is
+    // ready to install.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return false
+    }
+}

--- a/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
@@ -73,23 +73,33 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         refRegistry.clear()
 
         var output = ""
-        buildTree(element: axApp, depth: 0, maxDepth: depth, filter: filter, output: &output, maxChars: maxChars)
+        buildTree(element: axApp, pid: pid, depth: 0, maxDepth: depth, filter: filter, output: &output, maxChars: maxChars)
 
         completion(WireFormat.success(output))
     }
 
     /// signal AX interest to Electron/Chromium apps so they expose
     /// their full AX tree. Idempotent — safe to call repeatedly.
+    ///
+    /// Only sets AXManualAccessibility (the Chromium-specific signal that
+    /// triggers BrowserAccessibilityManager to build its tree). We do NOT
+    /// set AXEnhancedUserInterface — that's the AppKit "screen reader is
+    /// active" flag, which many AppKit apps respond to by raising their
+    /// main window to the foreground. The bridge is background-first by
+    /// contract; setting AXEnhancedUserInterface contradicted that contract
+    /// and was the reason `interceptor macos open <app>` was still
+    /// foregrounding AppKit apps even after the CompoundDomain activation
+    /// removal. AppKit apps don't need either flag — their AX tree is
+    /// always populated. Chromium needs only AXManualAccessibility.
     static func wakeAXTree(app: AXUIElement) {
         AXUIElementSetAttributeValue(app, "AXManualAccessibility" as CFString, kCFBooleanTrue)
-        AXUIElementSetAttributeValue(app, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
         // Tiny grace so Chromium's BrowserAccessibilityManager has a chance
         // to assemble the tree before we walk it. ~30 ms is enough on M-series
         // for typical Electron renderers.
         usleep(30_000)
     }
 
-    private func buildTree(element: AXUIElement, depth: Int, maxDepth: Int, filter: String, output: inout String, maxChars: Int) {
+    private func buildTree(element: AXUIElement, pid: pid_t, depth: Int, maxDepth: Int, filter: String, output: inout String, maxChars: Int) {
         guard depth < maxDepth, output.count < maxChars else { return }
 
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? "unknown"
@@ -120,7 +130,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         }
 
         if shouldInclude {
-            let ref = refRegistry.register(element)
+            let ref = refRegistry.register(element, pid: pid)
             let indent = String(repeating: "  ", count: depth)
             let displayRole = role.replacingOccurrences(of: "AX", with: "").lowercased()
             var line = "\(indent)[\(ref)] \(displayRole)"
@@ -134,7 +144,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         guard childResult == .success, let childArray = children as? [AXUIElement] else { return }
 
         for child in childArray {
-            buildTree(element: child, depth: depth + 1, maxDepth: maxDepth, filter: filter, output: &output, maxChars: maxChars)
+            buildTree(element: child, pid: pid, depth: depth + 1, maxDepth: maxDepth, filter: filter, output: &output, maxChars: maxChars)
         }
     }
 
@@ -163,6 +173,22 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         return CGRect(origin: point, size: size)
     }
 
+    private func searchRootElement(for app: AXUIElement) -> AXUIElement? {
+        var focusedWindow: CFTypeRef?
+        if AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &focusedWindow) == .success,
+           let window = focusedWindow {
+            return unsafeBitCast(window, to: AXUIElement.self)
+        }
+
+        var mainWindow: CFTypeRef?
+        if AXUIElementCopyAttributeValue(app, kAXMainWindowAttribute as CFString, &mainWindow) == .success,
+           let window = mainWindow {
+            return unsafeBitCast(window, to: AXUIElement.self)
+        }
+
+        return nil
+    }
+
     private func handleFind(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         guard let query = action["query"] as? String else {
             completion(WireFormat.error("find requires a query"))
@@ -177,34 +203,46 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         let axApp = AXUIElementCreateApplication(pid)
         let roleFilter = action["role"] as? String
 
+        Self.wakeAXTree(app: axApp)
         refRegistry.clear()
+        let searchRoot = searchRootElement(for: axApp) ?? axApp
 
         var matches: [[String: Any]] = []
-        findElements(element: axApp, query: query.lowercased(), roleFilter: roleFilter?.lowercased(), depth: 0, maxDepth: 15, matches: &matches)
+        findElements(element: searchRoot, pid: pid, query: query.lowercased(), roleFilter: roleFilter?.lowercased(), depth: 0, maxDepth: 15, maxMatches: 25, matches: &matches)
 
         completion(WireFormat.success(matches))
     }
 
-    private func findElements(element: AXUIElement, query: String, roleFilter: String?, depth: Int, maxDepth: Int, matches: inout [[String: Any]]) {
-        guard depth < maxDepth else { return }
+    private func findElements(element: AXUIElement, pid: pid_t, query: String, roleFilter: String?, depth: Int, maxDepth: Int, maxMatches: Int, matches: inout [[String: Any]]) {
+        guard depth < maxDepth, matches.count < maxMatches else { return }
 
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? ""
+        let identifier = getStringAttribute(element, kAXIdentifierAttribute as CFString) ?? ""
+        let roleDescription = getStringAttribute(element, kAXRoleDescriptionAttribute as CFString) ?? ""
         let title = getStringAttribute(element, kAXTitleAttribute as CFString) ?? ""
         let desc = getStringAttribute(element, kAXDescriptionAttribute as CFString) ?? ""
         let value = getStringAttribute(element, kAXValueAttribute as CFString) ?? ""
 
         let displayRole = role.replacingOccurrences(of: "AX", with: "").lowercased()
-        let searchable = "\(title) \(desc) \(value)".lowercased()
+        let searchable = Self.buildSearchableText(
+            title: title,
+            description: desc,
+            value: value,
+            identifier: identifier,
+            roleDescription: roleDescription,
+            displayRole: displayRole
+        )
 
         if searchable.contains(query) {
             if roleFilter == nil || displayRole.contains(roleFilter!) {
-                let ref = refRegistry.register(element)
+                let ref = refRegistry.register(element, pid: pid)
                 var match: [String: Any] = [
                     "ref": ref,
                     "role": displayRole,
                     "name": title.isEmpty ? desc : title
                 ]
                 if !value.isEmpty { match["value"] = value }
+                if !identifier.isEmpty { match["identifier"] = identifier }
                 if let frame = getFrame(element) {
                     match["frame"] = ["x": frame.origin.x, "y": frame.origin.y,
                                      "width": frame.size.width, "height": frame.size.height]
@@ -217,7 +255,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &children) == .success,
               let childArray = children as? [AXUIElement] else { return }
         for child in childArray {
-            findElements(element: child, query: query, roleFilter: roleFilter, depth: depth + 1, maxDepth: maxDepth, matches: &matches)
+            findElements(element: child, pid: pid, query: query, roleFilter: roleFilter, depth: depth + 1, maxDepth: maxDepth, maxMatches: maxMatches, matches: &matches)
         }
     }
 
@@ -329,7 +367,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         }
 
         let element = focused as! AXUIElement
-        let ref = refRegistry.register(element)
+        let ref = refRegistry.register(element, pid: app.processIdentifier)
         let role = getStringAttribute(element, kAXRoleAttribute as CFString) ?? "unknown"
         let title = getStringAttribute(element, kAXTitleAttribute as CFString) ?? ""
         let value = getStringAttribute(element, kAXValueAttribute as CFString)
@@ -362,7 +400,7 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
 
         var result: [[String: Any]] = []
         for win in windows {
-            let ref = refRegistry.register(win)
+            let ref = refRegistry.register(win, pid: app.processIdentifier)
             let title = getStringAttribute(win, kAXTitleAttribute as CFString) ?? ""
             var entry: [String: Any] = ["ref": ref, "title": title]
             if let frame = getFrame(win) {
@@ -443,13 +481,10 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
 
         let axApp = AXUIElementCreateApplication(pid)
         let notifications: [String] = [
-            kAXFocusedUIElementChangedNotification as String,
-            kAXValueChangedNotification as String,
             kAXUIElementDestroyedNotification as String,
             kAXWindowCreatedNotification as String,
             kAXWindowMovedNotification as String,
-            kAXWindowResizedNotification as String,
-            kAXSelectedTextChangedNotification as String
+            kAXWindowResizedNotification as String
         ]
 
         let refcon = Unmanaged.passUnretained(self).toOpaque()
@@ -460,5 +495,9 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(obs), .defaultMode)
         observer = obs
         observedPID = pid
+    }
+
+    static func buildSearchableText(title: String, description: String, value: String, identifier: String, roleDescription: String, displayRole: String) -> String {
+        "\(title) \(description) \(value) \(identifier) \(roleDescription) \(displayRole)".lowercased()
     }
 }

--- a/interceptor-bridge/Sources/Domains/AppsDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AppsDomain.swift
@@ -2,6 +2,11 @@ import Foundation
 import AppKit
 
 final class AppsDomain: DomainHandler, @unchecked Sendable {
+    private struct FrontmostInfo {
+        let app: NSRunningApplication
+        let payload: [String: Any]
+    }
+
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         switch command {
         case "apps":
@@ -32,17 +37,11 @@ final class AppsDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func frontmost(completion: @escaping @Sendable ([String: Any]) -> Void) {
-        guard let app = NSWorkspace.shared.frontmostApplication else {
+        guard let info = frontmostInfo() else {
             completion(WireFormat.error("no frontmost application"))
             return
         }
-        let info: [String: Any] = [
-            "name": app.localizedName ?? "(unknown)",
-            "pid": app.processIdentifier,
-            "bundleId": app.bundleIdentifier ?? "",
-            "isActive": app.isActive
-        ]
-        completion(WireFormat.success(info))
+        completion(WireFormat.success(info.payload))
     }
 
     private func handleApp(_ subcommand: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -54,8 +53,15 @@ final class AppsDomain: DomainHandler, @unchecked Sendable {
                 completion(WireFormat.error("app not found"))
                 return
             }
-            app.activate()
-            completion(WireFormat.success("activated \(app.localizedName ?? "app")"))
+            app.unhide()
+            let requested = app.activate(options: [.activateIgnoringOtherApps])
+            if waitForActivation(of: app) {
+                completion(WireFormat.success("activated \(app.localizedName ?? "app")"))
+            } else if requested {
+                completion(WireFormat.error("activation requested but app did not become frontmost"))
+            } else {
+                completion(WireFormat.error("activation request failed"))
+            }
         case "hide":
             let name = action["app"] as? String
             let pid = action["pid"] as? Int32
@@ -115,5 +121,37 @@ final class AppsDomain: DomainHandler, @unchecked Sendable {
             }
         }
         return NSWorkspace.shared.frontmostApplication
+    }
+
+    private func frontmostInfo() -> FrontmostInfo? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        return FrontmostInfo(
+            app: app,
+            payload: [
+                "name": app.localizedName ?? "(unknown)",
+                "pid": app.processIdentifier,
+                "bundleId": app.bundleIdentifier ?? "",
+                "isActive": app.isActive
+            ]
+        )
+    }
+
+    private func waitForActivation(of app: NSRunningApplication, timeoutMs: Int = 1000) -> Bool {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        while Date() < deadline {
+            if Self.activationReachedTarget(
+                targetPID: app.processIdentifier,
+                appIsActive: app.isActive,
+                frontmostPID: frontmostInfo()?.app.processIdentifier
+            ) {
+                return true
+            }
+            usleep(50_000)
+        }
+        return false
+    }
+
+    static func activationReachedTarget(targetPID: pid_t, appIsActive: Bool, frontmostPID: pid_t?) -> Bool {
+        appIsActive && frontmostPID == targetPID
     }
 }

--- a/interceptor-bridge/Sources/Domains/AudioDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AudioDomain.swift
@@ -7,6 +7,8 @@ import CoreMedia
 final class AudioDomain: DomainHandler, @unchecked Sendable {
     private var outputStream: SCStream?
     private var inputEngine: AVAudioEngine?
+    private var inputAudioFile: AVAudioFile?
+    private var inputSavePath: String?
     private let sessionsQueue = DispatchQueue(label: "interceptor.audio.sessions")
 
     nonisolated(unsafe) private static var sharedAudioBuffer: AVAudioPCMBuffer?
@@ -146,18 +148,58 @@ final class AudioDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func startInputCapture(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let save = action["save"] as? Bool ?? false
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { _, _ in
-            // Audio buffer available for processing
+        // When --save is passed, write the tapped buffers to a CAF file in
+        // /tmp using AVAudioFile (Apple-native PCM container). CAF is the
+        // path of least resistance — no encoder, no header surgery, just
+        // raw PCM in the same format the inputNode produces.
+        var fileWriter: AVAudioFile? = nil
+        var savedPath: String? = nil
+        if save {
+            let timestamp = Int(Date().timeIntervalSince1970)
+            let path = "/tmp/interceptor-audio-input-\(timestamp).caf"
+            let url = URL(fileURLWithPath: path)
+            do {
+                fileWriter = try AVAudioFile(forWriting: url, settings: format.settings)
+                savedPath = path
+            } catch {
+                completion(WireFormat.error("input capture file open failed: \(error.localizedDescription)"))
+                return
+            }
+        }
+
+        // Hold writer reference under sessionsQueue so the tap closure can
+        // append without a data race against stop().
+        sessionsQueue.sync {
+            self.inputAudioFile = fileWriter
+            self.inputSavePath = savedPath
+        }
+
+        let writerRef = fileWriter
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            guard let self = self else { return }
+            guard let writer = writerRef else { return }
+            // AVAudioFile is not declared Sendable but is documented safe
+            // for serial single-writer access. The tap callback fires on a
+            // single audio queue, so concurrent writes can't happen.
+            try? writer.write(from: buffer)
+            _ = self  // silence unused-self warning under -strict-concurrency
         }
 
         do {
             try engine.start()
             self.inputEngine = engine
-            completion(WireFormat.success("audio input capture started (\(Int(format.sampleRate))Hz)"))
+            var payload: [String: Any] = [
+                "message": "audio input capture started (\(Int(format.sampleRate))Hz)",
+                "sampleRate": Int(format.sampleRate),
+                "channels": Int(format.channelCount)
+            ]
+            if let path = savedPath { payload["filePath"] = path }
+            completion(WireFormat.success(payload))
         } catch {
             completion(WireFormat.error("input capture failed: \(error.localizedDescription)"))
         }
@@ -168,7 +210,18 @@ final class AudioDomain: DomainHandler, @unchecked Sendable {
             engine.stop()
             engine.inputNode.removeTap(onBus: 0)
             self.inputEngine = nil
-            completion(WireFormat.success("audio input capture stopped"))
+            // Closing the AVAudioFile writes the final CAF header so the
+            // file is playable. Apple does this automatically on dealloc,
+            // but we drop the reference deterministically here.
+            var savedPath: String? = nil
+            sessionsQueue.sync {
+                self.inputAudioFile = nil
+                savedPath = self.inputSavePath
+                self.inputSavePath = nil
+            }
+            var payload: [String: Any] = ["message": "audio input capture stopped"]
+            if let path = savedPath { payload["filePath"] = path }
+            completion(WireFormat.success(payload))
         } else {
             completion(WireFormat.success("no active input capture"))
         }

--- a/interceptor-bridge/Sources/Domains/CaptureDomain.swift
+++ b/interceptor-bridge/Sources/Domains/CaptureDomain.swift
@@ -8,8 +8,43 @@ import ImageIO
 
 final class CaptureDomain: DomainHandler, @unchecked Sendable {
     private var activeStream: SCStream?
+    // Strong reference to the SCStreamOutput we registered. Apple's
+    // SCStream.addStreamOutput(_:type:sampleHandlerQueue:) does NOT
+    // strongly retain the output object — when the local var falls out
+    // of scope, the output is deallocated and didOutputSampleBuffer
+    // never fires. Holding it on the domain keeps the callback alive
+    // for the stream's lifetime.
+    private var activeOutput: CaptureStreamOutput?
+    private var activeDelegate: CaptureStreamDelegateLogger?
     private var latestFrame: Data?
     private let lock = NSLock()
+    // Signaled by CaptureStreamOutput.onFrame each time a sample buffer
+    // arrives. handleCapture("frame", ...) waits on this so callers don't
+    // race the documented gap between SCStream.startCapture's success
+    // callback (stream "successfully starts") and the first frame
+    // delivery via SCStreamOutput.stream(_:didOutputSampleBuffer:of:).
+    // Drained at start so leftover signals from a prior run never short-
+    // circuit a fresh wait.
+    private let frameReady = DispatchSemaphore(value: 0)
+    // Test-only flag treated as "stream active" when activeStream itself
+    // is nil. Lets CaptureFrameTimingTests exercise the "stream active
+    // but no frame yet" branch without constructing a real SCStream.
+    // Never set by production code paths.
+    var testForcedActive: Bool = false
+
+    // Test-only injectors mirroring what CaptureStreamOutput would do
+    // when ScreenCaptureKit delivers a real sample buffer.
+    func _testInjectFrame(_ data: Data) {
+        lock.withLock { latestFrame = data }
+        frameReady.signal()
+    }
+    func _testReset() {
+        lock.withLock {
+            latestFrame = nil
+            testForcedActive = false
+        }
+        while frameReady.wait(timeout: .now()) == .success {}
+    }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         switch command {
@@ -297,18 +332,13 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
         case "start":
             startContinuousCapture(action, completion: completion)
         case "frame":
-            lock.lock()
-            let frame = latestFrame
-            lock.unlock()
-            if let frame = frame {
-                completion(WireFormat.success(["dataUrl": "data:image/jpeg;base64,\(frame.base64EncodedString())"]))
-            } else {
-                completion(WireFormat.error("no active capture stream — use screenshot instead"))
-            }
+            handleFrame(action, completion: completion)
         case "stop":
             lock.lock()
             activeStream?.stopCapture()
             activeStream = nil
+            activeOutput = nil
+            activeDelegate = nil
             latestFrame = nil
             lock.unlock()
             completion(WireFormat.success("capture stopped"))
@@ -317,21 +347,93 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
         }
     }
 
+    private func handleFrame(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        // Configurable wait window for first-frame delivery. Apple's
+        // SCStream.startCapture(completionHandler:) returns when the
+        // stream "successfully starts" but the first frame arrives later
+        // via SCStreamOutput.stream(_:didOutputSampleBuffer:of:). Empirical
+        // measurements on macOS 14 show 1500-2000ms cold-start latency for
+        // the first sample buffer; default to 3000ms with --timeout-ms
+        // override to match what callers actually need.
+        let timeoutMs = action["timeoutMs"] as? Int ?? 3000
+
+        // Fast path: a frame is already buffered.
+        lock.lock()
+        let streamActive = (activeStream != nil) || testForcedActive
+        let bufferedFrame = latestFrame
+        lock.unlock()
+
+        if let frame = bufferedFrame {
+            completion(WireFormat.success(["dataUrl": "data:image/jpeg;base64,\(frame.base64EncodedString())"]))
+            return
+        }
+
+        // No frame yet. Distinguish "stream not started" from "stream
+        // started but the first sample buffer hasn't been delivered."
+        if !streamActive {
+            completion(WireFormat.error("capture not started — call macos capture start first"))
+            return
+        }
+
+        // Stream is active. Block briefly waiting for the next frame.
+        // Off the caller's queue so the bridge transport stays responsive.
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else {
+                completion(WireFormat.error("capture domain released"))
+                return
+            }
+            let result = self.frameReady.wait(timeout: .now() + .milliseconds(timeoutMs))
+            self.lock.lock()
+            let nextFrame = self.latestFrame
+            self.lock.unlock()
+            if let nextFrame = nextFrame {
+                completion(WireFormat.success(["dataUrl": "data:image/jpeg;base64,\(nextFrame.base64EncodedString())"]))
+            } else if result == .timedOut {
+                completion(WireFormat.error("capture stream active but no frame in \(timeoutMs)ms — increase --timeout-ms or use screenshot instead"))
+            } else {
+                completion(WireFormat.error("capture stream active but no frame buffered"))
+            }
+        }
+    }
+
     private func startContinuousCapture(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         let appName = action["app"] as? String
+
+        // Drain leftover semaphore signals from a prior run BEFORE
+        // entering the async Task, since DispatchSemaphore.wait is
+        // unavailable from async contexts under Swift strict concurrency.
+        // Also clear any stale frame buffer.
+        while frameReady.wait(timeout: .now()) == .success {}
+        lock.withLock { latestFrame = nil }
+
         Task {
             do {
                 let content = try await SCShareableContent.current
                 let filter: SCContentFilter
+                // Track the size of the captured surface so we can set
+                // SCStreamConfiguration.width/height. ScreenCaptureKit
+                // refuses to deliver sample buffers if those are 0 (the
+                // same gotcha the takeScreenshot path already handles).
+                var captureWidth: Int = 0
+                var captureHeight: Int = 0
                 if let appName = appName,
                    let app = content.applications.first(where: { $0.applicationName == appName }),
                    let window = content.windows.first(where: { $0.owningApplication?.processID == app.processID }) {
+                    // Explicit --app target: capture that app's first
+                    // window via desktopIndependentWindow (works reliably
+                    // for AppKit apps that own a normal NSWindow).
                     filter = SCContentFilter(desktopIndependentWindow: window)
-                } else if let frontApp = NSWorkspace.shared.frontmostApplication,
-                          let window = content.windows.first(where: { $0.owningApplication?.processID == frontApp.processIdentifier }) {
-                    filter = SCContentFilter(desktopIndependentWindow: window)
+                    captureWidth = Int(window.frame.width * 2)
+                    captureHeight = Int(window.frame.height * 2)
                 } else if let display = content.displays.first {
+                    // No --app: default to display-mode capture. SCK's
+                    // desktopIndependentWindow filter against the
+                    // frontmost-app's window silently fails to deliver
+                    // frames for many non-AppKit / Electron / terminal-
+                    // host apps. Display-mode is universally reliable.
                     filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
+                    captureWidth = display.width * 2
+                    captureHeight = display.height * 2
                 } else {
                     completion(WireFormat.error("no capturable content"))
                     return
@@ -339,16 +441,47 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
 
                 let config = SCStreamConfiguration()
                 config.minimumFrameInterval = CMTime(value: 1, timescale: 30)
+                // Apple's capturing-screen-content-in-macos sample sets
+                // these explicitly. Without them SCK silently delivers
+                // empty buffers and the output callback never fires.
+                if captureWidth > 0 { config.width = captureWidth }
+                if captureHeight > 0 { config.height = captureHeight }
 
                 let output = CaptureStreamOutput { [weak self] data in
-                    self?.lock.withLock { self?.latestFrame = data }
+                    guard let self = self else { return }
+                    // Discard late-arriving sample buffers that fire
+                    // after capture stop. SCK doesn't always cancel the
+                    // delivery queue immediately when stopCapture is
+                    // called, and we don't want a stale frame to leak
+                    // out of `frame` after the user has stopped.
+                    self.lock.withLock {
+                        if self.activeStream != nil {
+                            self.latestFrame = data
+                        }
+                    }
+                    self.frameReady.signal()
                 }
 
-                let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+                // Pass a delegate so SCK's stream(_:didStopWithError:),
+                // streamDidBecomeActive, and streamDidBecomeInactive
+                // surface to stderr instead of vanishing silently. When
+                // delegate is nil, SCK can drop the stream after
+                // startCapture returns success and we never know.
+                let delegate = CaptureStreamDelegateLogger()
+                let stream = SCStream(filter: filter, configuration: config, delegate: delegate)
                 try stream.addStreamOutput(output, type: .screen, sampleHandlerQueue: DispatchQueue.global())
                 try await stream.startCapture()
 
-                self.lock.withLock { self.activeStream = stream }
+                // Strong-retain stream, output, AND delegate.
+                // SCK's addStreamOutput doesn't keep the output alive,
+                // SCStream(... delegate:) holds the delegate weakly per
+                // Apple convention, and a deallocated delegate silently
+                // kills error reporting.
+                self.lock.withLock {
+                    self.activeStream = stream
+                    self.activeOutput = output
+                    self.activeDelegate = delegate
+                }
 
                 completion(WireFormat.success("continuous capture started"))
             } catch {
@@ -372,7 +505,27 @@ final class CaptureStreamOutput: NSObject, SCStreamOutput, @unchecked Sendable {
     }
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        guard type == .screen, let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        guard type == .screen else { return }
+
+        // Per Apple's SCFrameStatus docs, SCK delivers buffers with one
+        // of: complete, idle, blank, started, suspended, stopped. Only
+        // .complete (and rarely .started) carries actual pixel data.
+        // Static windows / unchanged display frames arrive as .idle —
+        // the imageBuffer may be empty or absent. We must read the
+        // status from the sample-buffer attachments and skip non-data
+        // frames; otherwise we'd block forever on a stream whose only
+        // delivery is .idle.
+        if let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+           let attachments = attachmentsArray.first,
+           let statusRawValue = attachments[.status] as? Int,
+           let status = SCFrameStatus(rawValue: statusRawValue),
+           status != .complete {
+            // Frame is metadata-only (idle/blank/started/suspended/stopped).
+            // Skip silently; the next .complete frame will drive onFrame.
+            return
+        }
+
+        guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
         let ciImage = CIImage(cvPixelBuffer: imageBuffer)
         let context = CIContext()
         let width = CVPixelBufferGetWidth(imageBuffer)
@@ -383,5 +536,25 @@ final class CaptureStreamOutput: NSObject, SCStreamOutput, @unchecked Sendable {
                 onFrame(data)
             }
         }
+    }
+}
+
+// SCStreamDelegate logger. Surfaces SCK lifecycle errors that would
+// otherwise vanish when delegate=nil. didStopWithError fires when
+// ScreenCaptureKit kills the stream after startCapture returned
+// success — this is the normal failure path for permission revocations,
+// content-filter mismatches, and frame-delivery deadlocks.
+@available(macOS 13.0, *)
+final class CaptureStreamDelegateLogger: NSObject, SCStreamDelegate, @unchecked Sendable {
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        Platform.log("SCK stream stopped with error: \(error.localizedDescription)")
+    }
+
+    func streamDidBecomeActive(_ stream: SCStream) {
+        Platform.log("SCK stream became active")
+    }
+
+    func streamDidBecomeInactive(_ stream: SCStream) {
+        Platform.log("SCK stream became inactive")
     }
 }

--- a/interceptor-bridge/Sources/Domains/ClipboardDomain.swift
+++ b/interceptor-bridge/Sources/Domains/ClipboardDomain.swift
@@ -9,7 +9,11 @@ final class ClipboardDomain: DomainHandler, @unchecked Sendable {
     private var monitorTimer: DispatchSourceTimer?
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // Router sends command = "clipboard" because the action type is
+        // two-segment (`macos_clipboard`). The CLI parser puts the real
+        // sub-verb on action["sub"]. Mirror CompoundDomain's contract.
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "read":
             readClipboard(action, completion: completion)
         case "write":
@@ -23,7 +27,7 @@ final class ClipboardDomain: DomainHandler, @unchecked Sendable {
         case "types":
             getTypes(completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/CompoundDomain.swift
+++ b/interceptor-bridge/Sources/Domains/CompoundDomain.swift
@@ -1,11 +1,142 @@
 import Foundation
 import AppKit
 
+// Pluggable launcher seam so CompoundOpenTests can drive the
+// foreground-vs-background decision without depending on AppKit
+// activation behavior at runtime.
+protocol AppLauncher {
+    // Returns true iff the app is already running. Caller decides
+    // whether to launch or activate based on this.
+    func isRunning(_ name: String) -> Bool
+    // Activates a running app — used only when the caller asked for
+    // foregrounding via --activate.
+    func activateRunning(_ name: String)
+    // Launches a not-running app. The `activates` flag flows directly
+    // into NSWorkspace.OpenConfiguration.activates per Apple docs:
+    // false means "open in the background, do not steal focus."
+    func launch(_ name: String, activates: Bool, completion: @escaping () -> Void)
+}
+
+final class DefaultAppLauncher: AppLauncher {
+    // Case/locale-tolerant match on a running NSRunningApplication.
+    // The original `localizedName == name` check was the leak: it's
+    // exact-match and locale-sensitive, so an `isRunning` miss caused
+    // the launch fallback to fire on already-running apps and trigger
+    // self-foregrounding via kAEOpenApplication. We compare both
+    // `localizedName` and the bundle URL's last component (the .app
+    // basename), case-insensitive, against either the user-supplied
+    // name or the same name with .app appended/stripped.
+    static func matches(_ app: NSRunningApplication, _ name: String) -> Bool {
+        matches(
+            localizedName: app.localizedName,
+            bundleBaseName: app.bundleURL?.deletingPathExtension().lastPathComponent,
+            bundleId: app.bundleIdentifier,
+            name: name
+        )
+    }
+
+    // Pure helper extracted so the matching policy can be unit-tested
+    // without constructing a real NSRunningApplication.
+    static func matches(
+        localizedName: String?,
+        bundleBaseName: String?,
+        bundleId: String?,
+        name: String
+    ) -> Bool {
+        let target = name.lowercased()
+        let targetNoExt = target.hasSuffix(".app") ? String(target.dropLast(4)) : target
+        if let localized = localizedName?.lowercased(),
+           localized == target || localized == targetNoExt {
+            return true
+        }
+        if let bundle = bundleBaseName?.lowercased(),
+           bundle == target || bundle == targetNoExt {
+            return true
+        }
+        if let id = bundleId?.lowercased(), id == target {
+            return true
+        }
+        return false
+    }
+
+    func isRunning(_ name: String) -> Bool {
+        NSWorkspace.shared.runningApplications.contains(where: { Self.matches($0, name) })
+    }
+
+    func activateRunning(_ name: String) {
+        if let app = NSWorkspace.shared.runningApplications.first(where: { Self.matches($0, name) }) {
+            app.activate(options: [.activateIgnoringOtherApps])
+            usleep(300_000)
+        }
+    }
+
+    func launch(_ name: String, activates: Bool, completion: @escaping () -> Void) {
+        // Modern URL resolution path. Per Apple docs:
+        //   - `urlForApplication(withBundleIdentifier:)` is the modern
+        //     replacement for `absolutePathForApplication(...)`.
+        //   - `fullPath(forApplication:)` is deprecated since macOS 11.0
+        //     and is intentionally NOT used here.
+        //   - `launchApplication(_:)` is deprecated and always
+        //     foregrounds; it is intentionally NOT used here.
+        // For the "launch by display name" case where we don't have a
+        // bundle ID, we walk /Applications + /System/Applications to
+        // find a matching `.app` bundle. If that fails, we fail the
+        // launch rather than falling into a deprecated foregrounding
+        // API.
+        let workspace = NSWorkspace.shared
+        let appURL = Self.resolveAppURL(name: name)
+        guard let appURL = appURL else {
+            // No URL resolved by any modern API — fail closed instead
+            // of foregrounding via the deprecated path.
+            completion()
+            return
+        }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = activates
+        config.addsToRecentItems = false
+        // Reuse a running instance if there happens to be one (default).
+        // createsNewApplicationInstance defaults to false; we leave it.
+        workspace.openApplication(at: appURL, configuration: config) { _, _ in
+            completion()
+        }
+    }
+
+    static func resolveAppURL(name: String) -> URL? {
+        let workspace = NSWorkspace.shared
+        // 1. If `name` is itself a bundle id (contains a dot and matches
+        //    a known app), use the modern bundle-id resolver.
+        if name.contains("."),
+           let url = workspace.urlForApplication(withBundleIdentifier: name) {
+            return url
+        }
+        // 2. Walk standard app locations for a `.app` bundle whose
+        //    last-path-component matches `name` (with or without .app).
+        let target = name.hasSuffix(".app") ? name : "\(name).app"
+        let searchDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            "\(NSHomeDirectory())/Applications",
+        ]
+        let fm = FileManager.default
+        for dir in searchDirs {
+            let candidate = "\(dir)/\(target)"
+            if fm.fileExists(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+}
+
 final class CompoundDomain: DomainHandler, @unchecked Sendable {
     private let router: Router
+    private let launcher: AppLauncher
+    typealias AppIdentity = (name: String, pid: pid_t, bundleId: String)
 
-    init(router: Router) {
+    init(router: Router, launcher: AppLauncher = DefaultAppLauncher()) {
         self.router = router
+        self.launcher = launcher
     }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -26,31 +157,47 @@ final class CompoundDomain: DomainHandler, @unchecked Sendable {
 
     private func handleOpen(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         let appName = action["app"] as? String
+        let pid = action["pid"] as? Int32
+        // Background-first: only foreground when the caller explicitly
+        // sets activate=true on the action. The default is therefore
+        // "open and read AX state without stealing focus."
+        let shouldActivate = action["activate"] as? Bool ?? false
         if let appName = appName {
-            let apps = NSWorkspace.shared.runningApplications
-            if let app = apps.first(where: { $0.localizedName == appName }) {
-                app.activate()
-                usleep(300_000)
+            // Critical background-first invariant: when the target
+            // is already running, NEVER call NSWorkspace.openApplication.
+            // Per Apple docs (OpenConfiguration.activates), the activates
+            // flag only suppresses the *system's* activation pass; it does
+            // not stop an AppKit app from self-activating in response to
+            // the kAEOpenApplication / kAEOpenDocuments Apple Event that
+            // openApplication delivers. The only way to truly stay
+            // background-first for a running app is to do nothing.
+            if launcher.isRunning(appName) {
+                if shouldActivate { launcher.activateRunning(appName) }
+                // Else: no-op. Tree/windows reads below operate via AX
+                // and don't move focus.
             } else {
-                NSWorkspace.shared.launchApplication(appName)
-                usleep(500_000)
+                let semaphore = DispatchSemaphore(value: 0)
+                launcher.launch(appName, activates: shouldActivate) {
+                    semaphore.signal()
+                }
+                _ = semaphore.wait(timeout: .now() + 5.0)
             }
         }
 
         let filter = action["filter"] as? String ?? "interactive"
         let depth = action["depth"] as? Int ?? 10
-        let treeAction: [String: Any] = buildAction("macos_tree", app: appName, extra: ["filter": filter, "depth": depth])
+        let treeAction: [String: Any] = buildAction("macos_tree", app: appName, pid: pid, extra: ["filter": filter, "depth": depth])
 
-        router.route(action: treeAction) { [router, appName] treeResult in
+        router.route(action: treeAction) { [router, appName, pid] treeResult in
             let treeData: String = (treeResult["data"] as? String) ?? ""
-            let windowsAction: [String: Any] = ["type": "macos_windows"]
+            let windowsAction: [String: Any] = self.buildAction("macos_windows", app: appName, pid: pid)
             router.route(action: windowsAction) { windowsResult in
-                let frontApp = NSWorkspace.shared.frontmostApplication
+                let appInfo = self.describeApp(named: appName, pid: pid)
                 completion(WireFormat.success([
                     "tree": treeData,
                     "windows": (windowsResult["data"] as? [[String: Any]]) ?? [] as [[String: Any]],
-                    "app": frontApp?.localizedName ?? appName ?? "unknown",
-                    "pid": frontApp?.processIdentifier ?? 0
+                    "app": appInfo.name,
+                    "pid": appInfo.pid
                 ]))
             }
         }
@@ -58,16 +205,17 @@ final class CompoundDomain: DomainHandler, @unchecked Sendable {
 
     private func handleRead(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         let appName = action["app"] as? String
+        let pid = action["pid"] as? Int32
         let filter = action["filter"] as? String ?? "interactive"
         let depth = action["depth"] as? Int ?? 10
-        let treeAction = buildAction("macos_tree", app: appName, extra: ["filter": filter, "depth": depth])
+        let treeAction = buildAction("macos_tree", app: appName, pid: pid, extra: ["filter": filter, "depth": depth])
 
         router.route(action: treeAction) { treeResult in
-            let frontApp = NSWorkspace.shared.frontmostApplication
+            let appInfo = self.describeApp(named: appName, pid: pid)
             completion(WireFormat.success([
                 "tree": treeResult["data"] ?? "",
-                "app": frontApp?.localizedName ?? "unknown",
-                "pid": frontApp?.processIdentifier ?? 0
+                "app": appInfo.name,
+                "pid": appInfo.pid
             ]))
         }
     }
@@ -76,6 +224,7 @@ final class CompoundDomain: DomainHandler, @unchecked Sendable {
         let ref = action["ref"] as? String ?? ""
         let text = action["text"] as? String
         let appName = action["app"] as? String
+        let pid = (action["pid"] as? Int32) ?? RefRegistry.shared.resolvePID(ref)
 
         let inputAction: [String: Any]
         if let text = text {
@@ -92,7 +241,7 @@ final class CompoundDomain: DomainHandler, @unchecked Sendable {
 
             usleep(200_000)
 
-            let treeAction: [String: Any] = ["type": "macos_tree", "filter": "interactive", "depth": 10]
+            let treeAction = self.buildAction("macos_tree", app: appName, pid: pid, extra: ["filter": "interactive", "depth": 10])
             router.route(action: treeAction) { treeResult in
                 completion(WireFormat.success([
                     "action": text != nil ? "typed" : "clicked",
@@ -105,30 +254,73 @@ final class CompoundDomain: DomainHandler, @unchecked Sendable {
 
     private func handleInspect(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         let appName = action["app"] as? String
-        let treeAction = buildAction("macos_tree", app: appName, extra: ["filter": "interactive", "depth": 10])
+        let pid = action["pid"] as? Int32
+        let treeAction = buildAction("macos_tree", app: appName, pid: pid, extra: ["filter": "interactive", "depth": 10])
 
-        router.route(action: treeAction) { [router] treeResult in
+        router.route(action: treeAction) { [appName, pid] treeResult in
             let treeData: String = (treeResult["data"] as? String) ?? ""
-            let appsAction: [String: Any] = ["type": "macos_apps"]
-            router.route(action: appsAction) { appsResult in
-                let frontApp = NSWorkspace.shared.frontmostApplication
-                completion(WireFormat.success([
-                    "tree": treeData,
-                    "apps": (appsResult["data"] as? [[String: Any]]) ?? [] as [[String: Any]],
-                    "frontmost": [
-                        "name": frontApp?.localizedName ?? "unknown",
-                        "pid": frontApp?.processIdentifier ?? 0,
-                        "bundleId": frontApp?.bundleIdentifier ?? ""
-                    ]
-                ]))
-            }
+            let appInfo = self.describeApp(named: appName, pid: pid)
+            completion(WireFormat.success([
+                "tree": treeData,
+                "apps": self.appsSnapshot(),
+                "frontmost": [
+                    "name": appInfo.name,
+                    "pid": appInfo.pid,
+                    "bundleId": appInfo.bundleId
+                ]
+            ]))
         }
     }
 
-    private func buildAction(_ type: String, app: String?, extra: [String: Any] = [:]) -> [String: Any] {
+    private func buildAction(_ type: String, app: String?, pid: Int32? = nil, extra: [String: Any] = [:]) -> [String: Any] {
         var action: [String: Any] = ["type": type]
         if let app = app { action["app"] = app }
+        if let pid = pid { action["pid"] = Int(pid) }
         for (k, v) in extra { action[k] = v }
         return action
+    }
+
+    private func describeApp(named appName: String?, pid: Int32? = nil) -> AppIdentity {
+        if let pid = pid,
+           let app = NSRunningApplication(processIdentifier: pid_t(pid)) {
+            return Self.preferredAppIdentity(
+                requested: (app.localizedName ?? appName ?? "unknown", app.processIdentifier, app.bundleIdentifier ?? ""),
+                frontmost: nil
+            )
+        }
+        if let appName = appName,
+           let app = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == appName }) {
+            return Self.preferredAppIdentity(
+                requested: (app.localizedName ?? appName, app.processIdentifier, app.bundleIdentifier ?? ""),
+                frontmost: nil
+            )
+        }
+        let frontApp = NSWorkspace.shared.frontmostApplication
+        return Self.preferredAppIdentity(
+            requested: nil,
+            frontmost: (
+                frontApp?.localizedName ?? appName ?? "unknown",
+                frontApp?.processIdentifier ?? 0,
+                frontApp?.bundleIdentifier ?? ""
+            )
+        )
+    }
+
+    private func appsSnapshot() -> [[String: Any]] {
+        NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .map { app in
+                [
+                    "name": app.localizedName ?? "(unknown)",
+                    "pid": app.processIdentifier,
+                    "bundleId": app.bundleIdentifier ?? "",
+                    "isActive": app.isActive,
+                    "isHidden": app.isHidden
+                ]
+            }
+    }
+
+    static func preferredAppIdentity(requested: AppIdentity?, frontmost: AppIdentity?) -> AppIdentity {
+        requested ?? frontmost ?? ("unknown", 0, "")
     }
 }

--- a/interceptor-bridge/Sources/Domains/FilesDomain.swift
+++ b/interceptor-bridge/Sources/Domains/FilesDomain.swift
@@ -6,7 +6,11 @@ final class FilesDomain: DomainHandler, @unchecked Sendable {
     private var recentChanges: [[String: Any]] = []
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // Router sends command = "files" because the action type is
+        // two-segment (`macos_files`). The CLI parser puts the real
+        // sub-verb on action["sub"].
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "watch":
             watchDirectory(action, completion: completion)
         case "recent":
@@ -14,7 +18,7 @@ final class FilesDomain: DomainHandler, @unchecked Sendable {
         case "open":
             getOpenFiles(completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 
@@ -65,9 +69,17 @@ final class FilesDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func getOpenFiles(completion: @escaping @Sendable ([String: Any]) -> Void) {
+        // Use lsof's fast path: -nlP avoids DNS / login-name / port-name
+        // resolution; -c "^com.apple" excludes Apple-bundled processes;
+        // -Fn emits only file-name records. We post-filter to user files
+        // (those rooted at the user's home or /Volumes) and cap to 100.
+        // The previous implementation used `+D <homedir>` which is a
+        // recursive directory scan and routinely exceeded the daemon's
+        // 15s request timeout on large home directories.
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        task.arguments = ["-c", "^com.apple", "+D", FileManager.default.homeDirectoryForCurrentUser.path, "-Fn"]
+        task.arguments = ["-nlP", "-c", "^com.apple", "-Fn"]
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = FileHandle.nullDevice
@@ -77,10 +89,24 @@ final class FilesDomain: DomainHandler, @unchecked Sendable {
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             task.waitUntilExit()
             let output = String(data: data, encoding: .utf8) ?? ""
-            let files = output.split(separator: "\n")
-                .filter { $0.hasPrefix("n/") }
-                .map { String($0.dropFirst(1)) }
+            let files: [String] = output.split(separator: "\n")
+                .compactMap { line -> String? in
+                    guard line.hasPrefix("n/") else { return nil }
+                    return String(line.dropFirst(1))
+                }
+                .filter { path in
+                    // User-relevant files only. Exclude framework dylibs,
+                    // /System, /private noise, and pipes/sockets.
+                    if path.hasPrefix("/System/") { return false }
+                    if path.hasPrefix("/Library/") { return false }
+                    if path.hasPrefix("/usr/") { return false }
+                    if path.hasPrefix("/private/var/") { return false }
+                    if path.contains(".framework/") { return false }
+                    if path.contains(".dylib") { return false }
+                    return path.hasPrefix(homeDir) || path.hasPrefix("/Volumes/") || path.hasPrefix("/Applications/")
+                }
                 .prefix(100)
+                .map { $0 }
             completion(WireFormat.success(Array(files)))
         } catch {
             completion(WireFormat.error("lsof failed: \(error.localizedDescription)"))

--- a/interceptor-bridge/Sources/Domains/InputDomain.swift
+++ b/interceptor-bridge/Sources/Domains/InputDomain.swift
@@ -9,9 +9,11 @@ enum InputError: Error {
 
 final class InputDomain: DomainHandler, @unchecked Sendable {
     private let refRegistry: RefRegistry
+    private let selector: InputTargetSelector
 
     init(refRegistry: RefRegistry = .shared) {
         self.refRegistry = refRegistry
+        self.selector = InputTargetSelector.live(refRegistry: refRegistry)
     }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -31,6 +33,44 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         }
     }
 
+    // MARK: - Routing helpers
+
+    // Reads (ref?, app?, pid?) out of the action and asks the selector
+    // for a delivery target. Used by every input verb so behavior is
+    // uniform: ref present → AX press; explicit app/pid → postToPid;
+    // nothing → legacy cghidEventTap.
+    private func selectTarget(_ action: [String: Any]) -> InputTarget {
+        let ref = action["ref"] as? String
+        let appName = action["app"] as? String
+        let pid: pid_t? = (action["pid"] as? Int).map { pid_t($0) } ?? (action["pid"] as? pid_t)
+        return selector.select(ref: ref, appName: appName, pid: pid)
+    }
+
+    // Same shape but returns just a PID for keyboard fallback paths
+    // (type / keys) where AX press was inappropriate or unavailable.
+    private func targetPid(_ action: [String: Any]) -> pid_t? {
+        let ref = action["ref"] as? String
+        let appName = action["app"] as? String
+        let pid: pid_t? = (action["pid"] as? Int).map { pid_t($0) } ?? (action["pid"] as? pid_t)
+        return selector.resolveTargetPid(ref: ref, appName: appName, pid: pid)
+    }
+
+    // Posts a single CGEvent through the right layer for the resolved
+    // target. Centralizes the post-tap vs post-to-pid choice so every
+    // verb can stay short and consistent.
+    private func post(_ event: CGEvent, on target: InputTarget) {
+        switch target {
+        case .axPress:
+            // AX press doesn't post events; callers handle that path
+            // explicitly. Falling through here would be a bug.
+            break
+        case .postToPid(let pid):
+            event.postToPid(pid)
+        case .cghidEventTap:
+            event.post(tap: .cghidEventTap)
+        }
+    }
+
     // MARK: - Click
 
     private func handleClick(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -38,7 +78,36 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         let right = action["right"] as? Bool ?? false
         let clickCount = double ? 2 : 1
 
-        resolveCoordinates(action) { result in
+        let target = selectTarget(action)
+
+        // Pure AX press — only for plain single left clicks against a ref.
+        // AX press doesn't model double-click or right-click semantics;
+        // those keep going through synthesized CGEvents.
+        if case .axPress(let element) = target, !double, !right {
+            let err = AXUIElementPerformAction(element, kAXPressAction as CFString)
+            if err == .success {
+                completion(WireFormat.success("ax-pressed ref"))
+                return
+            }
+            // Fall through: AX rejected the action; synthesize the click
+            // and route it via PID so it still doesn't change focus.
+        }
+
+        // For AX-resolved targets, find the owning PID up front so we
+        // can postToPid the synthesized events without taking focus.
+        // For coords-only with no app, this falls back to cghidEventTap
+        // (legacy behavior). Resolved here (outside the closure) so the
+        // non-Sendable `action` dictionary doesn't have to be captured.
+        let resolvedPostTarget: InputTarget
+        switch target {
+        case .axPress:
+            if let pid = targetPid(action) { resolvedPostTarget = .postToPid(pid) }
+            else { resolvedPostTarget = .cghidEventTap }
+        default:
+            resolvedPostTarget = target
+        }
+
+        resolveCoordinates(action) { [self] result in
             switch result {
             case .success(let point):
                 let button: CGMouseButton = right ? .right : .left
@@ -50,25 +119,32 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
                     return
                 }
 
-                // Move first
+                let postTarget = resolvedPostTarget
+
                 if let moveEvent = CGEvent(mouseEventSource: source, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) {
-                    moveEvent.post(tap: .cghidEventTap)
+                    post(moveEvent, on: postTarget)
                 }
 
-                DispatchQueue.global().asyncAfter(deadline: .now() + 0.01) {
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.01) { [self] in
                     for click in 1...clickCount {
                         if let downEvent = CGEvent(mouseEventSource: source, mouseType: downType, mouseCursorPosition: point, mouseButton: button) {
                             downEvent.setIntegerValueField(.mouseEventClickState, value: Int64(click))
-                            downEvent.post(tap: .cghidEventTap)
+                            post(downEvent, on: postTarget)
                         }
                         usleep(5000)
                         if let upEvent = CGEvent(mouseEventSource: source, mouseType: upType, mouseCursorPosition: point, mouseButton: button) {
                             upEvent.setIntegerValueField(.mouseEventClickState, value: Int64(click))
-                            upEvent.post(tap: .cghidEventTap)
+                            post(upEvent, on: postTarget)
                         }
                         if click < clickCount { usleep(50000) }
                     }
-                    completion(WireFormat.success("clicked at (\(Int(point.x)), \(Int(point.y)))"))
+                    let routing: String
+                    switch postTarget {
+                    case .postToPid(let pid): routing = "pid=\(pid)"
+                    case .cghidEventTap: routing = "frontmost"
+                    case .axPress: routing = "ax"
+                    }
+                    completion(WireFormat.success("clicked at (\(Int(point.x)), \(Int(point.y))) → \(routing)"))
                 }
             case .failure(let error):
                 switch error {
@@ -86,12 +162,27 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        // If ref provided, focus first
-        if let ref = action["ref"] as? String {
-            if let element = refRegistry.resolve(ref) {
-                AXUIElementPerformAction(element, kAXPressAction as CFString)
-                usleep(100_000)
+        // AX-first path: when a ref points to a text-bearing element,
+        // try AXUIElementSetAttributeValue(kAXValueAttribute, text).
+        // This bypasses the keyboard entirely and never moves focus.
+        // Apple documents this as the supported way to programmatically
+        // populate text fields.
+        if let ref = action["ref"] as? String, let element = refRegistry.resolve(ref) {
+            if Self.isTextRole(element) {
+                let err = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, text as CFString)
+                if err == .success {
+                    completion(WireFormat.success("ax-set value (\(text.count) chars)"))
+                    return
+                }
+                // Element rejected programmatic value-set (e.g. password
+                // fields, fields with custom delegates). Fall through
+                // to synthesized key events, but still route to the
+                // ref's owning PID so we don't have to foreground.
             }
+            // Focus the element first so synthesized keys land in it,
+            // even though the app stays in the background.
+            AXUIElementPerformAction(element, kAXPressAction as CFString)
+            usleep(100_000)
         }
 
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
@@ -99,21 +190,54 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        DispatchQueue.global().async {
+        // Pick a delivery target for synthesized key events: prefer
+        // postToPid (ref → owning PID, or explicit pid/app), else fall
+        // through to cghidEventTap.
+        let postTarget: InputTarget
+        if let pid = targetPid(action) {
+            postTarget = .postToPid(pid)
+        } else {
+            postTarget = .cghidEventTap
+        }
+
+        DispatchQueue.global().async { [self] in
             for char in text {
                 let utf16 = Array(String(char).utf16)
                 if let downEvent = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
                     downEvent.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
-                    downEvent.post(tap: .cghidEventTap)
+                    post(downEvent, on: postTarget)
                 }
                 usleep(3000)
                 if let upEvent = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
                     upEvent.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
-                    upEvent.post(tap: .cghidEventTap)
+                    post(upEvent, on: postTarget)
                 }
                 usleep(8000)
             }
-            completion(WireFormat.success("typed \(text.count) characters"))
+            let routing: String
+            switch postTarget {
+            case .postToPid(let pid): routing = "pid=\(pid)"
+            case .cghidEventTap: routing = "frontmost"
+            case .axPress: routing = "ax"
+            }
+            completion(WireFormat.success("typed \(text.count) characters → \(routing)"))
+        }
+    }
+
+    // Roles that we accept programmatic value-set on. These are the
+    // standard text-bearing AX roles per Apple's accessibility
+    // documentation.
+    private static func isTextRole(_ element: AXUIElement) -> Bool {
+        var role: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role) == .success,
+              let r = role as? String else {
+            return false
+        }
+        switch r {
+        case "AXTextField", "AXTextArea", "AXSearchField", "AXComboBox":
+            return true
+        default:
+            return false
         }
     }
 
@@ -164,7 +288,16 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        DispatchQueue.global().async {
+        // Same routing rule as click/type: ref → owning PID, else
+        // explicit pid/app, else cghidEventTap.
+        let postTarget: InputTarget
+        if let pid = targetPid(action) {
+            postTarget = .postToPid(pid)
+        } else {
+            postTarget = .cghidEventTap
+        }
+
+        DispatchQueue.global().async { [self] in
             // Press modifiers
             let modKeyCodes: [(String, CGKeyCode)] = [
                 ("shift", 56), ("control", 59), ("ctrl", 59), ("alt", 58), ("option", 58),
@@ -174,7 +307,7 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
                 if let (_, code) = modKeyCodes.first(where: { $0.0 == mod }) {
                     if let event = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true) {
                         event.flags = flags
-                        event.post(tap: .cghidEventTap)
+                        post(event, on: postTarget)
                     }
                 }
             }
@@ -182,24 +315,30 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
 
             if let downEvent = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) {
                 downEvent.flags = flags
-                downEvent.post(tap: .cghidEventTap)
+                post(downEvent, on: postTarget)
             }
             usleep(5000)
             if let upEvent = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
                 upEvent.flags = flags
-                upEvent.post(tap: .cghidEventTap)
+                post(upEvent, on: postTarget)
             }
 
             usleep(5000)
             for mod in modifiers.reversed() {
                 if let (_, code) = modKeyCodes.first(where: { $0.0 == mod }) {
                     if let event = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: false) {
-                        event.post(tap: .cghidEventTap)
+                        post(event, on: postTarget)
                     }
                 }
             }
 
-            completion(WireFormat.success("sent keys: \(keys)"))
+            let routing: String
+            switch postTarget {
+            case .postToPid(let pid): routing = "pid=\(pid)"
+            case .cghidEventTap: routing = "frontmost"
+            case .axPress: routing = "ax"
+            }
+            completion(WireFormat.success("sent keys: \(keys) → \(routing)"))
         }
     }
 
@@ -210,20 +349,9 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         let amount = action["amount"] as? Int32 ?? 300
         let times = max(1, action["times"] as? Int ?? 1)
         let intervalMs = max(0, action["intervalMs"] as? Int ?? 50)
-        // --pid <pid> or --app <appName> routes the scroll wheel event
-        // directly to that process via CGEvent.postToPid, bypassing the
-        // focused-window routing of cghidEventTap. This lets us scroll an
-        // occluded window (e.g. Signal in the background) without bringing
-        // it to front. Same trick DockDoor / AltTab use.
-        let targetPid: pid_t?
-        if let p = action["pid"] as? Int {
-            targetPid = pid_t(p)
-        } else if let appName = action["app"] as? String {
-            let workspace = NSWorkspace.shared
-            targetPid = workspace.runningApplications.first(where: { $0.localizedName == appName })?.processIdentifier
-        } else {
-            targetPid = nil
-        }
+        // Prefer ref-resolved owning PID, then explicit --pid, then
+        // --app name lookup. Same precedence as click/type/keys.
+        let pidFromAction = targetPid(action)
 
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             completion(WireFormat.error("failed to create event source"))
@@ -244,7 +372,7 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
         // loop first via the SLPS make-key trick so Chromium / Electron
         // actually processes the scroll. The window stays where it is in
         // z-order; the user's focused app is preserved.
-        if let pid = targetPid {
+        if let pid = pidFromAction {
             // Find a window for this pid via CGWindowList so we have a CGWindowID.
             if let arr = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] {
                 let mine = arr.first(where: { ($0[kCGWindowOwnerPID as String] as? pid_t) == pid })
@@ -258,7 +386,7 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
 
         for i in 0..<times {
             if let scrollEvent = CGEvent(scrollWheelEvent2Source: source, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) {
-                if let pid = targetPid {
+                if let pid = pidFromAction {
                     scrollEvent.postToPid(pid)
                 } else {
                     scrollEvent.post(tap: .cghidEventTap)
@@ -268,20 +396,27 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
                 usleep(useconds_t(intervalMs * 1000))
             }
         }
-        let routing = targetPid.map { "pid=\($0)" } ?? "focused"
+        let routing = pidFromAction.map { "pid=\($0)" } ?? "frontmost"
         completion(WireFormat.success("scrolled \(direction) \(amount)x\(times) → \(routing)"))
     }
 
     // MARK: - Drag
 
     private func handleDrag(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let postTarget: InputTarget
+        if let pid = targetPid(action) {
+            postTarget = .postToPid(pid)
+        } else {
+            postTarget = .cghidEventTap
+        }
+
         guard let fromRef = action["from"] as? String, let toRef = action["to"] as? String else {
             // Try coordinate-based drag
             if let fromCoords = action["fromCoords"] as? String, let toCoords = action["toCoords"] as? String {
                 let fromParts = fromCoords.split(separator: ",").compactMap { Double($0) }
                 let toParts = toCoords.split(separator: ",").compactMap { Double($0) }
                 if fromParts.count == 2 && toParts.count == 2 {
-                    performDrag(from: CGPoint(x: fromParts[0], y: fromParts[1]), to: CGPoint(x: toParts[0], y: toParts[1]), completion: completion)
+                    performDrag(from: CGPoint(x: fromParts[0], y: fromParts[1]), to: CGPoint(x: toParts[0], y: toParts[1]), target: postTarget, completion: completion)
                     return
                 }
             }
@@ -301,25 +436,36 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        performDrag(from: fromPoint, to: toPoint, completion: completion)
+        // Refs were given but no app/pid was; pick up the owning PID
+        // from the ref so the drag still routes correctly.
+        let dragTarget: InputTarget
+        switch postTarget {
+        case .cghidEventTap:
+            if let pid = refRegistry.resolvePID(fromRef) { dragTarget = .postToPid(pid) }
+            else { dragTarget = .cghidEventTap }
+        default:
+            dragTarget = postTarget
+        }
+
+        performDrag(from: fromPoint, to: toPoint, target: dragTarget, completion: completion)
     }
 
-    private func performDrag(from: CGPoint, to: CGPoint, completion: @escaping @Sendable ([String: Any]) -> Void) {
+    private func performDrag(from: CGPoint, to: CGPoint, target: InputTarget, completion: @escaping @Sendable ([String: Any]) -> Void) {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             completion(WireFormat.error("failed to create event source"))
             return
         }
 
-        DispatchQueue.global().async {
+        DispatchQueue.global().async { [self] in
             // Move to start
             if let move = CGEvent(mouseEventSource: source, mouseType: .mouseMoved, mouseCursorPosition: from, mouseButton: .left) {
-                move.post(tap: .cghidEventTap)
+                post(move, on: target)
             }
             usleep(10000)
 
             // Mouse down
             if let down = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: from, mouseButton: .left) {
-                down.post(tap: .cghidEventTap)
+                post(down, on: target)
             }
             usleep(10000)
 
@@ -330,16 +476,22 @@ final class InputDomain: DomainHandler, @unchecked Sendable {
                 let x = from.x + (to.x - from.x) * t
                 let y = from.y + (to.y - from.y) * t
                 if let drag = CGEvent(mouseEventSource: source, mouseType: .leftMouseDragged, mouseCursorPosition: CGPoint(x: x, y: y), mouseButton: .left) {
-                    drag.post(tap: .cghidEventTap)
+                    post(drag, on: target)
                 }
                 usleep(5000)
             }
 
             // Mouse up
             if let up = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: to, mouseButton: .left) {
-                up.post(tap: .cghidEventTap)
+                post(up, on: target)
             }
-            completion(WireFormat.success("dragged from (\(Int(from.x)),\(Int(from.y))) to (\(Int(to.x)),\(Int(to.y)))"))
+            let routing: String
+            switch target {
+            case .postToPid(let pid): routing = "pid=\(pid)"
+            case .cghidEventTap: routing = "frontmost"
+            case .axPress: routing = "ax"
+            }
+            completion(WireFormat.success("dragged from (\(Int(from.x)),\(Int(from.y))) to (\(Int(to.x)),\(Int(to.y))) → \(routing)"))
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/MenuDomain.swift
+++ b/interceptor-bridge/Sources/Domains/MenuDomain.swift
@@ -16,13 +16,17 @@ final class MenuDomain: DomainHandler, @unchecked Sendable {
         }
     }
 
-    private func frontmostPid(_ action: [String: Any]) -> pid_t {
+    private func targetPid(_ action: [String: Any]) -> pid_t {
         if let pid = action["pid"] as? Int32 { return pid }
+        if let appName = action["app"] as? String,
+           let app = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == appName }) {
+            return app.processIdentifier
+        }
         return NSWorkspace.shared.frontmostApplication?.processIdentifier ?? 0
     }
 
     private func listMenu(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        let pid = frontmostPid(action)
+        let pid = targetPid(action)
         guard pid != 0 else {
             completion(WireFormat.error("no frontmost app"))
             return
@@ -74,7 +78,7 @@ final class MenuDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func invokeMenu(items: [String], action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        let pid = frontmostPid(action)
+        let pid = targetPid(action)
         guard pid != 0 else {
             completion(WireFormat.error("no frontmost app"))
             return

--- a/interceptor-bridge/Sources/Domains/NotificationsDomain.swift
+++ b/interceptor-bridge/Sources/Domains/NotificationsDomain.swift
@@ -6,13 +6,17 @@ final class NotificationsDomain: DomainHandler, @unchecked Sendable {
     private var observing = false
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // Router sends command = "notifications" because the action type
+        // is two-segment (`macos_notifications`). The CLI parser puts the
+        // real sub-verb on action["sub"].
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "tail":
             startTailing(completion: completion)
         case "log":
             getLog(action, completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/TrustDomain.swift
+++ b/interceptor-bridge/Sources/Domains/TrustDomain.swift
@@ -4,7 +4,50 @@ import AppKit
 import CoreGraphics
 import AVFoundation
 
+// Trust response payload — schema lifted from Apple's AVAuthorizationStatus
+// vocabulary. Status values:
+//
+//   granted        — user has authorized the permission
+//   denied         — user has denied the permission
+//   not_determined — user has not yet been prompted (Mic only by Apple API design)
+//   restricted     — system policy blocks the user from changing it (Mic only)
+//
+// AX and Screen Recording can only ever surface granted or denied because
+// Apple's AXIsProcessTrusted / CGPreflightScreenCaptureAccess return Bool.
+// We document that asymmetry inline via `limitation` on those entries.
+struct Permission {
+    let name: String
+    let status: PermissionStatus
+    let required: Bool
+    let path: String
+    let reason: String
+    let limitation: String?
+
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "name": name,
+            "status": status.rawValue,
+            "required": required,
+            "path": path,
+            "reason": reason,
+            // Deprecated for one release. Computed from `status`.
+            // Drop in a future release once consumers have migrated.
+            "granted": status == .granted
+        ]
+        if let limitation = limitation {
+            dict["limitation"] = limitation
+        }
+        return dict
+    }
+}
+
 final class TrustDomain: DomainHandler, @unchecked Sendable {
+    private let microphoneProvider: MicrophoneAuthorizationProvider
+
+    init(microphoneProvider: MicrophoneAuthorizationProvider = LiveMicrophoneAuthorizationProvider()) {
+        self.microphoneProvider = microphoneProvider
+    }
+
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         switch command {
         case "trust", "preflight":
@@ -14,91 +57,102 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         }
     }
 
-    private func preflight(completion: @escaping @Sendable ([String: Any]) -> Void) {
-        preflight(action: [:], completion: completion)
-    }
-
     private func preflight(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        let prompt = action["prompt"] as? Bool ?? false
-        let walkthrough = action["walkthrough"] as? Bool ?? false
-        let accessibilityPrompt = action["accessibilityPrompt"] as? Bool ?? false
-        let screenPrompt = action["screenPrompt"] as? Bool ?? false
-        let microphonePrompt = action["microphonePrompt"] as? Bool ?? false
+        // Defense-in-depth: --no-prompt overrides every other prompt flag so
+        // read-only consumers can rely on the call never modifying TCC state
+        // even if a future caller-side bug accidentally sets one of the
+        // prompt booleans.
+        let noPrompt = action["noPrompt"] as? Bool ?? false
+        let prompt = !noPrompt && (action["prompt"] as? Bool ?? false)
+        let walkthrough = !noPrompt && (action["walkthrough"] as? Bool ?? false)
+        let accessibilityPrompt = !noPrompt && (action["accessibilityPrompt"] as? Bool ?? false)
+        let screenPrompt = !noPrompt && (action["screenPrompt"] as? Bool ?? false)
+        let microphonePrompt = !noPrompt && (action["microphonePrompt"] as? Bool ?? false)
 
         let shouldPromptAccessibility = prompt || walkthrough || accessibilityPrompt
         let shouldPromptScreen = prompt || walkthrough || screenPrompt
         let shouldPromptMicrophone = prompt || walkthrough || microphonePrompt
 
-        let accessibilityGranted = promptAccessibilityIfNeeded(prompt: shouldPromptAccessibility)
-        let screenGranted = requestScreenRecordingIfNeeded(prompt: shouldPromptScreen)
-        let micGrantedNow = requestMicrophoneIfNeeded(prompt: shouldPromptMicrophone)
-
-        var openedPanes: [String] = []
-        if walkthrough {
-            if !accessibilityGranted {
-                openPrivacyPane("Privacy_Accessibility")
-                openedPanes.append("Accessibility")
-            } else if !screenGranted {
-                openPrivacyPane("Privacy_ScreenCapture")
-                openedPanes.append("Screen Recording")
-            } else if micGrantedNow != "true" {
-                openPrivacyPane("Privacy_Microphone")
-                openedPanes.append("Microphone")
-            }
-        }
+        let accessibilityStatus = checkAccessibility(prompt: shouldPromptAccessibility)
+        let screenStatus = checkScreenRecording(prompt: shouldPromptScreen)
+        let microphoneStatus = checkMicrophone(prompt: shouldPromptMicrophone)
 
         let displayName =
             (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
             ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
             ?? "Interceptor"
 
-        let permissions: [[String: Any]] = [
-            [
-                "name": "Accessibility",
-                "granted": accessibilityGranted,
-                "required": true,
-                "path": "System Settings → Privacy & Security → Accessibility → Enable \(displayName)",
-                "reason": "Required for UI element inspection, clicking, typing, and window management"
-            ],
-            [
-                "name": "Microphone",
-                "granted": micGrantedNow,
-                "required": false,
-                "path": "System Settings → Privacy & Security → Microphone → Enable \(displayName)",
-                "reason": "Required for speech recognition and voice activity detection"
-            ],
-            [
-                "name": "Screen Recording",
-                "granted": screenGranted,
-                "required": false,
-                "path": "System Settings → Privacy & Security → Screen Recording → Enable \(displayName)",
-                "reason": "Required for screenshots, screen capture, and vision analysis"
-            ]
+        let permissions: [Permission] = [
+            Permission(
+                name: "Accessibility",
+                status: accessibilityStatus,
+                required: true,
+                path: "System Settings → Privacy & Security → Accessibility → Enable \(displayName)",
+                reason: "Required for UI element inspection, clicking, typing, and window management",
+                limitation: "Apple's AXIsProcessTrusted returns Bool only; cannot distinguish denied from not_determined"
+            ),
+            Permission(
+                name: "Microphone",
+                status: microphoneStatus,
+                required: false,
+                path: "System Settings → Privacy & Security → Microphone → Enable \(displayName)",
+                reason: "Required for speech recognition and voice activity detection",
+                limitation: nil
+            ),
+            Permission(
+                name: "Screen Recording",
+                status: screenStatus,
+                required: false,
+                path: "System Settings → Privacy & Security → Screen Recording → Enable \(displayName)",
+                reason: "Required for screenshots, screen capture, and vision analysis",
+                limitation: "Apple's CGPreflightScreenCaptureAccess returns Bool only; cannot distinguish denied from not_determined"
+            )
         ]
 
-        var instructions: [String] = []
-        for perm in permissions {
-            let grantedValue = perm["granted"]
-            let denied =
-                (grantedValue as? Bool) == false ||
-                (grantedValue as? String) == "false"
-            if denied {
-                instructions.append(perm["path"] as? String ?? "")
+        // Walkthrough opens the next non-granted Privacy pane. Order matches
+        // the operator priority: Accessibility (required) before Screen
+        // (used for capture) before Microphone (optional).
+        var openedPanes: [String] = []
+        if walkthrough {
+            if accessibilityStatus != .granted {
+                openPrivacyPane("Privacy_Accessibility")
+                openedPanes.append("Accessibility")
+            } else if screenStatus != .granted {
+                openPrivacyPane("Privacy_ScreenCapture")
+                openedPanes.append("Screen Recording")
+            } else if microphoneStatus != .granted {
+                openPrivacyPane("Privacy_Microphone")
+                openedPanes.append("Microphone")
             }
         }
 
+        let actionRequired = permissions
+            .filter { $0.status != .granted }
+            .map { $0.path }
+
+        // pending_user_action signals that a prompt was just fired but the
+        // status is still not_determined — the user is being asked right now
+        // and the caller should re-poll trust later. Only meaningful for
+        // Microphone since it's the only surface where not_determined is
+        // observable.
+        var pendingUserAction: [String] = []
+        if shouldPromptMicrophone && microphoneStatus == .notDetermined {
+            pendingUserAction.append("Microphone")
+        }
+
         var result: [String: Any] = [
-            "accessibility": accessibilityGranted,
-            "screenRecording": screenGranted,
-            "microphone": micGrantedNow,
-            "permissions": permissions,
+            "accessibility": accessibilityStatus.rawValue,
+            "screenRecording": screenStatus.rawValue,
+            "microphone": microphoneStatus.rawValue,
+            "permissions": permissions.map { $0.toDictionary() },
             "bundlePath": Bundle.main.bundlePath,
             "displayName": displayName
         ]
 
-        if !instructions.isEmpty {
-            result["action_required"] = instructions
+        if !actionRequired.isEmpty {
+            result["action_required"] = actionRequired
         }
+
         var prompted: [String] = []
         if shouldPromptAccessibility { prompted.append("Accessibility") }
         if shouldPromptScreen { prompted.append("Screen Recording") }
@@ -106,48 +160,116 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         if !prompted.isEmpty {
             result["prompted"] = prompted
         }
+
         if !openedPanes.isEmpty {
             result["opened"] = openedPanes
+        }
+
+        if !pendingUserAction.isEmpty {
+            result["pending_user_action"] = pendingUserAction
         }
 
         completion(WireFormat.success(result))
     }
 
-    private func promptAccessibilityIfNeeded(prompt: Bool) -> Bool {
-        guard prompt else { return AXIsProcessTrusted() }
-        let key = "AXTrustedCheckOptionPrompt" as CFString
-        let options = [key: true] as CFDictionary
-        return AXIsProcessTrustedWithOptions(options)
+    // ── Accessibility ────────────────────────────────────────────────────
+    // Apple's AXIsProcessTrusted / AXIsProcessTrustedWithOptions return Bool
+    // only. The prompt is async and (per Apple's docs) "does not affect the
+    // return value." So this function returns the *current* trust state
+    // regardless of whether we just fired a prompt.
+    private func checkAccessibility(prompt: Bool) -> PermissionStatus {
+        let trusted: Bool
+        if prompt {
+            let key = "AXTrustedCheckOptionPrompt" as CFString
+            let options = [key: true] as CFDictionary
+            trusted = AXIsProcessTrustedWithOptions(options)
+        } else {
+            trusted = AXIsProcessTrusted()
+        }
+        return PermissionStatus.fromBool(trusted)
     }
 
-    private func requestScreenRecordingIfNeeded(prompt: Bool) -> Bool {
-        guard prompt else { return CGPreflightScreenCaptureAccess() }
+    // ── Screen Recording ─────────────────────────────────────────────────
+    // CGPreflightScreenCaptureAccess / CGRequestScreenCaptureAccess return
+    // Bool. Same Apple-imposed 2-state asymmetry as Accessibility.
+    private func checkScreenRecording(prompt: Bool) -> PermissionStatus {
+        if !prompt {
+            return PermissionStatus.fromBool(CGPreflightScreenCaptureAccess())
+        }
         if CGPreflightScreenCaptureAccess() {
-            return true
+            return .granted
         }
-        return CGRequestScreenCaptureAccess()
+        // CGRequestScreenCaptureAccess is documented as Bool. It returns
+        // the post-call grant state. We return that directly.
+        return PermissionStatus.fromBool(CGRequestScreenCaptureAccess())
     }
 
-    private func requestMicrophoneIfNeeded(prompt: Bool) -> String {
-        let status = AVCaptureDevice.authorizationStatus(for: .audio)
-        switch status {
-        case .authorized:
-            return "true"
-        case .denied, .restricted:
-            return "false"
-        case .notDetermined:
-            guard prompt else { return "not_requested" }
-            let semaphore = DispatchSemaphore(value: 0)
-            var granted = false
-            AVCaptureDevice.requestAccess(for: .audio) { allowed in
-                granted = allowed
-                semaphore.signal()
-            }
-            _ = semaphore.wait(timeout: .now() + 30)
-            return granted ? "true" : "false"
-        @unknown default:
-            return "unknown"
+    // ── Microphone ───────────────────────────────────────────────────────
+    // Apple's AVAuthorizationStatus is the only TCC surface in this domain
+    // that exposes all four states. Apple's requestAccess is documented
+    // non-blocking — we fire it without awaiting. The completion handler is
+    // intentionally a no-op so the bridge worker thread can return
+    // immediately. Callers re-poll `interceptor macos trust` to observe the
+    // user's eventual response.
+    //
+    // LSUIElement-attached caveat (this is the load-bearing detail for
+    // the live mic prompt): when an LSUIElement = true app calls
+    // requestAccess, macOS surfaces the permission alert as a transient
+    // notification banner instead of a modal dialog. The banner can be
+    // missed by the user and auto-resolves to "denied" within a few seconds.
+    //
+    // The canonical fix used by every menu-bar utility that needs TCC
+    // permissions (Hammerspoon, Bartender, Karabiner-Elements, etc.) is
+    // to temporarily upgrade the activation policy from .accessory to
+    // .regular before requesting permission. This forces macOS to surface
+    // a real modal dialog parented to the now-foreground process. After
+    // the user responds, we revert to .accessory so we don't leak a Dock
+    // icon or cmd-tab entry beyond the prompt.
+    private func checkMicrophone(prompt: Bool) -> PermissionStatus {
+        let current = microphoneProvider.currentStatus().permissionStatus
+
+        // Already-decided states cannot be changed by another prompt; short
+        // circuit so we never fire a redundant requestAccess.
+        if current != .notDetermined {
+            return current
         }
+
+        guard prompt else { return .notDetermined }
+
+        // Upgrade activation policy on the main thread BEFORE firing
+        // requestAccess so the alert surfaces modally. This is documented
+        // on NSApplication.setActivationPolicy and is the standard pattern
+        // for LSUIElement utilities.
+        //
+        // Gated on bundle id so unit tests (xctest) don't try to manipulate
+        // their own process's Dock presence. Only the real bridge process
+        // (com.interceptor.bridge) does the upgrade.
+        let isLiveBridge = Bundle.main.bundleIdentifier == "com.interceptor.bridge"
+
+        if isLiveBridge {
+            DispatchQueue.main.async {
+                NSApplication.shared.setActivationPolicy(.regular)
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+        }
+
+        // Fire-and-forget. Apple-doc: "Calling this method doesn't block
+        // the thread while the system is prompting the user for access."
+        // Once the user responds, revert to .accessory so the Dock icon
+        // disappears and we go back to background-first behavior.
+        microphoneProvider.requestAccess { _ in
+            if isLiveBridge {
+                DispatchQueue.main.async {
+                    NSApplication.shared.setActivationPolicy(.accessory)
+                }
+            }
+        }
+
+        // Re-read in case the request resolved synchronously (it shouldn't
+        // for a true notDetermined entry, but if Apple's behavior ever
+        // changes we surface the new state). If it's still notDetermined we
+        // emit pending_user_action upstream.
+        return microphoneProvider.currentStatus().permissionStatus
     }
 
     private func openPrivacyPane(_ anchor: String) {

--- a/interceptor-bridge/Sources/Domains/UpdateDomain.swift
+++ b/interceptor-bridge/Sources/Domains/UpdateDomain.swift
@@ -1,0 +1,65 @@
+import Foundation
+import AppKit
+import Sparkle
+
+// `interceptor macos update *` — thin wrapper around SPUUpdater so the
+// CLI can drive Sparkle directly (manual user-initiated update check,
+// state inspection). Without this, agents and operators have to rely on
+// Sparkle's automatic scheduled-check cadence, which for an LSUIElement
+// app means the update prompt frequently never surfaces visibly.
+//
+// The `check` verb calls SPUUpdater.checkForUpdates() — the user-initiated
+// API — which always shows the alert immediately, regardless of the
+// scheduled-check throttle or the automatic-driver's silent-download
+// behavior. Combined with `SparkleUserDriverDelegate`, that alert will
+// surface as a real modal window rather than a transient banner.
+final class UpdateDomain: DomainHandler, @unchecked Sendable {
+    private let updaterController: SPUStandardUpdaterController
+
+    init(updaterController: SPUStandardUpdaterController) {
+        self.updaterController = updaterController
+    }
+
+    func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let sub = action["sub"] as? String ?? command
+        switch sub {
+        case "check":
+            handleCheck(completion: completion)
+        case "status":
+            handleStatus(completion: completion)
+        default:
+            notImplemented("update \(sub)", completion: completion)
+        }
+    }
+
+    // User-initiated check. Sparkle's contract: always shows the user
+    // driver alert. `checkForUpdates(_:)` requires main-thread invocation.
+    private func handleCheck(completion: @escaping @Sendable ([String: Any]) -> Void) {
+        DispatchQueue.main.async { [updaterController] in
+            updaterController.checkForUpdates(nil)
+            completion(WireFormat.success([
+                "message": "user-initiated update check fired — Sparkle will now show the alert",
+                "feed": updaterController.updater.feedURL?.absoluteString ?? "unset"
+            ]))
+        }
+    }
+
+    // Snapshot of Sparkle's current scheduling/state. Useful for agents
+    // diagnosing why an update prompt did or didn't surface.
+    private func handleStatus(completion: @escaping @Sendable ([String: Any]) -> Void) {
+        DispatchQueue.main.async { [updaterController] in
+            let updater = updaterController.updater
+            var payload: [String: Any] = [
+                "feed": updater.feedURL?.absoluteString ?? "unset",
+                "automaticChecks": updater.automaticallyChecksForUpdates,
+                "checkInterval": updater.updateCheckInterval,
+                "canCheckForUpdates": updater.canCheckForUpdates,
+                "sessionInProgress": updater.sessionInProgress
+            ]
+            if let last = updater.lastUpdateCheckDate {
+                payload["lastCheck"] = ISO8601DateFormatter().string(from: last)
+            }
+            completion(WireFormat.success(payload))
+        }
+    }
+}

--- a/interceptor-bridge/Sources/InputTargetSelector.swift
+++ b/interceptor-bridge/Sources/InputTargetSelector.swift
@@ -1,0 +1,118 @@
+import Foundation
+import ApplicationServices
+import AppKit
+
+// Picks how a synthesized input event should be delivered without
+// stealing focus when a target is known. Three documented Apple
+// delivery layers, ordered from most-specific to least-specific:
+//
+//   axPress(elem)       — AXUIElementPerformAction(kAXPressAction).
+//                         Pure AX, no event posting, never moves focus.
+//   postToPid(pid)      — CGEvent.postToPid(_:). Per-process delivery,
+//                         does not require the target to be frontmost.
+//   cghidEventTap       — system-wide HID, routed by WindowServer to
+//                         the frontmost app. Legacy "drive whatever's
+//                         on screen" behavior.
+//
+// The selector is a pure decision function over (ref, app, pid).
+// It does not perform any AX or event work itself — callers do that —
+// so it is trivially unit-testable.
+enum InputTarget: Equatable, @unchecked Sendable {
+    case axPress(AXUIElement)
+    case postToPid(pid_t)
+    case cghidEventTap
+
+    static func == (lhs: InputTarget, rhs: InputTarget) -> Bool {
+        switch (lhs, rhs) {
+        case (.axPress, .axPress): return true
+        case (.postToPid(let a), .postToPid(let b)): return a == b
+        case (.cghidEventTap, .cghidEventTap): return true
+        default: return false
+        }
+    }
+}
+
+// Compact, testable variant that doesn't carry the AXUIElement so we
+// can compare decisions in unit tests without fabricating live AX state.
+enum InputTargetKind: String, Equatable {
+    case axPress
+    case postToPid
+    case cghidEventTap
+}
+
+struct InputTargetSelector {
+    // Resolution functions are injected so tests can drive the
+    // selector with deterministic inputs. Production callers pass the
+    // real RefRegistry / NSWorkspace lookups.
+    let resolveRef: (String) -> (element: AXUIElement, pid: pid_t?)?
+    let resolvePidByName: (String) -> pid_t?
+
+    init(
+        resolveRef: @escaping (String) -> (element: AXUIElement, pid: pid_t?)?,
+        resolvePidByName: @escaping (String) -> pid_t?
+    ) {
+        self.resolveRef = resolveRef
+        self.resolvePidByName = resolvePidByName
+    }
+
+    // Live-AX selection. Called from InputDomain when the request
+    // carries a real ref and we want the actual AXUIElement back.
+    func select(ref: String?, appName: String?, pid: pid_t?) -> InputTarget {
+        if let ref = ref, let entry = resolveRef(ref) {
+            return .axPress(entry.element)
+        }
+        if let pid = pid {
+            return .postToPid(pid)
+        }
+        if let appName = appName, let resolved = resolvePidByName(appName) {
+            return .postToPid(resolved)
+        }
+        return .cghidEventTap
+    }
+
+    // Pure-decision variant for tests: returns the kind only.
+    // Identical control flow to `select(...)`.
+    func selectKind(ref: String?, appName: String?, pid: pid_t?) -> InputTargetKind {
+        if let ref = ref, resolveRef(ref) != nil {
+            return .axPress
+        }
+        if pid != nil {
+            return .postToPid
+        }
+        if let appName = appName, resolvePidByName(appName) != nil {
+            return .postToPid
+        }
+        return .cghidEventTap
+    }
+
+    // Ref-aware PID resolution: when a ref is provided and registered,
+    // its owning PID is the right target for any keyboard fallback path
+    // that needs CGEvent.postToPid (e.g. text-field type when AX value
+    // set is rejected). Falls through to the explicit pid / app lookup
+    // chain otherwise.
+    func resolveTargetPid(ref: String?, appName: String?, pid: pid_t?) -> pid_t? {
+        if let ref = ref, let entry = resolveRef(ref), let owner = entry.pid {
+            return owner
+        }
+        if let pid = pid { return pid }
+        if let appName = appName, let resolved = resolvePidByName(appName) { return resolved }
+        return nil
+    }
+}
+
+// Production-default lookup wiring. Keeps construction sites short.
+extension InputTargetSelector {
+    static func live(refRegistry: RefRegistry = .shared) -> InputTargetSelector {
+        InputTargetSelector(
+            resolveRef: { ref in
+                guard let entry = refRegistry.resolveInfo(ref) else { return nil }
+                return (entry.element, entry.pid)
+            },
+            resolvePidByName: { name in
+                NSWorkspace.shared.runningApplications
+                    .first(where: { $0.localizedName?.lowercased() == name.lowercased() })?
+                    .processIdentifier
+            }
+        )
+    }
+}

--- a/interceptor-bridge/Sources/MicrophoneAuthorizationProvider.swift
+++ b/interceptor-bridge/Sources/MicrophoneAuthorizationProvider.swift
@@ -1,0 +1,69 @@
+import Foundation
+import AVFoundation
+
+// Wraps Apple's AVCaptureDevice authorization-status surface so TrustDomain
+// can be unit-tested without driving the live AVCaptureDevice singleton.
+//
+// Apple-doc anchors:
+//   AVAuthorizationStatus            — 4-state enum: notDetermined / restricted / denied / authorized
+//   authorizationStatus(for:)        — returns the current AVAuthorizationStatus
+//   requestAccess(for:completionHandler:) — non-blocking; "doesn't block the
+//                                            thread while the system is
+//                                            prompting the user for access"
+//
+// The provider is a thin protocol over those two calls. Production callers
+// use `.live`. Tests inject deterministic closures.
+protocol MicrophoneAuthorizationProvider: Sendable {
+    func currentStatus() -> AVAuthorizationStatus
+    func requestAccess(_ completion: @escaping @Sendable (Bool) -> Void)
+}
+
+// Production-default wiring. Calls Apple's APIs directly.
+struct LiveMicrophoneAuthorizationProvider: MicrophoneAuthorizationProvider {
+    func currentStatus() -> AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: .audio)
+    }
+
+    func requestAccess(_ completion: @escaping @Sendable (Bool) -> Void) {
+        // Apple's documented contract: "Calling this method doesn't block the
+        // thread while the system is prompting the user for access."
+        // We deliberately do not await the completion in TrustDomain; the
+        // caller re-polls `authorizationStatus(for:)` to observe the result.
+        AVCaptureDevice.requestAccess(for: .audio, completionHandler: completion)
+    }
+}
+
+// Maps Apple's AVAuthorizationStatus into the unified PermissionStatus
+// vocabulary used in the trust response. Mic is the only TCC surface
+// where Apple exposes all four cases, so this is the only mapping site.
+extension AVAuthorizationStatus {
+    var permissionStatus: PermissionStatus {
+        switch self {
+        case .authorized: return .granted
+        case .denied: return .denied
+        case .restricted: return .restricted
+        case .notDetermined: return .notDetermined
+        @unknown default: return .notDetermined
+        }
+    }
+}
+
+// Unified status vocabulary across all three TCC surfaces in the trust
+// response. Lifted from Apple's AVAuthorizationStatus enum so the JSON
+// schema is self-documenting against Apple's public API.
+//
+// AX and Screen Recording can only ever produce .granted or .denied —
+// Apple's AXIsProcessTrusted / CGPreflightScreenCaptureAccess return Bool
+// only, so notDetermined and restricted are unobservable for those
+// surfaces via public API. Trust response carries a `limitation` field on
+// AX/Screen entries to make that asymmetry self-documenting.
+enum PermissionStatus: String, Sendable {
+    case granted
+    case denied
+    case notDetermined = "not_determined"
+    case restricted
+
+    static func fromBool(_ granted: Bool) -> PermissionStatus {
+        granted ? .granted : .denied
+    }
+}

--- a/interceptor-bridge/Sources/RefRegistry.swift
+++ b/interceptor-bridge/Sources/RefRegistry.swift
@@ -4,8 +4,13 @@ import ApplicationServices
 final class RefRegistry: @unchecked Sendable {
     static let shared = RefRegistry()
 
+    struct Entry {
+        let element: AXUIElement
+        let pid: pid_t?
+    }
+
     private let lock = NSLock()
-    private var refs: [String: AXUIElement] = [:]
+    private var refs: [String: Entry] = [:]
     private var counter: Int = 0
 
     func clear() {
@@ -15,20 +20,34 @@ final class RefRegistry: @unchecked Sendable {
         lock.unlock()
     }
 
-    func register(_ element: AXUIElement) -> String {
+    func register(_ element: AXUIElement, pid: pid_t? = nil) -> String {
         lock.lock()
         counter += 1
         let ref = "e\(counter)"
-        refs[ref] = element
+        refs[ref] = Entry(element: element, pid: pid)
         lock.unlock()
         return ref
     }
 
     func resolve(_ ref: String) -> AXUIElement? {
         lock.lock()
-        let element = refs[ref]
+        let element = refs[ref]?.element
         lock.unlock()
         return element
+    }
+
+    func resolveInfo(_ ref: String) -> Entry? {
+        lock.lock()
+        let entry = refs[ref]
+        lock.unlock()
+        return entry
+    }
+
+    func resolvePID(_ ref: String) -> pid_t? {
+        lock.lock()
+        let pid = refs[ref]?.pid
+        lock.unlock()
+        return pid
     }
 
     func currentCount() -> Int {

--- a/interceptor-bridge/Sources/SparkleUserDriverDelegate.swift
+++ b/interceptor-bridge/Sources/SparkleUserDriverDelegate.swift
@@ -1,0 +1,96 @@
+import Foundation
+import AppKit
+import Sparkle
+
+// Sparkle "gentle reminders":
+//
+// The bridge ships LSUIElement = true (background-only) so it doesn't get a
+// Dock icon for normal operation. Sparkle's `SPUStandardUserDriver` detects
+// this via `SUApplicationInfo.isBackgroundApplication` (which checks
+// `application.activationPolicy == .accessory`) and, per its own docs,
+// shows update alerts "in the background, behind other running apps." The
+// user therefore never sees the prompt, even though Sparkle correctly
+// schedules + downloads the update. Sparkle itself logs an Error-level
+// warning every launch:
+//
+//   "Background app automatically schedules for update checks but does not
+//    implement gentle reminders. As a result, users may not take notice
+//    to update alerts that show up in the background."
+//
+// The fix is the same activation-policy pattern used for the
+// Microphone TCC dialog: temporarily upgrade NSApp to .regular while the
+// alert is being shown so it surfaces as a real modal window the user
+// can't miss, then revert to .accessory after the user has responded.
+// This is the canonical pattern used by Hammerspoon, Bartender, and other
+// LSUIElement utilities that integrate Sparkle.
+//
+// Implementation notes:
+//   - `supportsGentleScheduledUpdateReminders` must be `true` so Sparkle's
+//     own warning shuts up.
+//   - `standardUserDriverShouldHandleShowingScheduledUpdate` returns `true`
+//     so Sparkle still owns the alert UI — we just upgrade the activation
+//     policy around it.
+//   - `standardUserDriverWillHandleShowingUpdate` fires before the alert
+//     window is keyed; that's where we promote to `.regular`.
+//   - `standardUserDriverWillFinishUpdateSession` fires after the user
+//     dismisses, installs, or skips; that's where we revert to `.accessory`.
+final class SparkleUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
+
+    // Sparkle reads this property at delegate-installation time. Without
+    // it set to `true`, Sparkle logs the Error-level warning and falls
+    // back to default (background) alert behavior.
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    // Returning `true` keeps Sparkle in charge of showing the alert UI.
+    // We only intervene to make the alert window visible — we don't try
+    // to replace Sparkle's own UI with our own (that's Path B / a future
+    // PRD that uses UNUserNotificationCenter).
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        return true
+    }
+
+    // Called immediately before the alert window is shown. Upgrade the
+    // activation policy on the main thread so the alert parents to a
+    // regular foreground app (visible Dock icon, proper NSApp.activate).
+    // Same dispatch dance the mic prompt uses.
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        DispatchQueue.main.async {
+            NSApplication.shared.setActivationPolicy(.regular)
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
+    }
+
+    // Called when the update session ends — user dismissed, skipped,
+    // installed, or hit an error. Revert to `.accessory` so the bridge
+    // disappears from the Dock and goes back to background-first.
+    func standardUserDriverWillFinishUpdateSession() {
+        DispatchQueue.main.async {
+            NSApplication.shared.setActivationPolicy(.accessory)
+        }
+    }
+}
+
+// SPUUpdaterDelegate — separate from the user-driver delegate. Implements
+// `allowedChannelsForUpdater:` so Sparkle accepts items posted to our
+// "full" channel (every appcast item we publish carries
+// `<sparkle:channel>full</sparkle:channel>`). Without this opt-in, Sparkle
+// silently skips every channel-tagged item per its documented rule:
+//
+//   "If the @c <sparkle:channel> element is not present, the update item
+//    is posted to the default channel and can be found by any updater.
+//    Otherwise an item posted to a channel can only be found by an
+//    updater that is allowed to use that channel."
+//
+// Source: research/Sparkle/Sparkle/SPUUpdaterDelegate.h:90-111.
+final class SparkleUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        return ["full"]
+    }
+}

--- a/interceptor-bridge/Sources/main.swift
+++ b/interceptor-bridge/Sources/main.swift
@@ -133,15 +133,60 @@ signal(SIGTERM) { _ in
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory) // No dock icon, no menu bar
 
+// Install an NSApplicationDelegate so AppKit's default Apple-Event
+// handling routes Sparkle's `kAEQuitApplication` (sent at stage 2 of an
+// install) through `applicationShouldTerminate`. Without this, the install
+// flow hangs because the bridge never exits to let Sparkle replace the
+// bundle. See AppDelegate.swift for the full rationale.
+let bridgeAppDelegate = BridgeAppDelegate()
+app.delegate = bridgeAppDelegate
+
 // Sparkle auto-update. SUFeedURL + SUPublicEDKey + scheduled-check settings
 // live in the bundled Info.plist (see scripts/build-bridge.sh). Holding a
 // strong reference here for the lifetime of the process; Sparkle handles its
 // own polling, prompts, and the hand-off to the macOS installer for the .pkg.
+//
+// `sparkleUserDriverDelegate` adopts SPUStandardUserDriverDelegate to
+// surface update alerts in front of other apps. Without it, our LSUIElement
+// bridge silently shows alerts in the background and the user never sees
+// them (Sparkle itself logs an Error-level warning to confirm). See
+// SparkleUserDriverDelegate.swift for the full rationale and the gentle-
+// reminders contract. Held strongly here so it lives the lifetime of the
+// process — Sparkle weakly references its delegate.
+let sparkleUpdaterDelegate = SparkleUpdaterDelegate()
+let sparkleUserDriverDelegate = SparkleUserDriverDelegate()
 let updaterController = SPUStandardUpdaterController(
     startingUpdater: true,
-    updaterDelegate: nil,
-    userDriverDelegate: nil
+    updaterDelegate: sparkleUpdaterDelegate,
+    userDriverDelegate: sparkleUserDriverDelegate
 )
+
+// `interceptor macos update *` thin wrapper around SPUUpdater so the CLI
+// can drive a user-initiated update check directly. Useful both for agents
+// and for verifying the activation-policy dialog path (since automatic
+// checks for LSUIElement apps may silently download rather than surface).
+let updateDomain = UpdateDomain(updaterController: updaterController)
+router.register("update", handler: updateDomain)
 Platform.log("sparkle updater started; feed: \(updaterController.updater.feedURL?.absoluteString ?? "unset")")
 
-RunLoop.main.run()
+// Switched from `RunLoop.main.run()` to `app.run()`.
+// `RunLoop.main.run()` only spins the underlying CFRunLoop and does NOT
+// invoke NSApplication's Cocoa event loop. That was fine for the bridge
+// when no AppKit windows were ever shown (LSUIElement headless daemon
+// mode). The moment Sparkle's `SPUStandardUserDriver` puts up its modal
+// "A new version of Interceptor is available!" alert window, that window
+// needs the full NSApp event pump to receive mouse/keyboard events; under
+// `RunLoop.main.run()` the window appears but the main thread doesn't
+// process its UI events, so macOS marks the bridge "Not Responding" and
+// the user can't click any of the alert's buttons.
+//
+// `NSApp.run()` invokes `finishLaunching` and starts the standard Cocoa
+// event loop. It only returns when the app terminates. With our
+// `BridgeAppDelegate.applicationShouldTerminateAfterLastWindowClosed`
+// returning `false`, the bridge stays alive after the Sparkle alert is
+// dismissed; with `applicationShouldTerminate` running cleanup and
+// returning `.terminateNow`, Sparkle's stage-2 quit event lets the install
+// proceed cleanly. This also means our SIGINT/SIGTERM signal handlers
+// above continue to work — they call `Platform.cleanup()` + `exit(0)`
+// before NSApp.run() ever sees them.
+app.run()

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AccessibilityDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AccessibilityDomainTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import interceptor_bridge
+
+final class AccessibilityDomainTests: XCTestCase {
+    func testBuildSearchableTextIncludesRoleIdentifierAndVisibleStrings() {
+        let searchable = AccessibilityDomain.buildSearchableText(
+            title: "",
+            description: "",
+            value: "",
+            identifier: "First Text View",
+            roleDescription: "text entry area",
+            displayRole: "textarea"
+        )
+
+        XCTAssertTrue(searchable.contains("first text view"))
+        XCTAssertTrue(searchable.contains("text entry area"))
+        XCTAssertTrue(searchable.contains("textarea"))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AppsDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AppsDomainTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import interceptor_bridge
+
+final class AppsDomainTests: XCTestCase {
+    func testActivationReachedTargetRequiresMatchingFrontmostPID() {
+        XCTAssertTrue(AppsDomain.activationReachedTarget(targetPID: 123, appIsActive: true, frontmostPID: 123))
+        XCTAssertFalse(AppsDomain.activationReachedTarget(targetPID: 123, appIsActive: true, frontmostPID: 456))
+        XCTAssertFalse(AppsDomain.activationReachedTarget(targetPID: 123, appIsActive: false, frontmostPID: 123))
+        XCTAssertFalse(AppsDomain.activationReachedTarget(targetPID: 123, appIsActive: false, frontmostPID: nil))
+    }
+
+    func testPreferredCompoundAppIdentityPrefersExplicitTargetOverFrontmost() {
+        let requested: CompoundDomain.AppIdentity = ("TextEdit", 30873, "com.apple.TextEdit")
+        let frontmost: CompoundDomain.AppIdentity = ("Codex", 793, "com.openai.codex")
+        let chosen = CompoundDomain.preferredAppIdentity(requested: requested, frontmost: frontmost)
+        XCTAssertEqual(chosen.name, "TextEdit")
+        XCTAssertEqual(chosen.pid, 30873)
+        XCTAssertEqual(chosen.bundleId, "com.apple.TextEdit")
+    }
+
+    func testPreferredCompoundAppIdentityFallsBackToFrontmostWhenNoExplicitTargetExists() {
+        let frontmost: CompoundDomain.AppIdentity = ("Codex", 793, "com.openai.codex")
+        let chosen = CompoundDomain.preferredAppIdentity(requested: nil, frontmost: frontmost)
+        XCTAssertEqual(chosen.name, "Codex")
+        XCTAssertEqual(chosen.pid, 793)
+        XCTAssertEqual(chosen.bundleId, "com.openai.codex")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/CaptureFrameTimingTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/CaptureFrameTimingTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import interceptor_bridge
+
+// Regression: CaptureDomain.handleCapture("frame", ...) used to
+// check `latestFrame` synchronously and return "no active capture stream
+// — use screenshot instead" any time the first sample buffer hadn't yet
+// arrived. Apple's SCStream.startCapture(completionHandler:) doc says
+// the success callback fires when the stream "successfully starts" but
+// the first frame arrives async via SCStreamOutput. These tests pin the
+// new behavior: distinguish "no stream" vs "stream active no frame yet"
+// and respect a configurable timeout.
+
+// Lock-protected holder so completion-handler mutations are Sendable.
+private final class ResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
+    func set(_ v: [String: Any]) {
+        lock.lock(); stored = v; lock.unlock()
+    }
+}
+
+final class CaptureFrameTimingTests: XCTestCase {
+    private func dispatchFrame(_ domain: CaptureDomain, timeoutMs: Int? = nil) -> [String: Any] {
+        var action: [String: Any] = ["type": "macos_capture", "sub": "frame"]
+        if let timeoutMs = timeoutMs { action["timeoutMs"] = timeoutMs }
+        let holder = ResultHolder()
+        let exp = expectation(description: "frame dispatch")
+        domain.handle("capture", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        return holder.value
+    }
+
+    func testNoStreamReturnsCaptureNotStarted() {
+        let domain = CaptureDomain()
+        let r = dispatchFrame(domain)
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(
+            err.contains("capture not started"),
+            "Expected 'capture not started' error, got: \(err)"
+        )
+        // Specifically: must NOT incorrectly suggest using screenshot
+        // when the stream simply wasn't started — that's a different
+        // failure mode for an active-but-empty stream.
+        XCTAssertFalse(err.contains("use screenshot instead") && err.contains("active but no frame"))
+    }
+
+    func testBufferedFrameReturnsImmediately() {
+        let domain = CaptureDomain()
+        let payload = "test-immediate-frame".data(using: .utf8)!
+        domain._testInjectFrame(payload)
+
+        let r = dispatchFrame(domain, timeoutMs: 100)
+        XCTAssertEqual(r["success"] as? Bool, true)
+        let data = r["data"] as? [String: Any]
+        let dataUrl = (data?["dataUrl"] as? String) ?? ""
+        XCTAssertTrue(dataUrl.hasPrefix("data:image/jpeg;base64,"))
+        XCTAssertTrue(dataUrl.contains(payload.base64EncodedString()))
+        domain._testReset()
+    }
+
+    func testStreamActiveButNoFrameTimesOut() {
+        let domain = CaptureDomain()
+        domain.testForcedActive = true
+        defer { domain._testReset() }
+
+        let start = Date()
+        let r = dispatchFrame(domain, timeoutMs: 200)
+        let elapsed = Date().timeIntervalSince(start)
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(
+            err.contains("capture stream active but no frame in 200ms"),
+            "Expected timeout-error wording with 200ms, got: \(err)"
+        )
+        XCTAssertGreaterThanOrEqual(elapsed, 0.18, "Should actually wait close to 200ms; waited \(elapsed)s")
+        XCTAssertLessThan(elapsed, 1.5, "Should not wait far beyond timeout; waited \(elapsed)s")
+    }
+
+    func testStreamActiveAndFrameArrivesMidWaitReturnsSuccess() {
+        let domain = CaptureDomain()
+        domain.testForcedActive = true
+        defer { domain._testReset() }
+
+        let payload = "test-midwait-frame".data(using: .utf8)!
+        // Dispatch the frame request first — it will block waiting on the
+        // semaphore for up to 1500ms — then inject a frame ~150ms later
+        // to simulate ScreenCaptureKit delivering the first sample buffer
+        // after startCapture's success callback returned.
+        let holder = ResultHolder()
+        let exp = expectation(description: "midwait frame")
+        let action: [String: Any] = ["type": "macos_capture", "sub": "frame", "timeoutMs": 1500]
+        domain.handle("capture", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(150)) {
+            domain._testInjectFrame(payload)
+        }
+        wait(for: [exp], timeout: 3.0)
+
+        let result = holder.value
+        XCTAssertEqual(result["success"] as? Bool, true, "Expected success after frame injection. Got: \(result)")
+        let data = result["data"] as? [String: Any]
+        let dataUrl = (data?["dataUrl"] as? String) ?? ""
+        XCTAssertTrue(dataUrl.contains(payload.base64EncodedString()), "dataUrl should contain the injected payload")
+    }
+
+    func testTimeoutMsHonored() {
+        // 50ms timeout — verifies the timeoutMs override flows through.
+        let domain = CaptureDomain()
+        domain.testForcedActive = true
+        defer { domain._testReset() }
+
+        let r = dispatchFrame(domain, timeoutMs: 50)
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(err.contains("50ms"), "Expected timeout error to mention 50ms, got: \(err)")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/ClipboardDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/ClipboardDispatchTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import interceptor_bridge
+
+// Regression: ClipboardDomain.handle was switching on `command`
+// (which the router passes as the literal "clipboard" for two-segment
+// action types) instead of action["sub"], so every clipboard call fell
+// through to `notImplemented`. These tests pin the dispatch contract.
+//
+// We don't exercise NSPasteboard directly — the regression target is the
+// dispatch path that selects a sub-handler. We assert via "did NOT return
+// the not-implemented sentinel."
+
+private final class ClipboardResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class ClipboardDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = ClipboardDomain()
+        var action: [String: Any] = ["type": "macos_clipboard", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = ClipboardResultHolder()
+        let exp = expectation(description: "clipboard dispatch \(sub)")
+        domain.handle("clipboard", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+        return holder.value
+    }
+
+    private func errorMessage(_ result: [String: Any]) -> String? {
+        result["error"] as? String
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = errorMessage(result) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    func testReadIsRoutedFromSub() {
+        let r = dispatch(sub: "read")
+        XCTAssertFalse(isNotImplemented(r), "read sub must reach the read handler")
+    }
+
+    func testWriteIsRoutedFromSub() {
+        let r = dispatch(sub: "write", extra: ["text": "prd60-clip"])
+        XCTAssertFalse(isNotImplemented(r), "write sub must reach the write handler")
+    }
+
+    func testTailIsRoutedFromSub() {
+        let r = dispatch(sub: "tail")
+        XCTAssertFalse(isNotImplemented(r), "tail sub must reach the tail handler")
+        // Tail returns success with {"tailing": true} payload.
+        XCTAssertEqual(r["success"] as? Bool, true)
+    }
+
+    func testHistoryIsRoutedFromSub() {
+        let r = dispatch(sub: "history")
+        XCTAssertFalse(isNotImplemented(r), "history sub must reach the history handler")
+    }
+
+    func testClearIsRoutedFromSub() {
+        let r = dispatch(sub: "clear")
+        XCTAssertFalse(isNotImplemented(r), "clear sub must reach the clear handler")
+    }
+
+    func testTypesIsRoutedFromSub() {
+        let r = dispatch(sub: "types")
+        XCTAssertFalse(isNotImplemented(r), "types sub must reach the types handler")
+    }
+
+    func testUnknownSubReturnsNotImplementedWithSubString() {
+        let r = dispatch(sub: "nonexistent")
+        let err = errorMessage(r) ?? ""
+        XCTAssertTrue(err.contains("nonexistent"), "Error should reference the unknown sub, not the domain key")
+    }
+
+    func testFallsBackToCommandWhenSubMissing() {
+        // If a future caller (or the router on a hypothetical
+        // three-segment routing change) doesn't pass `sub`, the
+        // handler should still try `command` as the sub-verb.
+        let domain = ClipboardDomain()
+        let holder = ClipboardResultHolder()
+        let exp = expectation(description: "clipboard fallback")
+        domain.handle("read", action: ["type": "macos_clipboard"]) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertFalse(isNotImplemented(holder.value))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/CompoundOpenTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/CompoundOpenTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import interceptor_bridge
+
+// Stub handler that immediately returns an empty success payload for
+// any macos_tree or macos_windows the compound flow asks for.
+private final class StubHandler: DomainHandler, @unchecked Sendable {
+    func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let key = (action["type"] as? String) ?? command
+        if key.hasSuffix("windows") {
+            completion(WireFormat.success([] as [[String: Any]]))
+        } else {
+            completion(WireFormat.success(""))
+        }
+    }
+}
+
+private final class FakeLauncher: AppLauncher, @unchecked Sendable {
+    let alreadyRunning: Bool
+    private(set) var activateRunningCount: Int = 0
+    private(set) var launchCalls: [(name: String, activates: Bool)] = []
+
+    init(alreadyRunning: Bool) {
+        self.alreadyRunning = alreadyRunning
+    }
+
+    func isRunning(_ name: String) -> Bool { alreadyRunning }
+
+    func activateRunning(_ name: String) {
+        activateRunningCount += 1
+    }
+
+    func launch(_ name: String, activates: Bool, completion: @escaping () -> Void) {
+        launchCalls.append((name, activates))
+        completion()
+    }
+}
+
+final class CompoundOpenTests: XCTestCase {
+    private func makeRouter() -> Router {
+        let router = Router()
+        let stub = StubHandler()
+        router.register("tree", handler: stub)
+        router.register("windows", handler: stub)
+        return router
+    }
+
+    func testRunningAppDoesNotActivateWhenActivateFlagAbsent() {
+        let launcher = FakeLauncher(alreadyRunning: true)
+        let domain = CompoundDomain(router: makeRouter(), launcher: launcher)
+
+        let exp = expectation(description: "open returns")
+        domain.handle("open", action: ["app": "TextEdit"]) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(launcher.activateRunningCount, 0)
+        XCTAssertEqual(launcher.launchCalls.count, 0)
+    }
+
+    func testRunningAppActivatesOnlyWhenActivateFlagTrue() {
+        let launcher = FakeLauncher(alreadyRunning: true)
+        let domain = CompoundDomain(router: makeRouter(), launcher: launcher)
+
+        let exp = expectation(description: "open returns")
+        domain.handle("open", action: ["app": "TextEdit", "activate": true]) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(launcher.activateRunningCount, 1)
+        XCTAssertEqual(launcher.launchCalls.count, 0)
+    }
+
+    func testNotRunningAppLaunchesWithActivatesFalseByDefault() {
+        let launcher = FakeLauncher(alreadyRunning: false)
+        let domain = CompoundDomain(router: makeRouter(), launcher: launcher)
+
+        let exp = expectation(description: "open returns")
+        domain.handle("open", action: ["app": "TextEdit"]) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(launcher.launchCalls.count, 1)
+        XCTAssertEqual(launcher.launchCalls.first?.name, "TextEdit")
+        XCTAssertEqual(launcher.launchCalls.first?.activates, false)
+        XCTAssertEqual(launcher.activateRunningCount, 0)
+    }
+
+    func testNotRunningAppLaunchesWithActivatesTrueWhenFlagSet() {
+        let launcher = FakeLauncher(alreadyRunning: false)
+        let domain = CompoundDomain(router: makeRouter(), launcher: launcher)
+
+        let exp = expectation(description: "open returns")
+        domain.handle("open", action: ["app": "TextEdit", "activate": true]) { _ in exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(launcher.launchCalls.count, 1)
+        XCTAssertEqual(launcher.launchCalls.first?.activates, true)
+    }
+
+    // Background-first followup: the original `localizedName == name` exact-match
+    // was the leak that caused isRunning to miss already-running apps,
+    // pushing control into the launch fallback which then foregrounded
+    // the app via NSWorkspace.openApplication's Apple-Event reopen path.
+    // The strengthened predicate must match across casing, .app suffix,
+    // bundle base name, and bundle identifier.
+    func testMatchesIsCaseInsensitive() {
+        XCTAssertTrue(DefaultAppLauncher.matches(
+            localizedName: "TextEdit", bundleBaseName: "TextEdit", bundleId: "com.apple.TextEdit",
+            name: "textedit"
+        ))
+        XCTAssertTrue(DefaultAppLauncher.matches(
+            localizedName: "TextEdit", bundleBaseName: "TextEdit", bundleId: "com.apple.TextEdit",
+            name: "TEXTEDIT"
+        ))
+    }
+
+    func testMatchesAcceptsDotAppSuffix() {
+        XCTAssertTrue(DefaultAppLauncher.matches(
+            localizedName: "TextEdit", bundleBaseName: "TextEdit", bundleId: "com.apple.TextEdit",
+            name: "TextEdit.app"
+        ))
+    }
+
+    func testMatchesFallsBackToBundleBaseNameWhenLocalizedDiffers() {
+        // Some Electron apps ship localized names that don't equal the
+        // .app basename — e.g. an app where localizedName is "Visual
+        // Studio Code" but bundleURL ends in "Code.app". User asking
+        // for "Code" should match.
+        XCTAssertTrue(DefaultAppLauncher.matches(
+            localizedName: "Visual Studio Code", bundleBaseName: "Code", bundleId: "com.microsoft.VSCode",
+            name: "Code"
+        ))
+    }
+
+    func testMatchesAcceptsBundleIdentifier() {
+        XCTAssertTrue(DefaultAppLauncher.matches(
+            localizedName: "TextEdit", bundleBaseName: "TextEdit", bundleId: "com.apple.TextEdit",
+            name: "com.apple.textedit"
+        ))
+    }
+
+    func testMatchesRejectsUnrelatedNames() {
+        XCTAssertFalse(DefaultAppLauncher.matches(
+            localizedName: "TextEdit", bundleBaseName: "TextEdit", bundleId: "com.apple.TextEdit",
+            name: "Finder"
+        ))
+    }
+
+    func testMatchesHandlesMissingFieldsGracefully() {
+        XCTAssertFalse(DefaultAppLauncher.matches(
+            localizedName: nil, bundleBaseName: nil, bundleId: nil,
+            name: "TextEdit"
+        ))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/FilesDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/FilesDispatchTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import interceptor_bridge
+
+// Regression: FilesDomain.handle was switching on `command` so
+// `files recent`, `files watch`, `files open` all fell through to
+// `notImplemented`. These tests pin the dispatch contract.
+
+private final class FilesResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class FilesDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = FilesDomain()
+        var action: [String: Any] = ["type": "macos_files", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = FilesResultHolder()
+        let exp = expectation(description: "files dispatch \(sub)")
+        domain.handle("files", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        return holder.value
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = (result["error"] as? String) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    func testRecentIsRoutedFromSub() {
+        let r = dispatch(sub: "recent")
+        XCTAssertFalse(isNotImplemented(r), "recent sub must reach the recent handler")
+    }
+
+    func testWatchIsRoutedFromSubAndFailsOnMissingPath() {
+        // No `path` key — handler should reject with "watch requires a
+        // path", proving the router reached the watch handler.
+        let r = dispatch(sub: "watch")
+        XCTAssertFalse(isNotImplemented(r))
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(err.contains("watch requires a path"), "got: \(err)")
+    }
+
+    func testOpenIsRoutedFromSub() {
+        let r = dispatch(sub: "open")
+        XCTAssertFalse(isNotImplemented(r), "open sub must reach the open handler")
+    }
+
+    func testUnknownSubReturnsNotImplementedWithSubString() {
+        let r = dispatch(sub: "garbage")
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(err.contains("garbage"), "Error should reference the unknown sub")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/InputTargetSelectionTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/InputTargetSelectionTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+final class InputTargetSelectionTests: XCTestCase {
+    // System-wide AX root makes a stable AXUIElement that can be
+    // returned from the resolveRef hook without any UI side effects.
+    // We never call into AX from the selector itself; this is just a
+    // valid CFTypeRef that the helper carries through.
+    private var anyElement: AXUIElement {
+        AXUIElementCreateSystemWide()
+    }
+
+    func testRefWithRegisteredEntryPrefersAxPress() {
+        let selector = InputTargetSelector(
+            resolveRef: { ref in
+                ref == "e1" ? (self.anyElement, pid_t(1234)) : nil
+            },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: "e1", appName: nil, pid: nil)
+        XCTAssertEqual(kind, .axPress)
+    }
+
+    func testRefThatDoesNotResolveFallsThroughToPostToPidWhenPidProvided() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: "e99", appName: nil, pid: pid_t(7777))
+        XCTAssertEqual(kind, .postToPid)
+    }
+
+    func testExplicitPidRoutesToPostToPid() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: nil, appName: nil, pid: pid_t(4321))
+        XCTAssertEqual(kind, .postToPid)
+    }
+
+    func testAppNameRoutesToPostToPidWhenNameResolves() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { name in
+                name == "TextEdit" ? pid_t(8888) : nil
+            }
+        )
+
+        let kind = selector.selectKind(ref: nil, appName: "TextEdit", pid: nil)
+        XCTAssertEqual(kind, .postToPid)
+    }
+
+    func testAppNameThatDoesNotResolveFallsToCghidEventTap() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: nil, appName: "NoSuchApp", pid: nil)
+        XCTAssertEqual(kind, .cghidEventTap)
+    }
+
+    func testNoTargetingFallsToCghidEventTap() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: nil, appName: nil, pid: nil)
+        XCTAssertEqual(kind, .cghidEventTap)
+    }
+
+    func testRefBeatsExplicitPid() {
+        let selector = InputTargetSelector(
+            resolveRef: { ref in
+                ref == "e2" ? (self.anyElement, pid_t(1111)) : nil
+            },
+            resolvePidByName: { _ in nil }
+        )
+
+        let kind = selector.selectKind(ref: "e2", appName: nil, pid: pid_t(2222))
+        XCTAssertEqual(kind, .axPress)
+    }
+
+    func testResolveTargetPidPrefersRefOwnerOverExplicitPid() {
+        let selector = InputTargetSelector(
+            resolveRef: { ref in
+                ref == "e3" ? (self.anyElement, pid_t(5555)) : nil
+            },
+            resolvePidByName: { _ in nil }
+        )
+
+        let pid = selector.resolveTargetPid(ref: "e3", appName: nil, pid: pid_t(6666))
+        XCTAssertEqual(pid, pid_t(5555))
+    }
+
+    func testResolveTargetPidFallsThroughToExplicitPidThenAppLookup() {
+        let selector = InputTargetSelector(
+            resolveRef: { _ in nil },
+            resolvePidByName: { name in
+                name == "Finder" ? pid_t(9999) : nil
+            }
+        )
+
+        XCTAssertEqual(selector.resolveTargetPid(ref: nil, appName: nil, pid: pid_t(7777)), pid_t(7777))
+        XCTAssertEqual(selector.resolveTargetPid(ref: nil, appName: "Finder", pid: nil), pid_t(9999))
+        XCTAssertNil(selector.resolveTargetPid(ref: nil, appName: "Other", pid: nil))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/NotificationsDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/NotificationsDispatchTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import interceptor_bridge
+
+// Regression: NotificationsDomain.handle was switching on
+// `command` so `notifications tail` and `notifications log` all fell
+// through to `notImplemented`. These tests pin the dispatch contract.
+
+private final class NotificationsResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class NotificationsDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = NotificationsDomain()
+        var action: [String: Any] = ["type": "macos_notifications", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = NotificationsResultHolder()
+        let exp = expectation(description: "notifications dispatch \(sub)")
+        domain.handle("notifications", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+        return holder.value
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = (result["error"] as? String) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    func testTailIsRoutedFromSub() {
+        let r = dispatch(sub: "tail")
+        XCTAssertFalse(isNotImplemented(r), "tail sub must reach the tail handler")
+        XCTAssertEqual(r["success"] as? Bool, true)
+    }
+
+    func testLogIsRoutedFromSub() {
+        let r = dispatch(sub: "log", extra: ["limit": 5])
+        XCTAssertFalse(isNotImplemented(r), "log sub must reach the log handler")
+    }
+
+    func testUnknownSubReturnsNotImplementedWithSubString() {
+        let r = dispatch(sub: "unknownop")
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(err.contains("unknownop"), "Error should reference the unknown sub")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/RefRegistryTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/RefRegistryTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import ApplicationServices
+@testable import interceptor_bridge
+
+final class RefRegistryTests: XCTestCase {
+    func testRegistryStoresPIDMetadataAlongsideElementRefs() {
+        let registry = RefRegistry()
+        let element = AXUIElementCreateSystemWide()
+        let ref = registry.register(element, pid: 4242)
+
+        XCTAssertNotNil(registry.resolve(ref))
+        XCTAssertEqual(registry.resolvePID(ref), 4242)
+        XCTAssertEqual(registry.resolveInfo(ref)?.pid, 4242)
+    }
+
+    func testClearRemovesElementsAndResetsCounter() {
+        let registry = RefRegistry()
+        _ = registry.register(AXUIElementCreateSystemWide(), pid: 1)
+        registry.clear()
+
+        XCTAssertEqual(registry.count, 0)
+        XCTAssertEqual(registry.currentCount(), 0)
+
+        let next = registry.register(AXUIElementCreateSystemWide(), pid: 2)
+        XCTAssertEqual(next, "e1")
+        XCTAssertEqual(registry.resolvePID(next), 2)
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/TrustDomainStatusTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/TrustDomainStatusTests.swift
@@ -1,0 +1,275 @@
+import XCTest
+import AVFoundation
+@testable import interceptor_bridge
+
+// Coverage: status vocabulary, non-blocking microphone path,
+// limitation field on AX/Screen, pending_user_action signal, --no-prompt
+// defense-in-depth, and the deprecated `granted` compat shim.
+final class TrustDomainStatusTests: XCTestCase {
+
+    // MARK: - PermissionStatus rawValue mapping
+
+    func testPermissionStatusRawValues() {
+        XCTAssertEqual(PermissionStatus.granted.rawValue, "granted")
+        XCTAssertEqual(PermissionStatus.denied.rawValue, "denied")
+        XCTAssertEqual(PermissionStatus.notDetermined.rawValue, "not_determined")
+        XCTAssertEqual(PermissionStatus.restricted.rawValue, "restricted")
+    }
+
+    func testPermissionStatusFromBool() {
+        XCTAssertEqual(PermissionStatus.fromBool(true), .granted)
+        XCTAssertEqual(PermissionStatus.fromBool(false), .denied)
+    }
+
+    // MARK: - AVAuthorizationStatus → PermissionStatus mapping
+
+    func testAuthorizedMapsToGranted() {
+        XCTAssertEqual(AVAuthorizationStatus.authorized.permissionStatus, .granted)
+    }
+
+    func testDeniedMapsToDenied() {
+        XCTAssertEqual(AVAuthorizationStatus.denied.permissionStatus, .denied)
+    }
+
+    func testRestrictedMapsToRestricted() {
+        XCTAssertEqual(AVAuthorizationStatus.restricted.permissionStatus, .restricted)
+    }
+
+    func testNotDeterminedMapsToNotDetermined() {
+        XCTAssertEqual(AVAuthorizationStatus.notDetermined.permissionStatus, .notDetermined)
+    }
+
+    // MARK: - Permission struct serialization
+
+    func testPermissionDictionaryIncludesStatusAndDeprecatedGranted() {
+        let perm = Permission(
+            name: "Microphone",
+            status: .granted,
+            required: false,
+            path: "Settings",
+            reason: "test",
+            limitation: nil
+        )
+        let dict = perm.toDictionary()
+        XCTAssertEqual(dict["status"] as? String, "granted")
+        XCTAssertEqual(dict["granted"] as? Bool, true)
+        XCTAssertEqual(dict["name"] as? String, "Microphone")
+        XCTAssertNil(dict["limitation"])
+    }
+
+    func testPermissionDictionaryGrantedComputedFromStatus() {
+        for status: PermissionStatus in [.denied, .notDetermined, .restricted] {
+            let perm = Permission(
+                name: "X",
+                status: status,
+                required: false,
+                path: "p",
+                reason: "r",
+                limitation: nil
+            )
+            let dict = perm.toDictionary()
+            XCTAssertEqual(dict["status"] as? String, status.rawValue)
+            XCTAssertEqual(
+                dict["granted"] as? Bool, false,
+                "granted shim should be false for non-granted status \(status.rawValue)"
+            )
+        }
+    }
+
+    func testPermissionDictionaryEmitsLimitationWhenSet() {
+        let perm = Permission(
+            name: "Accessibility",
+            status: .denied,
+            required: true,
+            path: "Settings",
+            reason: "test",
+            limitation: "Apple's AXIsProcessTrusted returns Bool only"
+        )
+        let dict = perm.toDictionary()
+        XCTAssertEqual(dict["limitation"] as? String, "Apple's AXIsProcessTrusted returns Bool only")
+    }
+
+    // MARK: - Microphone provider stub
+
+    final class StubMicrophoneProvider: MicrophoneAuthorizationProvider, @unchecked Sendable {
+        var status: AVAuthorizationStatus
+        var requestCalls: Int = 0
+        // If non-nil, requestAccess invokes the completion synchronously
+        // with this value (simulating an Apple impl that returns
+        // immediately). Real Apple behavior is async so the default is nil
+        // and the completion is dropped — matching production.
+        var synchronousResult: Bool? = nil
+
+        init(initialStatus: AVAuthorizationStatus) {
+            self.status = initialStatus
+        }
+
+        func currentStatus() -> AVAuthorizationStatus { status }
+
+        func requestAccess(_ completion: @escaping @Sendable (Bool) -> Void) {
+            requestCalls += 1
+            if let synchronousResult = synchronousResult {
+                completion(synchronousResult)
+            }
+        }
+    }
+
+    // MARK: - TrustDomain non-blocking + pending_user_action behavior
+    //
+    // These exercise the helper functions on TrustDomain through the same
+    // `handle("trust", ...)` entry point production uses, so we cover the
+    // full preflight result-shape, not just the helper path.
+
+    // Thread-safe holder so the `@Sendable` completion closure can publish
+    // the result back to the test body without violating Swift 6 sendable
+    // capture rules.
+    final class ResultBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: [String: Any] = [:]
+
+        func set(_ v: [String: Any]) {
+            lock.lock(); defer { lock.unlock() }
+            value = v
+        }
+
+        func get() -> [String: Any] {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+    }
+
+    private func runTrust(action: [String: Any], provider: MicrophoneAuthorizationProvider) -> [String: Any] {
+        let domain = TrustDomain(microphoneProvider: provider)
+        let box = ResultBox()
+        let exp = expectation(description: "trust completion")
+        domain.handle("trust", action: action) { result in
+            box.set(result)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        return box.get()
+    }
+
+    private func data(from result: [String: Any]) -> [String: Any] {
+        XCTAssertEqual(result["success"] as? Bool, true)
+        return result["data"] as? [String: Any] ?? [:]
+    }
+
+    private func permissions(from result: [String: Any]) -> [[String: Any]] {
+        let payload = data(from: result)
+        return payload["permissions"] as? [[String: Any]] ?? []
+    }
+
+    func testReadOnlyTrustReturnsCurrentMicStatusWithoutPrompting() {
+        let provider = StubMicrophoneProvider(initialStatus: .notDetermined)
+        let result = runTrust(action: [:], provider: provider)
+        let payload = data(from: result)
+
+        XCTAssertEqual(payload["microphone"] as? String, "not_determined")
+        XCTAssertEqual(provider.requestCalls, 0)
+        XCTAssertNil(payload["pending_user_action"])
+    }
+
+    func testMicrophonePromptIsNonBlockingAndTriggersRequestAccess() {
+        let provider = StubMicrophoneProvider(initialStatus: .notDetermined)
+        let start = DispatchTime.now()
+        let result = runTrust(action: ["microphonePrompt": true], provider: provider)
+        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000.0
+
+        XCTAssertEqual(provider.requestCalls, 1, "requestAccess must be called exactly once")
+        XCTAssertLessThan(elapsed, 200.0, "non-blocking path should return well under 200ms (got \(elapsed)ms)")
+
+        let payload = data(from: result)
+        XCTAssertEqual(payload["microphone"] as? String, "not_determined")
+        XCTAssertEqual(payload["pending_user_action"] as? [String], ["Microphone"])
+    }
+
+    func testAlreadyGrantedMicShortCircuitsRequestAccess() {
+        let provider = StubMicrophoneProvider(initialStatus: .authorized)
+        let result = runTrust(action: ["microphonePrompt": true], provider: provider)
+
+        XCTAssertEqual(provider.requestCalls, 0, "must not re-prompt when already authorized")
+        let payload = data(from: result)
+        XCTAssertEqual(payload["microphone"] as? String, "granted")
+        XCTAssertNil(payload["pending_user_action"])
+    }
+
+    func testAlreadyDeniedMicShortCircuitsRequestAccess() {
+        let provider = StubMicrophoneProvider(initialStatus: .denied)
+        let result = runTrust(action: ["microphonePrompt": true], provider: provider)
+
+        XCTAssertEqual(provider.requestCalls, 0, "must not re-prompt when already denied")
+        let payload = data(from: result)
+        XCTAssertEqual(payload["microphone"] as? String, "denied")
+        XCTAssertNil(payload["pending_user_action"])
+    }
+
+    func testRestrictedMicShortCircuitsRequestAccess() {
+        let provider = StubMicrophoneProvider(initialStatus: .restricted)
+        let result = runTrust(action: ["microphonePrompt": true], provider: provider)
+
+        XCTAssertEqual(provider.requestCalls, 0)
+        let payload = data(from: result)
+        XCTAssertEqual(payload["microphone"] as? String, "restricted")
+    }
+
+    // MARK: - --no-prompt defense-in-depth
+
+    func testNoPromptOverridesEveryPromptFlag() {
+        let provider = StubMicrophoneProvider(initialStatus: .notDetermined)
+        let result = runTrust(action: [
+            "noPrompt": true,
+            "prompt": true,
+            "walkthrough": true,
+            "accessibilityPrompt": true,
+            "screenPrompt": true,
+            "microphonePrompt": true
+        ], provider: provider)
+
+        XCTAssertEqual(provider.requestCalls, 0, "noPrompt must suppress every requestAccess call")
+        let payload = data(from: result)
+        XCTAssertNil(payload["prompted"], "noPrompt must suppress the prompted[] field")
+        XCTAssertNil(payload["opened"], "noPrompt must suppress walkthrough pane opening")
+    }
+
+    // MARK: - Permissions array shape
+
+    func testPermissionsArrayCarriesAllThreeWithStatus() {
+        let provider = StubMicrophoneProvider(initialStatus: .authorized)
+        let result = runTrust(action: [:], provider: provider)
+        let perms = permissions(from: result)
+
+        XCTAssertEqual(perms.count, 3)
+        let names = perms.compactMap { $0["name"] as? String }
+        XCTAssertEqual(Set(names), Set(["Accessibility", "Microphone", "Screen Recording"]))
+
+        for perm in perms {
+            XCTAssertNotNil(perm["status"] as? String, "every entry must have a string status")
+            XCTAssertNotNil(perm["granted"] as? Bool, "deprecated granted shim must remain Bool for one release")
+        }
+    }
+
+    func testAccessibilityAndScreenCarryLimitationButMicDoesNot() {
+        let provider = StubMicrophoneProvider(initialStatus: .authorized)
+        let result = runTrust(action: [:], provider: provider)
+        let perms = permissions(from: result)
+
+        let ax = perms.first(where: { $0["name"] as? String == "Accessibility" })
+        let screen = perms.first(where: { $0["name"] as? String == "Screen Recording" })
+        let mic = perms.first(where: { $0["name"] as? String == "Microphone" })
+
+        XCTAssertNotNil(ax?["limitation"] as? String)
+        XCTAssertNotNil(screen?["limitation"] as? String)
+        XCTAssertNil(mic?["limitation"], "Microphone status is fully expressive — no limitation field")
+    }
+
+    func testTopLevelStatusFieldsAreStrings() {
+        let provider = StubMicrophoneProvider(initialStatus: .denied)
+        let result = runTrust(action: [:], provider: provider)
+        let payload = data(from: result)
+
+        XCTAssertNotNil(payload["accessibility"] as? String)
+        XCTAssertNotNil(payload["screenRecording"] as? String)
+        XCTAssertEqual(payload["microphone"] as? String, "denied")
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.10.8",
+  "version": "0.10.32",
   "type": "module",
   "bin": {
     "interceptor": "./dist/interceptor"

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -13,5 +13,15 @@
          per (interceptor-bridge, target_app) pair via TCC. -->
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <!-- Microphone capture entitlement. Per Apple's "Requesting Authorization
+         for Media Capture on macOS": NSMicrophoneUsageDescription in Info.plist
+         AND com.apple.security.device.audio-input as an entitlement are BOTH
+         required under hardened runtime; without the entitlement the system
+         silently terminates the requestAccess call rather than showing the
+         permission alert. Source:
+         /BundleResources/requesting-authorization-for-media-capture-on-macos.md
+         /AVFoundation/requesting-authorization-to-capture-and-save-media.md -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/test/bridge-recovery.test.ts
+++ b/test/bridge-recovery.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import {
+  formatBridgeUnavailableError,
+  getBridgeRecoveryActions,
+  getBridgeRecoveryLayout,
+} from "../daemon/bridge-recovery"
+
+const home = "/Users/tester"
+const uid = 501
+const daemonImportMetaUrl = new URL("../daemon/index.ts", import.meta.url).href
+const repoBundlePath = new URL("../dist/interceptor-bridge.app", daemonImportMetaUrl).pathname
+const repoDistBinaryPath = new URL("../dist/interceptor-bridge", daemonImportMetaUrl).pathname
+
+function existsFor(paths: string[]) {
+  const set = new Set(paths)
+  return (path: string) => set.has(path)
+}
+
+describe("bridge recovery layout", () => {
+  test("browser-only mode produces upgrade guidance and no recovery actions", () => {
+    const layout = getBridgeRecoveryLayout({
+      exists: existsFor([]),
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    expect(layout.mode).toBe("browser-only")
+    expect(layout.launchAgentInstalled).toBe(false)
+    expect(layout.availableBundlePath).toBeNull()
+    expect(getBridgeRecoveryActions(layout, existsFor([]))).toEqual([])
+    expect(formatBridgeUnavailableError(layout)).toContain("interceptor upgrade --full")
+  })
+
+  test("user-local full install prefers kickstart before opening the user bundle", () => {
+    const userLaunchAgent = `${home}/Library/LaunchAgents/com.interceptor.bridge.plist`
+    const userBundle = `${home}/.local/share/interceptor/interceptor-bridge.app`
+    const exists = existsFor([userLaunchAgent, userBundle])
+    const layout = getBridgeRecoveryLayout({
+      exists,
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    expect(layout.mode).toBe("full-install")
+    expect(layout.launchAgentDomain).toBe("gui/501/com.interceptor.bridge")
+    expect(layout.availableBundlePath).toBe(userBundle)
+
+    const actions = getBridgeRecoveryActions(layout, exists)
+    expect(actions.map((action) => action.kind)).toEqual([
+      "kickstart_launchagent",
+      "open_user_bundle",
+    ])
+  })
+
+  test("pkg full install prefers kickstart then the /Applications bundle", () => {
+    const systemLaunchAgent = "/Library/LaunchAgents/com.interceptor.bridge.plist"
+    const applicationsBundle = "/Applications/interceptor-bridge.app"
+    const exists = existsFor([systemLaunchAgent, applicationsBundle])
+    const layout = getBridgeRecoveryLayout({
+      exists,
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    expect(layout.mode).toBe("full-install")
+    expect(layout.availableBundlePath).toBe(applicationsBundle)
+
+    const actions = getBridgeRecoveryActions(layout, exists)
+    expect(actions.map((action) => action.kind)).toEqual([
+      "kickstart_launchagent",
+      "open_applications_bundle",
+    ])
+    expect(formatBridgeUnavailableError(layout)).not.toContain("build-bridge.sh")
+    expect(formatBridgeUnavailableError(layout)).toContain("interceptor status")
+  })
+
+  test("repo fallback uses the repo bundle before the bare binary", () => {
+    const exists = existsFor([repoBundlePath, repoDistBinaryPath])
+    const layout = getBridgeRecoveryLayout({
+      exists,
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    expect(layout.mode).toBe("dev-checkout")
+    expect(layout.availableBundlePath).toBe(repoBundlePath)
+    expect(layout.availableBareBinaryPath).toBe(repoDistBinaryPath)
+
+    const actions = getBridgeRecoveryActions(layout, exists)
+    expect(actions.map((action) => action.kind)).toEqual([
+      "open_repo_bundle",
+      "spawn_bare_binary",
+    ])
+    expect(formatBridgeUnavailableError(layout)).toContain("build-bridge.sh")
+  })
+})

--- a/test/macos-parser.test.ts
+++ b/test/macos-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test"
+import { parseMacosCommand } from "../cli/commands/macos"
+
+describe("macos parser", () => {
+  test("menu --app keeps the app name out of the menu path", () => {
+    const action = parseMacosCommand(["macos", "menu", "--app", "TextEdit"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_menu")
+    expect(action.app).toBe("TextEdit")
+    expect(action.items).toBeUndefined()
+  })
+
+  test("menu positional items still parse as a menu path", () => {
+    const action = parseMacosCommand(["macos", "menu", "Window", "Bring All to Front"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_menu")
+    expect(action.items).toEqual(["Window", "Bring All to Front"])
+  })
+
+  test("inspect with a ref uses the raw inspect action", () => {
+    const action = parseMacosCommand(["macos", "inspect", "e5"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_inspect")
+    expect(action.ref).toBe("e5")
+  })
+
+  test("bare inspect uses the compound inspect action", () => {
+    const action = parseMacosCommand(["macos", "inspect"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_compound")
+    expect(action.sub).toBe("inspect")
+  })
+
+  test("inspect with --app keeps the compound inspect action", () => {
+    const action = parseMacosCommand(["macos", "inspect", "--app", "TextEdit"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_compound")
+    expect(action.sub).toBe("inspect")
+    expect(action.app).toBe("TextEdit")
+  })
+
+  test("open is background-first by default — no --activate means activate=false", () => {
+    const action = parseMacosCommand(["macos", "open", "TextEdit"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_compound")
+    expect(action.sub).toBe("open")
+    expect(action.app).toBe("TextEdit")
+    expect(action.activate).toBe(false)
+  })
+
+  test("open --activate sets activate=true so the bridge will foreground", () => {
+    const action = parseMacosCommand(["macos", "open", "TextEdit", "--activate"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_compound")
+    expect(action.sub).toBe("open")
+    expect(action.activate).toBe(true)
+  })
+
+  test("click --app routes the synthesized event to a specific PID via the bridge", () => {
+    const action = parseMacosCommand(["macos", "click", "100,200", "--app", "TextEdit"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_click")
+    expect(action.coords).toBe("100,200")
+    expect(action.app).toBe("TextEdit")
+  })
+
+  test("type --app carries the app target through to the bridge", () => {
+    const action = parseMacosCommand(["macos", "type", "hello", "--app", "TextEdit"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_type")
+    expect(action.text).toBe("hello")
+    expect(action.app).toBe("TextEdit")
+  })
+
+  test("keys --pid carries an explicit PID target through to the bridge", () => {
+    const action = parseMacosCommand(["macos", "keys", "Meta+A", "--pid", "1234"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_keys")
+    expect(action.keys).toBe("Meta+A")
+    expect(action.pid).toBe(1234)
+  })
+
+  test("drag --app carries app target through to the bridge", () => {
+    const action = parseMacosCommand(["macos", "drag", "100,100", "200,200", "--app", "Finder"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_drag")
+    expect(action.app).toBe("Finder")
+  })
+
+  test("capture frame defaults to no explicit timeout", () => {
+    const action = parseMacosCommand(["macos", "capture", "frame"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_capture")
+    expect(action.sub).toBe("frame")
+    expect(action.timeoutMs).toBeUndefined()
+  })
+
+  test("capture frame --timeout-ms threads through to the bridge", () => {
+    const action = parseMacosCommand(["macos", "capture", "frame", "--timeout-ms", "3000"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_capture")
+    expect(action.sub).toBe("frame")
+    expect(action.timeoutMs).toBe(3000)
+  })
+
+  test("trust with no flags is read-only — no prompt fields are true", () => {
+    const action = parseMacosCommand(["macos", "trust"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_trust")
+    expect(action.noPrompt).toBe(false)
+    expect(action.prompt).toBe(false)
+    expect(action.walkthrough).toBe(false)
+    expect(action.accessibilityPrompt).toBe(false)
+    expect(action.screenPrompt).toBe(false)
+    expect(action.microphonePrompt).toBe(false)
+  })
+
+  test("trust --prompt fans out to all three prompt families", () => {
+    const action = parseMacosCommand(["macos", "trust", "--prompt"]) as Record<string, unknown>
+    expect(action.prompt).toBe(true)
+    expect(action.walkthrough).toBe(false)
+    expect(action.noPrompt).toBe(false)
+  })
+
+  test("trust --walkthrough implies prompt", () => {
+    const action = parseMacosCommand(["macos", "trust", "--walkthrough"]) as Record<string, unknown>
+    expect(action.prompt).toBe(true)
+    expect(action.walkthrough).toBe(true)
+  })
+
+  test("trust --microphone-prompt only sets the microphone prompt flag", () => {
+    const action = parseMacosCommand(["macos", "trust", "--microphone-prompt"]) as Record<string, unknown>
+    expect(action.microphonePrompt).toBe(true)
+    expect(action.accessibilityPrompt).toBe(false)
+    expect(action.screenPrompt).toBe(false)
+    expect(action.prompt).toBe(false)
+  })
+
+  test("trust --no-prompt forces every prompt flag to false even when others are present", () => {
+    const action = parseMacosCommand([
+      "macos", "trust",
+      "--no-prompt",
+      "--prompt",
+      "--walkthrough",
+      "--accessibility-prompt",
+      "--screen-prompt",
+      "--microphone-prompt",
+    ]) as Record<string, unknown>
+    expect(action.type).toBe("macos_trust")
+    expect(action.noPrompt).toBe(true)
+    expect(action.prompt).toBe(false)
+    expect(action.walkthrough).toBe(false)
+    expect(action.accessibilityPrompt).toBe(false)
+    expect(action.screenPrompt).toBe(false)
+    expect(action.microphonePrompt).toBe(false)
+  })
+
+  test("trust --no-prompt alone yields a clean read-only payload", () => {
+    const action = parseMacosCommand(["macos", "trust", "--no-prompt"]) as Record<string, unknown>
+    expect(action.noPrompt).toBe(true)
+    expect(action.prompt).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Ships ten releases of macOS bridge work in one PR — `0.10.8 → 0.10.32`. Four themes, all backed by Apple-doc-cited fixes and live verification on a signed/notarized/stapled pkg installed end-to-end.

## Background-first contract — operations no longer steal focus

`InputDomain` now picks one of three documented Apple delivery layers based on target specificity:

| Target | Mechanism | Focus impact |
|---|---|---|
| ref resolves to AXUIElement | `AXUIElementPerformAction(kAXPressAction)` | none |
| `--app` / `--pid` provided | `CGEvent.postToPid` | none |
| no target | `cghidEventTap` (legacy) | follows frontmost |

`CompoundDomain.handleOpen` replaces `app.activate()` and the deprecated `NSWorkspace.launchApplication` with `NSWorkspace.openApplication(at:configuration:)` + `configuration.activates = false`. New `--activate` flag for explicit foregrounding. `AccessibilityDomain` no longer sets `AXEnhancedUserInterface` (AppKit apps treated it as a foreground signal).

## Parser & dispatch correctness

- `menu --app` no longer consumes the app name as a menu-path item
- Bare `inspect` routes to compound inspect; `inspect <ref>` routes to raw
- `app activate` / `frontmost` share a unified truth model
- `compound read` / `act` propagate explicit `--app`/`--pid` to post-action reads
- `Clipboard` / `Files` / `Notifications` domains read `action["sub"]` so `clipboard read`, `files watch`, `notifications log` actually dispatch instead of falling through to `notImplemented`
- `find` narrows to focused/main window subtree first, with bounded traversal so it doesn't hang on visible elements

## Capture — ScreenCaptureKit timing + frame correctness

- `DispatchSemaphore` signaled from the SCK output callback resolves the start-vs-first-frame race; configurable `--timeout-ms` (default 3000)
- `SCStreamConfiguration.width/height` set from captured surface size
- `activeOutput` / `activeDelegate` retained as class fields so SCK callbacks aren't dropped
- `SCFrameStatus` filtered to only `.complete` buffers (skip `.idle` / `.blank` / `.suspended`)
- Late-frame guard after `capture stop`
- Default to display-mode capture when no `--app` is set (Electron / terminal apps don't deliver window-mode frames)

## Trust & permissions — Apple `AVAuthorizationStatus` vocabulary

- `permissions[].status` is a string from `{granted, denied, not_determined, restricted}`
- AX and Screen Recording entries carry a `limitation` field documenting the 2-state Bool API constraint Apple imposes; Microphone has full 4-state expressivity
- Microphone prompt is **non-blocking** — no more 30-second `DispatchSemaphore.wait`. Response carries `pending_user_action: ["Microphone"]` until the user replies; re-poll to observe.
- `--no-prompt` flag forces read-only behavior even when other prompt flags are set
- Activation policy briefly upgrades to `.regular` around `requestAccess` so the LSUIElement bridge surfaces the system dialog modally instead of as a transient notification banner
- `com.apple.security.device.audio-input` added to entitlements per Apple's *Requesting Authorization for Media Capture on macOS* contract
- `audio input start --save` writes a CAF file via `AVAudioEngine` + `AVAudioFile`; response carries `filePath` on both `start` and `stop`

## Sparkle auto-update — modal alert, channel opt-in, graceful install

Four-fix stack required to make Sparkle work for an `LSUIElement` background daemon:

1. **`SparkleUpdaterDelegate.allowedChannels(for:) = ["full"]`** — without this, every channel-tagged appcast item was silently skipped
2. **`SparkleUserDriverDelegate`** — `supportsGentleScheduledUpdateReminders = true` plus activation-policy upgrade around the alert window. Update prompt now surfaces modally instead of vanishing into the background
3. **`BridgeAppDelegate.applicationShouldTerminate`** — runs cleanup and returns `.terminateNow` so Sparkle's stage-2 Apple Quit event lets the install proceed cleanly instead of macOS marking the bridge "Not Responding"
4. **`NSApp.run()` instead of `RunLoop.main.run()`** — the modal alert window needs the full Cocoa event loop to receive mouse/keyboard events

New `interceptor macos update check / status` CLI verbs expose user-initiated Sparkle checks and updater state for diagnosis.

## Test coverage

| Suite | Before | After |
|---|---|---|
| `swift test` | 33 / 0 fail | **71 / 0 fail** |
| `bun test test/macos-parser.test.ts` | 11 / 0 fail | **19 / 0 fail** |
| `bun run typecheck` | clean | clean |

New Swift suites: `InputTargetSelectionTests`, `CompoundOpenTests`, `RefRegistryTests`, `CaptureFrameTimingTests`, `AccessibilityDomainTests`, `AppsDomainTests`, `ClipboardDispatchTests`, `FilesDispatchTests`, `NotificationsDispatchTests`, `TrustDomainStatusTests`.

## Live verification

- **Sparkle auto-update** completed bundle replacement `0.10.31 → 0.10.32` in **21 seconds** end-to-end. Modal dialog visible, click registered, install completed, bridge respawned on new bundle.
- **Trust dialog** modal verified — Dock-flash + click + revert pattern works.
- **Microphone capture** end-to-end: 5.10 s sample, 1.96 MB CAF file, 2 ch / 48 kHz Float32.
- **Accessibility / Screen Recording** surfaces all green.

## Files

40 files changed, +3349 / -339. New files include 6 Swift sources (`AppDelegate`, `InputTargetSelector`, `MicrophoneAuthorizationProvider`, `SparkleUserDriverDelegate`, `Domains/UpdateDomain`) and 10 Swift test files.

## Versions shipped tonight

`0.10.23 → 0.10.32`. Each signed by `Developer ID Installer: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)`, notarized, stapled, Gatekeeper-accepted as `Notarized Developer ID`, deployed to Railway at https://updates.hackervalley.media/appcast.xml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trust management command flags: `--no-prompt`, `--prompt`, `--walkthrough`, `--accessibility-prompt`, `--screen-prompt`, `--microphone-prompt`
  * Audio input capture to CAF files
  * Background-first interaction patterns for macOS operations
  * Enhanced bridge recovery with contextual error messages

* **Documentation**
  * Expanded macOS skill documentation with trust, input, capture, and background operation guidance
  * Added background-first interaction examples

* **Chores**
  * Version bump to 0.10.32

<!-- end of auto-generated comment: release notes by coderabbit.ai -->