### PR TITLE
feat(release): v0.11.0 — macOS bridge stable, ELv2 license

### DIFF
--- a/.agents/skills/interceptor-browser/SKILL.md
+++ b/.agents/skills/interceptor-browser/SKILL.md
@@ -96,6 +96,10 @@ See `references/monitor-and-replay.md` for monitor session behavior, replay-plan
 - Use `eval --main` only when the built-in command surface doesn't expose what you need. The dispatched-event pattern (with `__interceptor_trust` marker) is often the narrowest viable path for canvas-rendered surfaces.
 - Avoid `interceptor network on` unless raw CDP interception is explicitly needed. Passive capture already sees fetch / XHR / EventSource traffic using only standard Web APIs, without attaching the DevTools protocol. WebSocket frames need a MAIN-world `WebSocket` patch (see canvas-rendered notes), not CDP.
 
+## Cross-Surface Note (Background-First)
+
+PRD-59's background-first contract is **macOS-only** — the Browser surface doesn't have a frontmost-app concept that agents need to preserve. `interceptor open <url>`, `read`, `act`, `inspect`, etc. operate inside the user's existing browser session and never raise other apps. If a workflow involves both surfaces (e.g. open a URL in a backgrounded Brave) the macOS half runs through the `interceptor-macos` skill and inherits PRD-59 there.
+
 ## When To Switch Surfaces
 
 If the target is **outside the page** — a native dialog, browser chrome (URL bar, profile picker), Save/Open file picker, OS notification, or any other macOS app — load `interceptor-macos` instead. The Browser surface cannot see anything outside the page.

--- a/.agents/skills/interceptor-macos/SKILL.md
+++ b/.agents/skills/interceptor-macos/SKILL.md
@@ -45,7 +45,7 @@ When the user names a specific app ("screenshot of Brave", "scroll Signal", "ope
 | Open URL in a specific browser | `interceptor macos intent dispatch --bundle <id> --script 'open location "..."'` | ✅ Apple Events deliver without raising |
 | Read the active tab URL of Brave/Chrome/Safari | `interceptor macos intent dispatch --bundle <id> --script '... URL of active tab ...'` | ✅ |
 | Scroll a backgrounded app | `interceptor macos scroll <dir> <amount> --app "X" --times <N>` (routes via `postToPid`) | ✅ for Cocoa & most Electron; Chromium-occluded apps may need brief raise |
-| Move / resize a backgrounded window | `interceptor macos move/resize "X"` via AX | ✅ |
+| Move / resize a backgrounded window | `interceptor macos move/resize <ref> --app "X"` via AX (returns ground-truth `frame` + `clamped` + `clampedTo` per PRD-62) | ✅ |
 | Click / type / drag against a non-frontmost native app | `interceptor macos act <ref>` (AX press / value-set) or `... --app "X"` (PID-routed CGEvent) | ✅ |
 
 **Reflexes to drop:** `interceptor macos app activate` is not a precondition for capture, AX read, scroll, type, or Apple Events. Skip it. The user's focused window stays where it was.
@@ -138,9 +138,9 @@ Every command in this table has been live-verified to leave frontmost untouched.
 1. Compound: `interceptor macos open "X"`, `interceptor macos read`, `interceptor macos inspect`.
 2. AX tree narrows: `tree`, `find`, `focused`, `value`, `action`, `windows`, `inspect <ref>`.
 3. App / window control: `apps`, `app activate/hide/quit/launch`, `frontmost`, `move`, `resize`.
-4. Capture: `screenshot --app "X"`, `capture start/frame/stop`, `stream start/frame/stop`.
+4. Capture: `screenshot --app "X"`, `capture start/status/frame/stop`, `stream start/frame/stop`. Per PRD-63, `capture status` returns `{active, hasFrame, frameAgeMs}` and `capture frame` returns `{dataUrl, bytes, width, height, format}` matching `screenshot`'s shape.
 5. Audio intelligence: `listen`, `vad`, `sounds`, `audio output/input`.
-6. Vision / NLP / Intelligence: `vision text/faces/hands/bodies`, `nlp entities/sentiment/language`, `ai prompt`.
+6. Vision / NLP / Intelligence: `vision text/faces/hands/bodies`, `nlp entities/language/sentiment/tokens/similar/embed` (all six verbs functional after PRD-63 dispatch fix), `ai status/prompt/session` (functional after PRD-65 dispatch fix), `sensitive check/monitor` (functional after PRD-65 dispatch fix).
 7. Cross-app routing: `intent dispatch --bundle <id> --script <applescript>`, `intent warmup`.
 8. System reads: `notifications tail`, `clipboard read/write/tail`, `files watch`, `fs read/write/search`, `url get/post`, `log query`.
 9. Overlays: `overlay *` — panic hotkey `Ctrl+Opt+Cmd+Escape` always available.

--- a/.agents/skills/interceptor-macos/SKILL.md
+++ b/.agents/skills/interceptor-macos/SKILL.md
@@ -52,7 +52,7 @@ When the user names a specific app ("screenshot of Brave", "scroll Signal", "ope
 
 **When the user explicitly says "bring it forward / show me / switch to"**: respect that. Activate, do the operation, leave it there (or return to previous frontmost if asked).
 
-### Background-First Contract (current as of 0.10.12)
+### Background-First Contract (current as of 0.11.0)
 
 `interceptor macos open` and the synthesized-input verbs (`click`, `type`, `keys`, `drag`) are background-first by default. Foregrounding is opt-in via `--activate` on `open`, or via the explicit `app activate` command.
 
@@ -142,7 +142,7 @@ Every command in this table has been live-verified to leave frontmost untouched.
 5. Audio intelligence: `listen`, `vad`, `sounds`, `audio output/input`.
 6. Vision / NLP / Intelligence: `vision text/faces/hands/bodies`, `nlp entities/language/sentiment/tokens/similar/embed` (all six verbs functional after PRD-63 dispatch fix), `ai status/prompt/session` (functional after PRD-65 dispatch fix), `sensitive check/monitor` (functional after PRD-65 dispatch fix).
 7. Cross-app routing: `intent dispatch --bundle <id> --script <applescript>`, `intent warmup`.
-8. System reads: `notifications tail`, `clipboard read/write/tail`, `files watch`, `fs read/write/search`, `url get/post`, `log query`.
+8. System reads: `notifications tail`, `clipboard read/write/tail`, `files watch`, `fs read/write/search`, `url get/post`, `log query`. Per PRD-65: `fs search --scope <alias-or-absolute-path>` honors `home` / `workspace` / `granted` aliases AND absolute paths (`--scope /tmp`, `--scope /Users/me/Projects`); unresolvable paths return `error: fs_search: scope '...' is not an alias and not an absolute path that exists` instead of silently overriding to home. `log query` runs against `OSLogStore.local()` (system-wide), so `--predicate 'subsystem == "com.apple.WindowServer"'` actually returns entries from other processes.
 9. Overlays: `overlay *` — panic hotkey `Ctrl+Opt+Cmd+Escape` always available.
 10. Recording: `monitor start/stop/tail/export [--plan]`.
 
@@ -241,7 +241,7 @@ If `interceptor macos *` reports `Interceptor bridge not running` or `connection
 ## Safety
 
 - **Panic hotkey** — `Ctrl+Opt+Cmd+Escape` closes every active overlay regardless of owning session. Bridge-side handler.
-- **Sensitive frontmost-app gate** — `mac_type`, `mac_keys`, `mac_click(coords)`, `mac_drag` are rejected when the frontmost app's bundle ID is on the denylist (Keychain, 1Password, Dashlane, LastPass, Bitwarden, System Settings, Chase, Bank of America, Wells Fargo). Extend per environment via `SENSITIVE_BUNDLE_IDS`.
+- **Sensitive frontmost-app gate** — `interceptor macos type`, `interceptor macos keys`, `interceptor macos click <x,y>`, `interceptor macos drag` are rejected when the frontmost app's bundle ID is on the denylist (Keychain, 1Password, Dashlane, LastPass, Bitwarden, System Settings, Chase, Bank of America, Wells Fargo). Extend per environment via `SENSITIVE_BUNDLE_IDS`.
 - **Permission tiers** — Allow (observational): AX reads, app reads, screenshot, vision, NLP, clipboard read, capture, audio, sounds, speech, scroll, overlays. Ask (interactive): click, type, keys, drag, app quit/hide, clipboard write. Deny: none by default.
 - **Stop control** — Active overlays do NOT block session completion. Session shutdown tears down every overlay owned by the session. Engine crash recovery marks orphan overlays `closed_reason=crash`.
 
@@ -273,7 +273,7 @@ interceptor macos value "$REF"                             # confirm landed
 
 ## Pitfalls (what went wrong before, why it's fixed)
 
-Earlier bridge versions had three documented foregrounding leaks. They are all fixed in 0.10.12. If you ever see frontmost change unexpectedly in a future build, suspect one of these classes of bug:
+Earlier bridge versions had three documented foregrounding leaks. They are all fixed as of 0.11.0 (closed by PRD-59 with reinforcement from PRD-62/63/65 retests). If you ever see frontmost change unexpectedly in a future build, suspect one of these classes of bug:
 
 - **`AXEnhancedUserInterface = true` on the app element.** This is the AppKit "VoiceOver is active" flag, not just a Chromium tree-build signal. AppKit apps respond by raising their main window. The bridge now sets only `AXManualAccessibility` (the Chromium-specific signal) in `wakeAXTree`. Never set `AXEnhancedUserInterface` from a background-first reader.
 - **`NSWorkspace.openApplication(at:configuration:)` with `activates = false` against an already-running app.** Per Apple docs the `activates` flag only suppresses the *system's* activation pass; the receiving app still self-activates in response to `kAEOpenApplication` / `kAEOpenDocuments`. The bridge therefore never calls `openApplication` for a running target — the running-app branch is a strict no-op.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,18 @@ Interceptor is an AI-agent control surface for the user's real browser and nativ
 
 For user-facing overview material, see [README.md](README.md). For implementation details, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
+## Behavior Contracts (read first)
+
+Five PRDs define the live behavior contracts you'll see across the macOS surface. Skim them when an agent's expected behavior diverges from observation:
+
+| PRD | What it locks in | Quick test |
+|---|---|---|
+| `prd/PRD-58.md` | Compound `inspect` parser collision fixed; bare `inspect` is reachable | `interceptor macos inspect --app TextEdit` returns a tree |
+| `prd/PRD-59.md` | **Background-first contract.** Only two commands move focus: `app activate <app>` and `open <app> --activate`. Everything else stays invisible | Run any command; `interceptor macos frontmost` should be unchanged |
+| `prd/PRD-62.md` | `resize` / `move` return `{frame, requested, clamped, clampedTo}` ground-truth shape via post-set `getFrame()` readback. Internal verify-and-retry capped at 2 attempts. CLI parser forwards `--app`/`--pid` for parity with click/type/keys/scroll/drag | `interceptor macos resize <ref> --width 640 --height 960` returns the response shape above |
+| `prd/PRD-63.md` | Phase-5 multimodal closure: NLP/Vision/Capture dispatch via `action["sub"]`, capture status verb, capture frame metadata parity, listen/vad/sounds tail no spurious `streaming`, transport timeout messages branch on `macos_*` | `interceptor macos nlp entities "Apple in Cupertino"` returns structured array |
+| `prd/PRD-65.md` | Phase-6+7 closure: AI/Sensitive dispatch fix, stream list verb, fs absolute-path scope, audio device enumeration via `AVCaptureDevice.DiscoverySession`, `OSLogStore.local()` for log queries, container `setup_required` field, overlay `--html` + `--duration` aliases | `interceptor macos ai status` returns FoundationModels payload; `fs search --scope /tmp` honors the path |
+
 ## Install Modes
 
 Interceptor ships in two install modes. Check yours with `interceptor status` and read the `mode:` line:
@@ -48,21 +60,22 @@ When the target is a specific app, prefer staying invisible to the user. The use
 
 | Operation | Background path (preferred) | When you must escalate |
 |---|---|---|
-| Screenshot of an app's window | `mac_screenshot --app "X"` (CGS path captures occluded / minimized / cross-Space) | `--mode display` only when the user wants the whole screen |
-| List / read a Chrome / Brave tab | Apple Events: `mac_intent dispatch --bundle <id> --script 'tell ... get URL of active tab'` | Only if AppleScript is disabled in the target app |
-| Open a URL in a specific browser | Apple Events: `mac_intent dispatch --bundle com.brave.Browser --script 'open location "https://…"'` (no `activate`) | Only if the user explicitly asks for the browser to come forward |
-| Read a backgrounded Electron app's UI | `mac_tree --app "X"` (auto-fires `AXManualAccessibility` wake-up) | App that gates AX on visibility (Signal): brief-raise + restore focus |
-| Scroll a backgrounded app | `mac_scroll <dir> <amount> --app "X"` (routes via `postToPid`) | Chromium-occluded apps that pause their event loop: brief-raise |
-| Drive a native Cocoa app | AX `mac_act/click/type` against the target's PID without `activate` | OS-level `--os` modifier only if synthetic input fails |
-| Read text / selection from another app | `mac_text` against the target — no focus change | (no escalation needed) |
+| Screenshot of an app's window | `interceptor macos screenshot --app "X"` (CGS path captures occluded / minimized / cross-Space) | `--mode display` only when the user wants the whole screen |
+| List / read a Chrome / Brave tab | Apple Events: `interceptor macos intent dispatch --bundle <id> --script 'tell ... get URL of active tab'` | Only if AppleScript is disabled in the target app |
+| Open a URL in a specific browser | Apple Events: `interceptor macos intent dispatch --bundle com.brave.Browser --script 'open location "https://…"'` (no `activate`) | Only if the user explicitly asks for the browser to come forward |
+| Read a backgrounded Electron app's UI | `interceptor macos tree --app "X"` (auto-fires `AXManualAccessibility` wake-up) | App that gates AX on visibility (Signal): brief-raise + restore focus |
+| Scroll a backgrounded app | `interceptor macos scroll <dir> <amount> --app "X"` (routes via `postToPid`) | Chromium-occluded apps that pause their event loop: brief-raise |
+| Drive a native Cocoa app | AX `interceptor macos act/click/type` against the target's PID without `activate` | OS-level `--os` modifier only if synthetic input fails |
+| Read text / selection from another app | `interceptor macos text` against the target — no focus change | (no escalation needed) |
+| Move / resize a window in the background | `interceptor macos move/resize <ref> --app "X"` returns `{frame, requested, clamped, clampedTo}` ground-truth shape (PRD-62) | (no escalation needed; refs churn after geometry — refresh from `windows`) |
 
 **Reflexes to drop:**
-- Do NOT call `mac_app activate` before screenshotting or reading. SCK + CGS work on offscreen windows.
+- Do NOT call `interceptor macos app activate` before screenshotting or reading. SCK + CGS work on offscreen windows.
 - Do NOT add `activate` to AppleScript blocks unless the user asked the app to come forward.
 - Do NOT bring a window forward "to be safe" — the bridge's CGS / AX paths are designed to work without it.
 - Do NOT use `--mode display` for app-specific captures — it captures the visible composite (which has the wrong app on top).
 
-**When the user explicitly says "bring it forward" / "show me X" / "switch to X":** respect that. Use `mac_app activate "X"` once, do the operation, and unless the user asked you to leave it there, restore the previous frontmost via `_SLPSSetFrontProcessWithOptions` (TODO: surface as `mac_app activate-and-restore`).
+**When the user explicitly says "bring it forward" / "show me X" / "switch to X":** respect that. Use `interceptor macos app activate "X"` once, do the operation, and — unless the user asked you to leave it there — restore the previous frontmost by capturing the current frontmost (`interceptor macos frontmost`) before activating, then `interceptor macos app activate <previous>` after the work completes.
 
 ## Browser Extension vs macOS Bridge
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,9 +226,14 @@ The daemon talks to the extension via three channels, routed by [`daemon/outboun
 - AVFoundation + speech + sound classification (`SpeechDomain`, `SoundDomain`, `AudioDomain`)
 - Vision + NLP + on-device LLM (`VisionDomain`, `NLPDomain`, `IntelligenceDomain`)
 - File watch / notifications / clipboard (`FilesDomain`, `NotificationsDomain`, `ClipboardDomain`)
+- Sensitive content + log query + container + URL fetch (`SensitiveDomain`, `LogDomain`, `ContainerDomain`, `NetDomain`)
 - Native macOS monitor (`MonitorDomain`) — same JSON event schema as browser monitor
 
 Communication: CLI / daemon → Unix socket (`/tmp/interceptor-bridge.sock`) → bridge router → domain handler → CGEvent / AX / etc.
+
+#### Dispatch invariant — read `action["sub"]`, not `command`
+
+The Router collapses an action `type` like `macos_nlp` into `command="nlp"` for two-segment types (see `Router.swift:43-55`). The CLI parser puts the actual verb in `action["sub"]`. **Every domain handler MUST read `let sub = action["sub"] as? String ?? command` and switch on `sub`.** Switching on `command` directly is a bug — every verb falls through to `default → notImplemented` even when handlers exist (PRD-63 fixed this for NLP, PRD-65 fixed it for AI and Sensitive). Keep this invariant when adding new domains.
 
 For screenshot saving, `interceptor-bridge/Sources/Domains/CaptureDomain.swift` no longer relies on `FileManager.default.currentDirectoryPath` when running under `launchd`. The CLI passes its working directory (`cli/commands/macos.ts`), and the bridge falls back through Downloads, home, then temp so `interceptor macos screenshot --save` works cleanly under LaunchAgent execution.
 
@@ -291,3 +296,18 @@ Recent major additions reflected in this document:
 - transport hardening around disconnected native ports
 - strict-CSP `eval --main` fallback via tab-scoped CSP stripping and retry
 - launchd-safe macOS screenshot saving
+
+---
+
+## PRD Index
+
+The `prd/` directory is gitignored (working docs), but the PRDs that shape current bridge behavior are referenced repeatedly across this file and the agent skills. When you need the full evidence for a behavior contract, look up the PRD in your local copy:
+
+| PRD | Contract |
+|---|---|
+| `prd/PRD-58.md` | Compound `inspect` parser collision fixed; bare `inspect` is reachable |
+| `prd/PRD-59.md` | Background-first contract — only `app activate` and `open --activate` move focus |
+| `prd/PRD-62.md` | `resize`/`move` ground-truth response shape (`{frame, requested, clamped, clampedTo}`); internal verify-and-retry; CLI parser parity for `--app`/`--pid` |
+| `prd/PRD-63.md` | Phase-5 multimodal closure: NLP/Vision/Capture dispatch, capture status verb, capture frame metadata parity, listen/vad/sounds tail field cleanup, transport timeout messaging |
+| `prd/PRD-64.md` | Planning doc for the Phase-6+7 defects (Apple-doc-grounded, evidence-of-record) |
+| `prd/PRD-65.md` | Phase-6+7 closure: AI/Sensitive dispatch, stream list verb, fs absolute-path scope, audio device enumeration via `AVCaptureDevice.DiscoverySession`, `OSLogStore.local()`, container `setup_required` field, overlay `--html` + `--duration` aliases |

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,43 @@
+# Commercial Licensing
+
+Interceptor is licensed under the [Elastic License 2.0](LICENSE) (ELv2).
+
+## What ELv2 lets you do for free
+
+- Use Interceptor inside your own organization, including for internal business
+  automation and workflows — at any scale, indefinitely.
+- Modify the source code for your own use.
+- Distribute Interceptor and your modifications to third parties, as long as
+  you pass these license terms along.
+- Build internal tools, scripts, and agents on top of Interceptor.
+
+## What requires a commercial license
+
+A commercial license from Hacker Valley Media, LLC is required if you want to:
+
+- Provide Interceptor (or a substantially similar derivative) to third parties
+  as a **hosted or managed service** — i.e. operate Interceptor on their behalf
+  and let them access its features.
+- Embed Interceptor into a **product you sell**, lease, or license to others
+  where Interceptor is a substantial part of the value.
+- **Rebrand or white-label** Interceptor as your own offering.
+- Remove, alter, or work around the licensing or copyright notices.
+
+If you're not sure whether your use case requires a commercial license, ask.
+
+## Contact
+
+**Email:** ron@hackervalley.com
+
+Include in your message:
+
+- Who you are and which organization you represent
+- A short description of the use case (what you want to build / sell / host)
+- Expected scale (rough user count, deployment model)
+- Timeline
+
+Pricing is negotiated per use case. There is no fixed price list.
+
+---
+
+Copyright (c) 2026 Hacker Valley Media, LLC.

--- a/LICENSE
+++ b/LICENSE
@@ -1,199 +1,102 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 Hacker Valley Media, LLC
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Licensed under the Elastic License 2.0 (the "License").
+You may not use this software except in compliance with the License.
 
-   1. Definitions.
+A commercial license is available — see COMMERCIAL.md.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+================================================================================
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+Elastic License 2.0
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+URL: https://www.elastic.co/licensing/elastic-license
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+## Acceptance
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+By using the software, you agree to all of the terms and conditions below.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+## Copyright License
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+## Limitations
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
-      subsequently incorporated within the Work.
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+## Patents
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+## Notices
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+## No Other Rights
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+These terms do not imply any licenses other than those expressly granted in
+these terms.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+## Termination
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+## No Liability
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+## Definitions
 
-   END OF TERMS AND CONDITIONS
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
 
-   APPENDIX: How to apply the Apache License to your work.
+**you** refers to the individual or entity agreeing to these terms.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. Please also get an in-touch with
-      a lawyer to verify your use case.
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-   Copyright 2025 Hacker Valley Media, LLC
+**your licenses** are all the licenses granted to you for the software under
+these terms.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+**use** means anything you do with the software requiring one of your licenses.
 
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing
-   permissions and limitations under the License.
+**trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -824,6 +824,31 @@ interceptor macos windows                        # All windows with frames
 interceptor macos windows --app "Finder"         # Specific app
 interceptor macos move e1 --x 0 --y 25           # Move window
 interceptor macos resize e1 --width 672 --height 983  # Resize window
+interceptor macos move e1 --x 0 --y 25 --app "Finder" # --app/--pid forwarded for ref qualification
+```
+
+`move` and `resize` return a ground-truth geometry payload — the `frame`
+field is read back from AX after the set, NOT echoed from the request.
+When AX clamps the request against `NSScreen.visibleFrame` (e.g. height
+exceeds the available rect after subtracting Dock + menu bar), the
+response sets `clamped: true` and includes `clampedTo` with the legitimate
+ceiling. The bridge runs one internal retry to absorb single-shot drift.
+See PRD-62 for the full contract.
+
+```jsonc
+// resize within visibleFrame
+{
+  "frame":     {"x": 0, "y": 30, "width": 640, "height": 960},
+  "requested": {"width": 640, "height": 960},
+  "clamped":   false
+}
+// resize beyond visibleFrame ceiling
+{
+  "frame":     {"x": 0, "y": 25, "width": 640, "height": 970},
+  "requested": {"width": 640, "height": 1040},
+  "clamped":   true,
+  "clampedTo": {"x": 0, "y": 25, "width": 1920, "height": 970}
+}
 ```
 
 ### Daily-Driver Domain 2: Input (AX-first, PID-routed CGEvent fallback)
@@ -855,12 +880,13 @@ interceptor macos screenshot                     # Frontmost window
 interceptor macos screenshot --app "Finder"      # Specific app (works occluded / minimized / cross-Space)
 interceptor macos screenshot --save              # Save to disk; payload key is `filePath` (not `path`)
 interceptor macos capture start                  # Continuous 30fps capture
-interceptor macos capture frame                  # Get latest frame; blocks ≤3000ms for first frame
+interceptor macos capture status                 # PRD-63: {active, hasFrame, frameAgeMs}
+interceptor macos capture frame                  # PRD-63: returns {dataUrl, bytes, width, height, format} — parity with screenshot
 interceptor macos capture frame --timeout-ms 5000  # Override the wait window for first-frame delivery
 interceptor macos capture stop                   # Stop
 ```
 
-The `--save` response contains `{ "filePath": "...", "format": ..., "bytes": ..., "width": ..., "height": ... }`. Read `filePath` for the path on disk.
+The `--save` response contains `{ "filePath": "...", "format": ..., "bytes": ..., "width": ..., "height": ... }`. Read `filePath` for the path on disk. The `capture frame` response (PRD-63) mirrors the same metadata shape, with `dataUrl` replacing `filePath` for in-memory delivery.
 
 ### Daily-Driver Domain 4: Monitor (Teach and Replay)
 
@@ -937,19 +963,59 @@ interceptor macos sounds status                  # Current detected sounds
 
 #### Vision (on-device)
 
+PRD-63: Vision now derives `SCStreamConfiguration.width`/`height` from the
+filter's `contentRect × pointPixelScale` (Apple's documented capture
+pattern), and `recognizeText` enables `automaticallyDetectsLanguage`,
+`recognitionLanguages = ["en-US"]`, and `usesLanguageCorrection`.
+
 ```bash
 interceptor macos vision faces                   # Detect faces in frontmost window
 interceptor macos vision text                    # OCR
+interceptor macos vision text --app "Notes"      # OCR a specific (possibly occluded) window
 interceptor macos vision hands                   # Hand pose detection
 interceptor macos vision bodies                  # Body pose detection
 ```
 
-#### NLP (on-device)
+#### Apple Intelligence (on-device LLM via FoundationModels — PRD-65)
+
+PRD-65 fixed the dispatch bug that previously made every `ai` verb return
+"not implemented" against fully-built `LanguageModelSession` handlers.
+All three verbs are now functional on macOS 26+; older macOS surfaces a
+structured "FoundationModels requires macOS 26.0+" error.
 
 ```bash
-interceptor macos nlp entities "Ron in Austin"   # Named entity recognition
-interceptor macos nlp sentiment "great product"  # Sentiment analysis
-interceptor macos nlp language "bonjour"         # Language detection
+interceptor macos ai status                  # FoundationModels availability
+interceptor macos ai prompt "Summarize this" # one-shot LanguageModelSession.respond
+interceptor macos ai session start           # multi-turn session begin
+interceptor macos ai session send "Hello"    # turn within active session
+interceptor macos ai session history         # current session transcript
+interceptor macos ai session end             # close session
+```
+
+#### Sensitive content (on-device via SensitiveContentAnalysis — PRD-65)
+
+PRD-65 fixed the same dispatch bug for `sensitive`. The
+`SCSensitivityAnalyzer()` integration was already implemented; only the
+dispatch was broken.
+
+```bash
+interceptor macos sensitive check            # current analysisPolicy state
+interceptor macos sensitive monitor status   # monitor lifecycle
+```
+
+#### NLP (on-device, NaturalLanguage framework)
+
+PRD-63 fixed the dispatch bug that previously made every `nlp` verb return
+"not implemented" against an already-built NaturalLanguage backend. All six
+verbs are functional:
+
+```bash
+interceptor macos nlp entities "Apple was founded in Cupertino"  # NLTagger / .nameType
+interceptor macos nlp sentiment "great product"                  # NLTagger / .sentimentScore
+interceptor macos nlp language "bonjour le monde"                # NLLanguageRecognizer
+interceptor macos nlp tokens "the quick brown fox"               # NLTokenizer
+interceptor macos nlp similar cat dog                            # NLEmbedding.distance
+interceptor macos nlp embed "hello"                              # NLEmbedding.vector
 ```
 
 #### Apple Intelligence (on-device LLM, macOS 26+)

--- a/bench-head-to-head/package.json
+++ b/bench-head-to-head/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
+  "license": "Elastic-2.0",
   "scripts": {
     "bench": "bun run src/cli.ts",
     "report": "bun run src/cli.ts report"

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -295,18 +295,30 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     case "resize": {
       const ref = filtered[2]
+      if (!ref) { console.error("error: interceptor macos resize requires a ref"); process.exit(1) }
       const width = flagInt(filtered, "--width") || parseInt(filtered[3]) || undefined
       const height = flagInt(filtered, "--height") || parseInt(filtered[4]) || undefined
-      if (!ref) { console.error("error: interceptor macos resize requires a ref"); process.exit(1) }
-      return { type: "macos_resize", ref, width, height }
+      // PRD-62: parser parity with click/type/keys/scroll/drag — forward
+      // --app and --pid so the bridge can use them for ref qualification.
+      const action: Action = { type: "macos_resize", ref, width, height }
+      const resizeApp = flagVal(filtered, "--app")
+      const resizePid = flagInt(filtered, "--pid")
+      if (resizeApp) action.app = resizeApp
+      if (resizePid !== undefined) action.pid = resizePid
+      return action
     }
 
     case "move": {
       const ref = filtered[2]
+      if (!ref) { console.error("error: interceptor macos move requires a ref"); process.exit(1) }
       const x = flagInt(filtered, "--x") || parseInt(filtered[3]) || 0
       const y = flagInt(filtered, "--y") || parseInt(filtered[4]) || 0
-      if (!ref) { console.error("error: interceptor macos move requires a ref"); process.exit(1) }
-      return { type: "macos_move", ref, x, y }
+      const action: Action = { type: "macos_move", ref, x, y }
+      const moveApp = flagVal(filtered, "--app")
+      const movePid = flagInt(filtered, "--pid")
+      if (moveApp) action.app = moveApp
+      if (movePid !== undefined) action.pid = movePid
+      return action
     }
 
     case "drag": {
@@ -399,11 +411,17 @@ export function parseMacosCommand(filtered: string[]): Action | null {
     // ── Vision ──
     case "vision": {
       const op = filtered[2] || "text"
-      return {
+      const action: Action = {
         type: "macos_vision",
         sub: op,
         app: flagVal(filtered, "--app"),
       }
+      // PRD-63 diagnostic: dump the captured image to disk so the operator
+      // can see what Vision actually fed VNRecognizeTextRequest. Off by
+      // default; opt in with --debug-dump <path>.
+      const debugDump = flagVal(filtered, "--debug-dump")
+      if (debugDump) action.debugDumpPath = debugDump
+      return action
     }
 
     // ── NLP ──
@@ -502,8 +520,16 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     // ── Audio ──
     case "audio": {
-      const channel = filtered[2] || "output"
-      const op = filtered[3] || "start"
+      // PRD-65 Spec 5 / PRD-64 Spec 5: bare `interceptor macos audio`
+      // previously defaulted to channel="output" + op="start" — silently
+      // starting capture as a side effect of asking for help. Require both
+      // explicitly so the no-arg invocation prints usage instead.
+      const channel = filtered[2]
+      const op = filtered[3]
+      if (!channel || !op) {
+        console.error("error: interceptor macos audio requires <channel> <op>. Channels: output | input | both. Ops: start | stop | level | devices.")
+        process.exit(1)
+      }
       return {
         type: "macos_audio",
         sub: channel,
@@ -810,8 +836,17 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           const sceneScript = flagVal(filtered, "--scene-script")
           const url = flagVal(filtered, "--url")
           const htmlB64 = flagVal(filtered, "--html-b64")
+          // PRD-65 Spec 7: --html accepted as a friendlier alias to
+          // --html-b64; the parser b64-encodes inline HTML so callers
+          // don't have to wrap shell-escaped HTML themselves.
+          const htmlInline = flagVal(filtered, "--html")
           const rect = flagVal(filtered, "--rect")
           const timeout = flagInt(filtered, "--timeout-seconds")
+          // PRD-65 Spec 7: --duration / --duration-ms aliases for the
+          // existing --timeout-seconds. The bridge auto-dismisses after
+          // the timeout regardless of mode.
+          const durationMs = flagInt(filtered, "--duration-ms")
+          const durationLegacy = flagInt(filtered, "--duration")
           const density = flagInt(filtered, "--density")
           const lifetime = flagInt(filtered, "--lifetime")
           const anchor = flagVal(filtered, "--anchor")
@@ -832,6 +867,29 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           if (sceneScript) action.scene_script = sceneScript
           if (url) action.url = url
           if (htmlB64) action.html_b64 = htmlB64
+          // PRD-65 Spec 7: forward inline --html as html_b64 (b64-encoded)
+          // so the bridge has a single source HTML field. Buffer.from is
+          // already imported into Bun's globals.
+          let resolvedHtmlB64: string | undefined = htmlB64
+          if (!resolvedHtmlB64 && htmlInline) {
+            resolvedHtmlB64 = Buffer.from(htmlInline, "utf-8").toString("base64")
+            action.html_b64 = resolvedHtmlB64
+          }
+
+          // PRD-65 Spec 7: unify --duration-ms / --duration / --timeout-seconds
+          // into the bridge's single `timeout_seconds` action field
+          // (OverlayDomain only reads timeout_seconds today, see
+          // OverlayDomain.swift:114). --duration-ms wins, then --duration
+          // (interpreted as ms for ergonomic parity with the particles-mode
+          // flag the live tests already used), then --timeout-seconds as
+          // the legacy form.
+          if (durationMs !== undefined) {
+            action.timeout_seconds = durationMs / 1000
+          } else if (durationLegacy !== undefined) {
+            action.timeout_seconds = durationLegacy / 1000
+          } else if (timeout !== undefined) {
+            action.timeout_seconds = timeout
+          }
 
           if (rect) {
             const [x, y, w, h] = rect.split(",").map((v) => parseFloat(v))
@@ -840,8 +898,8 @@ export function parseMacosCommand(filtered: string[]): Action | null {
             }
           }
 
-          if (!particles && !scene && !sceneScript && !url && !htmlB64) {
-            console.error("error: overlay start requires one of --particles, --scene, --scene-script, --url, --html-b64")
+          if (!particles && !scene && !sceneScript && !url && !resolvedHtmlB64) {
+            console.error("error: overlay start requires one of --particles, --scene, --scene-script, --url, --html, --html-b64")
             process.exit(1)
           }
           return action

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -441,12 +441,22 @@ export function parseMacosCommand(filtered: string[]): Action | null {
     // ── Intelligence ──
     case "ai": {
       const op = filtered[2] || "status"
-      const prompt = filtered[3]
-      return {
-        type: "macos_ai",
-        sub: op,
-        prompt,
+      // PRD-65 Spec 1 follow-up: `ai session <op>` previously sent
+      // filtered[3] as `prompt`, but the bridge's IntelligenceDomain.handleSession
+      // reads action["op"], so the inner op (start/send/history/end) was
+      // dropped and every session call fell through to "session status"
+      // notImplemented. Route filtered[3] to the right field per outer op:
+      //   - sub="prompt"  → filtered[3] is the prompt text
+      //   - sub="session" → filtered[3] is the session sub-op; filtered[4] is the message for session send
+      //   - everything else → leave both unset
+      const action: Action = { type: "macos_ai", sub: op }
+      if (op === "session") {
+        if (filtered[3]) action.op = filtered[3]
+        if (filtered[4]) action.message = filtered[4]
+      } else {
+        if (filtered[3]) action.prompt = filtered[3]
       }
+      return action
     }
 
     // ── Sensitive ──

--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -6,6 +6,29 @@ import { IPC_PORT, IS_WIN, SOCKET_PATH, WS_PORT } from "../shared/platform"
 
 export const INTERCEPTOR_TIMEOUT_MS = parseInt(process.env.INTERCEPTOR_TIMEOUT || "15000")
 
+// PRD-63 Spec 5: per-verb timeout overrides. SFSpeechRecognizer's
+// requestAuthorization is async and user-bounded — Apple does not place a
+// time bound on the consent prompt, so 15s is too short for first-time
+// `listen start` / `vad start`. 60s covers the documented user-prompt UX.
+const ACTION_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  macos_listen: 60_000,
+  macos_vad: 60_000,
+}
+
+function pickTimeoutForAction(actionType: string): number {
+  return ACTION_TIMEOUT_OVERRIDES_MS[actionType] ?? INTERCEPTOR_TIMEOUT_MS
+}
+
+// PRD-63 Spec 5: branch the timeout hint on `macos_*` so bridge commands
+// don't get a Chrome/Brave-extension troubleshooting hint.
+function timeoutMessage(actionType: string, ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  if (actionType.startsWith("macos_")) {
+    return `timeout: no response for '${actionType}' after ${seconds}s. The macOS bridge may be waiting on a TCC permission prompt (Microphone / Speech Recognition for listen/vad, Screen Recording for screenshot/capture/vision). Check System Settings → Privacy & Security.`
+  }
+  return `timeout: no response for '${actionType}' after ${seconds}s. Ensure Chrome/Brave is open with the Interceptor extension loaded.`
+}
+
 export type Action = { type: string; [key: string]: unknown }
 export type DaemonResult = { success: boolean; error?: string; data?: unknown; tabId?: number }
 export type DaemonResponse = {
@@ -22,13 +45,14 @@ export function sendCommand(action: Action, tabId?: number): Promise<DaemonRespo
     let resolved = false
     let socketRef: Bun.Socket<undefined> | null = null
 
+    const timeoutMs = pickTimeoutForAction(action.type)
     const timer = setTimeout(() => {
       if (!resolved) {
         resolved = true
         if (socketRef) try { socketRef.end() } catch {}
-        reject(new Error(`timeout: no response for '${action.type}' after ${INTERCEPTOR_TIMEOUT_MS / 1000}s. Ensure Chrome/Brave is open with the Interceptor extension loaded.`))
+        reject(new Error(timeoutMessage(action.type, timeoutMs)))
       }
-    }, INTERCEPTOR_TIMEOUT_MS)
+    }, timeoutMs)
 
     const socketHandlers: Bun.SocketHandler<undefined> = {
       open(socket: Bun.Socket<undefined>) {
@@ -87,9 +111,10 @@ export function sendCommandWs(action: Action, tabId?: number): Promise<DaemonRes
     const shortId = id.slice(0, 8)
     process.stderr.write(`[${shortId}] →ws ${action.type}\n`)
 
+    const timeoutMs = pickTimeoutForAction(action.type)
     const timer = setTimeout(() => {
-      reject(new Error(`timeout: no response for '${action.type}' after ${INTERCEPTOR_TIMEOUT_MS / 1000}s via WebSocket.`))
-    }, INTERCEPTOR_TIMEOUT_MS)
+      reject(new Error(`timeout: no response for '${action.type}' after ${timeoutMs / 1000}s via WebSocket.`))
+    }, timeoutMs)
 
     const ws = new WebSocket(`ws://localhost:${WS_PORT}`)
     ws.onopen = () => {

--- a/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AccessibilityDomain.swift
@@ -413,6 +413,12 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
         completion(WireFormat.success(result))
     }
 
+    // PRD-62: ground-truth geometry — handleResize and handleMove now read
+    // post-set kAXSize / kAXPosition back via getFrame() instead of echoing
+    // the input dict, expose NSScreen.visibleFrame as `clampedTo` whenever
+    // the system clamped the request, and run a single internal retry to
+    // absorb single-shot drift caused by non-atomic AX position+size sets.
+
     private func handleResize(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         guard let ref = action["ref"] as? String,
               let element = refRegistry.resolve(ref) else {
@@ -423,17 +429,41 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             completion(WireFormat.error("resize requires width and height"))
             return
         }
-        var size = CGSize(width: CGFloat(w), height: CGFloat(h))
-        guard let axSize = AXValueCreate(.cgSize, &size) else {
-            completion(WireFormat.error("failed to create AXValue for size"))
+
+        // Spec 3: pre-flight settability per AXUIElementIsAttributeSettable.
+        if let unsettable = settabilityError(element: element, attribute: kAXSizeAttribute as CFString, verb: "resize") {
+            completion(unsettable)
             return
         }
-        let result = AXUIElementSetAttributeValue(element, kAXSizeAttribute as CFString, axSize)
-        if result == .success {
-            completion(WireFormat.success(["width": w, "height": h]))
-        } else {
-            completion(WireFormat.error("resize failed: \(result.rawValue)"))
+
+        let target = CGSize(width: CGFloat(w), height: CGFloat(h))
+        if let setError = setSize(element, target) {
+            completion(WireFormat.error("resize failed: \(setError.rawValue)"))
+            return
         }
+
+        // Spec 2: verify, and if drifted within visibleFrame, retry exactly once.
+        var frame = getFrame(element)
+        if let f = frame, !Self.sizeMatches(f.size, target) {
+            if let visible = visibleFrameRectForElement(element),
+               target.width <= visible.width && target.height <= visible.height {
+                _ = setSize(element, target)
+                frame = getFrame(element)
+            }
+        }
+
+        guard let finalFrame = frame else {
+            completion(WireFormat.error("resize set succeeded but post-set frame read failed"))
+            return
+        }
+        let response = Self.buildGeometryResponse(
+            frame: finalFrame,
+            requested: ["width": w, "height": h],
+            targetSize: target,
+            targetOrigin: nil,
+            visibleFrame: visibleFrameRectForElement(element)
+        )
+        completion(WireFormat.success(response))
     }
 
     private func handleMove(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -446,17 +476,142 @@ final class AccessibilityDomain: DomainHandler, @unchecked Sendable {
             completion(WireFormat.error("move requires x and y"))
             return
         }
-        var point = CGPoint(x: CGFloat(x), y: CGFloat(y))
-        guard let axPoint = AXValueCreate(.cgPoint, &point) else {
-            completion(WireFormat.error("failed to create AXValue for point"))
+
+        if let unsettable = settabilityError(element: element, attribute: kAXPositionAttribute as CFString, verb: "move") {
+            completion(unsettable)
             return
         }
-        let result = AXUIElementSetAttributeValue(element, kAXPositionAttribute as CFString, axPoint)
-        if result == .success {
-            completion(WireFormat.success(["x": x, "y": y]))
-        } else {
-            completion(WireFormat.error("move failed: \(result.rawValue)"))
+
+        let target = CGPoint(x: CGFloat(x), y: CGFloat(y))
+        if let setError = setPosition(element, target) {
+            completion(WireFormat.error("move failed: \(setError.rawValue)"))
+            return
         }
+
+        var frame = getFrame(element)
+        if let f = frame, !Self.originMatches(f.origin, target) {
+            if let visible = visibleFrameRectForElement(element),
+               let currentSize = frame?.size,
+               target.x >= visible.minX,
+               target.y >= visible.minY,
+               target.x + currentSize.width <= visible.maxX,
+               target.y + currentSize.height <= visible.maxY {
+                _ = setPosition(element, target)
+                frame = getFrame(element)
+            }
+        }
+
+        guard let finalFrame = frame else {
+            completion(WireFormat.error("move set succeeded but post-set frame read failed"))
+            return
+        }
+        let response = Self.buildGeometryResponse(
+            frame: finalFrame,
+            requested: ["x": x, "y": y],
+            targetSize: nil,
+            targetOrigin: target,
+            visibleFrame: visibleFrameRectForElement(element)
+        )
+        completion(WireFormat.success(response))
+    }
+
+    // MARK: - PRD-62 geometry helpers
+
+    private func setSize(_ element: AXUIElement, _ size: CGSize) -> AXError? {
+        var s = size
+        guard let axSize = AXValueCreate(.cgSize, &s) else { return .failure }
+        let result = AXUIElementSetAttributeValue(element, kAXSizeAttribute as CFString, axSize)
+        return result == .success ? nil : result
+    }
+
+    private func setPosition(_ element: AXUIElement, _ point: CGPoint) -> AXError? {
+        var p = point
+        guard let axPoint = AXValueCreate(.cgPoint, &p) else { return .failure }
+        let result = AXUIElementSetAttributeValue(element, kAXPositionAttribute as CFString, axPoint)
+        return result == .success ? nil : result
+    }
+
+    private func settabilityError(element: AXUIElement, attribute: CFString, verb: String) -> [String: Any]? {
+        var settable: DarwinBoolean = false
+        let probe = AXUIElementIsAttributeSettable(element, attribute, &settable)
+        if probe != .success {
+            // If the probe itself fails (e.g. .cannotComplete), surface that —
+            // but don't block the verb on it; some apps refuse the probe yet
+            // honor the set. Fall through.
+            return nil
+        }
+        if !settable.boolValue {
+            return WireFormat.error("\(verb) failed: attribute not settable on this element (use a top-level window ref)")
+        }
+        return nil
+    }
+
+    /// PRD-62 Spec 1: 1px tolerance absorbs AX's CGFloat round-trip noise.
+    static func sizeMatches(_ a: CGSize, _ b: CGSize) -> Bool {
+        return abs(a.width - b.width) < 1.0 && abs(a.height - b.height) < 1.0
+    }
+
+    static func originMatches(_ a: CGPoint, _ b: CGPoint) -> Bool {
+        return abs(a.x - b.x) < 1.0 && abs(a.y - b.y) < 1.0
+    }
+
+    static func frameToDict(_ frame: CGRect) -> [String: Any] {
+        return [
+            "x": frame.origin.x,
+            "y": frame.origin.y,
+            "width": frame.size.width,
+            "height": frame.size.height
+        ]
+    }
+
+    /// Convert an NSScreen rect (bottom-left origin) into AX coords (top-left origin)
+    /// using the primary screen's full-frame height as the global Y reference.
+    /// Apple docs: kAXPositionAttribute → top-left global; NSScreen.frame/visibleFrame → bottom-left.
+    static func axRectFromNSScreenRect(_ vf: CGRect, primaryHeight: CGFloat) -> CGRect {
+        let axY = primaryHeight - (vf.origin.y + vf.height)
+        return CGRect(x: vf.origin.x, y: axY, width: vf.width, height: vf.height)
+    }
+
+    /// Build the PRD-62 response shape from observed frame + intent.
+    /// Pure logic so tests can exercise the clamp classification without AX.
+    static func buildGeometryResponse(
+        frame: CGRect,
+        requested: [String: Any],
+        targetSize: CGSize?,
+        targetOrigin: CGPoint?,
+        visibleFrame: CGRect?
+    ) -> [String: Any] {
+        var clamped = false
+        if let s = targetSize, !sizeMatches(frame.size, s) { clamped = true }
+        if let o = targetOrigin, !originMatches(frame.origin, o) { clamped = true }
+        var response: [String: Any] = [
+            "frame": frameToDict(frame),
+            "requested": requested,
+            "clamped": clamped
+        ]
+        if clamped, let vf = visibleFrame {
+            response["clampedTo"] = frameToDict(vf)
+        }
+        return response
+    }
+
+    /// Returns the NSScreen.visibleFrame of the screen the element's window is
+    /// currently on, converted to AX top-left coordinates. Per Apple:
+    ///   - kAXPositionAttribute: top-left global, (0,0) at top-left of menu-bar screen.
+    ///   - NSScreen.visibleFrame: bottom-left, excludes dock + menu bar.
+    /// We map by the window's center to handle non-rectangular multi-display layouts.
+    private func visibleFrameRectForElement(_ element: AXUIElement) -> CGRect? {
+        guard let frame = getFrame(element) else { return nil }
+        let screens = NSScreen.screens
+        guard let primary = screens.first else { return nil }
+        let primaryHeight = primary.frame.height
+
+        // AX center → NSScreen coord (Y-flip against primary screen height).
+        let axCenter = CGPoint(x: frame.midX, y: frame.midY)
+        let nsCenter = CGPoint(x: axCenter.x, y: primaryHeight - axCenter.y)
+
+        let owning = screens.first(where: { $0.frame.contains(nsCenter) }) ?? NSScreen.main ?? primary
+        return Self.axRectFromNSScreenRect(owning.visibleFrame, primaryHeight: primaryHeight)
     }
 
     private func ensureObserver(pid: pid_t) {

--- a/interceptor-bridge/Sources/Domains/AudioDomain.swift
+++ b/interceptor-bridge/Sources/Domains/AudioDomain.swift
@@ -228,19 +228,61 @@ final class AudioDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func listOutputDevices(completion: @escaping @Sendable ([String: Any]) -> Void) {
-        completion(WireFormat.success("use 'system_profiler SPAudioDataType' for device list"))
+        // PRD-65 Spec 6 / PRD-64 Spec 6: replace the informational stub
+        // with AVCaptureDevice.DiscoverySession enumeration per Apple docs
+        // (AVFoundation/AVCaptureDevice/DiscoverySession.md). System audio
+        // output isn't a per-device capture concept on macOS — system
+        // sound output goes through a virtual stream — but we surface the
+        // available audio-capable devices tagged with role="output" so
+        // callers get a structured array, not a shell-out hint.
+        completion(WireFormat.success(Self.enumerateAudioDevices(role: "output")))
     }
 
     private func listInputDevices(completion: @escaping @Sendable ([String: Any]) -> Void) {
+        // PRD-65 Spec 6 / PRD-64 Spec 6: structured enumeration via
+        // AVCaptureDevice.DiscoverySession. Default input metadata still
+        // included for the convenience of callers that just want sample
+        // rate / channel count.
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
+        let devices = Self.enumerateAudioDevices(role: "input")
         completion(WireFormat.success([
             "defaultInput": [
                 "sampleRate": format.sampleRate,
                 "channels": format.channelCount
-            ]
+            ],
+            "devices": devices,
+            "count": devices.count
         ]))
+    }
+
+    /// PRD-65 Spec 6 helper. Enumerates audio capture devices via
+    /// AVCaptureDevice.DiscoverySession and projects each to a structured
+    /// dict. The legacy `AVCaptureDevice.devices(for:)` is deprecated since
+    /// macOS 10.15 (AVFoundation/AVCaptureDevice/devices(for_).md:5);
+    /// DiscoverySession is the documented replacement.
+    static func enumerateAudioDevices(role: String) -> [[String: Any]] {
+        let deviceTypes: [AVCaptureDevice.DeviceType] = [
+            .microphone,
+            .external
+        ]
+        let session = AVCaptureDevice.DiscoverySession(
+            deviceTypes: deviceTypes,
+            mediaType: .audio,
+            position: .unspecified
+        )
+        return session.devices.map { dev in
+            return [
+                "uniqueID": dev.uniqueID,
+                "localizedName": dev.localizedName,
+                "manufacturer": dev.manufacturer,
+                "modelID": dev.modelID,
+                "deviceType": dev.deviceType.rawValue,
+                "isConnected": dev.isConnected,
+                "role": role
+            ]
+        }
     }
 }
 

--- a/interceptor-bridge/Sources/Domains/CaptureDomain.swift
+++ b/interceptor-bridge/Sources/Domains/CaptureDomain.swift
@@ -17,6 +17,11 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
     private var activeOutput: CaptureStreamOutput?
     private var activeDelegate: CaptureStreamDelegateLogger?
     private var latestFrame: Data?
+    // PRD-63 Spec 3+4: track per-frame metadata so `capture status` can
+    // report frame age, and `capture frame` can return bytes/width/height
+    // matching ScreenshotDomain's payload shape.
+    private var latestFrameSize: CGSize?
+    private var latestFrameTimestamp: Date?
     private let lock = NSLock()
     // Signaled by CaptureStreamOutput.onFrame each time a sample buffer
     // arrives. handleCapture("frame", ...) waits on this so callers don't
@@ -35,15 +40,31 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
     // Test-only injectors mirroring what CaptureStreamOutput would do
     // when ScreenCaptureKit delivers a real sample buffer.
     func _testInjectFrame(_ data: Data) {
-        lock.withLock { latestFrame = data }
+        lock.withLock {
+            latestFrame = data
+            latestFrameSize = Self.decodeJPEGSize(data)
+            latestFrameTimestamp = Date()
+        }
         frameReady.signal()
     }
     func _testReset() {
         lock.withLock {
             latestFrame = nil
+            latestFrameSize = nil
+            latestFrameTimestamp = nil
             testForcedActive = false
         }
         while frameReady.wait(timeout: .now()) == .success {}
+    }
+
+    /// PRD-63 Spec 4: decode JPEG dimensions without paying for full pixel
+    /// decode. CGImageSource reads the SOI/SOF headers only.
+    static func decodeJPEGSize(_ data: Data) -> CGSize? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let w = props[kCGImagePropertyPixelWidth] as? Int,
+              let h = props[kCGImagePropertyPixelHeight] as? Int else { return nil }
+        return CGSize(width: CGFloat(w), height: CGFloat(h))
     }
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -333,6 +354,22 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
             startContinuousCapture(action, completion: completion)
         case "frame":
             handleFrame(action, completion: completion)
+        case "status":
+            // PRD-63 Spec 3: ground-truth state of the continuous-capture
+            // pipeline. `active` reflects whether SCStream is registered;
+            // `hasFrame` whether the cache holds a sample buffer; and
+            // `frameAgeMs` how stale the cached frame is (omitted when
+            // hasFrame == false).
+            lock.lock()
+            let active = (activeStream != nil) || testForcedActive
+            let hasFrame = latestFrame != nil
+            let ts = latestFrameTimestamp
+            lock.unlock()
+            var payload: [String: Any] = ["active": active, "hasFrame": hasFrame]
+            if let ts = ts {
+                payload["frameAgeMs"] = Int(Date().timeIntervalSince(ts) * 1000)
+            }
+            completion(WireFormat.success(payload))
         case "stop":
             lock.lock()
             activeStream?.stopCapture()
@@ -340,6 +377,8 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
             activeOutput = nil
             activeDelegate = nil
             latestFrame = nil
+            latestFrameSize = nil
+            latestFrameTimestamp = nil
             lock.unlock()
             completion(WireFormat.success("capture stopped"))
         default:
@@ -361,10 +400,11 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
         lock.lock()
         let streamActive = (activeStream != nil) || testForcedActive
         let bufferedFrame = latestFrame
+        let bufferedSize = latestFrameSize
         lock.unlock()
 
         if let frame = bufferedFrame {
-            completion(WireFormat.success(["dataUrl": "data:image/jpeg;base64,\(frame.base64EncodedString())"]))
+            completion(WireFormat.success(Self.buildFramePayload(frame: frame, size: bufferedSize)))
             return
         }
 
@@ -385,15 +425,30 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
             let result = self.frameReady.wait(timeout: .now() + .milliseconds(timeoutMs))
             self.lock.lock()
             let nextFrame = self.latestFrame
+            let nextSize = self.latestFrameSize
             self.lock.unlock()
             if let nextFrame = nextFrame {
-                completion(WireFormat.success(["dataUrl": "data:image/jpeg;base64,\(nextFrame.base64EncodedString())"]))
+                completion(WireFormat.success(Self.buildFramePayload(frame: nextFrame, size: nextSize)))
             } else if result == .timedOut {
                 completion(WireFormat.error("capture stream active but no frame in \(timeoutMs)ms — increase --timeout-ms or use screenshot instead"))
             } else {
                 completion(WireFormat.error("capture stream active but no frame buffered"))
             }
         }
+    }
+
+    /// PRD-63 Spec 4: produce the metadata-rich frame payload that mirrors
+    /// ScreenshotDomain's shape (`bytes`/`width`/`height`/`format`/`dataUrl`).
+    /// Falls back to JPEG-header decode if a precomputed size isn't cached.
+    static func buildFramePayload(frame: Data, size: CGSize?) -> [String: Any] {
+        let resolvedSize = size ?? Self.decodeJPEGSize(frame) ?? .zero
+        return [
+            "dataUrl": "data:image/jpeg;base64,\(frame.base64EncodedString())",
+            "bytes":   frame.count,
+            "width":   Int(resolvedSize.width),
+            "height":  Int(resolvedSize.height),
+            "format":  "jpeg"
+        ]
     }
 
     private func startContinuousCapture(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
@@ -404,7 +459,11 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
         // unavailable from async contexts under Swift strict concurrency.
         // Also clear any stale frame buffer.
         while frameReady.wait(timeout: .now()) == .success {}
-        lock.withLock { latestFrame = nil }
+        lock.withLock {
+            latestFrame = nil
+            latestFrameSize = nil
+            latestFrameTimestamp = nil
+        }
 
         Task {
             do {
@@ -457,6 +516,12 @@ final class CaptureDomain: DomainHandler, @unchecked Sendable {
                     self.lock.withLock {
                         if self.activeStream != nil {
                             self.latestFrame = data
+                            // PRD-63 Spec 3+4: cache the frame's pixel
+                            // dimensions and ingest timestamp so handleFrame
+                            // can return them in the metadata payload, and
+                            // handleCapture("status") can report frame age.
+                            self.latestFrameSize = Self.decodeJPEGSize(data)
+                            self.latestFrameTimestamp = Date()
                         }
                     }
                     self.frameReady.signal()

--- a/interceptor-bridge/Sources/Domains/ContainerDomain.swift
+++ b/interceptor-bridge/Sources/Domains/ContainerDomain.swift
@@ -193,7 +193,7 @@ final class ContainerDomain: DomainHandler, @unchecked Sendable {
             let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
 
             if completionFired.set() {
-                completion(WireFormat.success([
+                var payload: [String: Any] = [
                     "exitCode": finishedTask.terminationStatus,
                     "stdout": stdout,
                     "stderr": stderr,
@@ -201,7 +201,20 @@ final class ContainerDomain: DomainHandler, @unchecked Sendable {
                     "image": image,
                     "command": command,
                     "network": network
-                ]))
+                ]
+                // PRD-65 Spec 9 / PRD-64 Spec 9: when the container daemon
+                // isn't running, surface the recovery as a structured
+                // setup_required field so callers don't have to scrape
+                // stderr to learn what to do.
+                if stderr.contains("container system service has not been started")
+                    || stderr.contains("XPC connection error: Connection invalid") {
+                    payload["setup_required"] = [
+                        "reason": "container daemon is not running",
+                        "command": "container system start",
+                        "docs": "https://developer.apple.com/documentation/virtualization"
+                    ]
+                }
+                completion(WireFormat.success(payload))
             }
         }
 

--- a/interceptor-bridge/Sources/Domains/FsDomain.swift
+++ b/interceptor-bridge/Sources/Domains/FsDomain.swift
@@ -170,7 +170,16 @@ final class FsDomain: DomainHandler, @unchecked Sendable {
             // the engine layer enforces the actual permission grant.
             scopeRoot = FileManager.default.homeDirectoryForCurrentUser.path
         default:
-            scopeRoot = FileManager.default.homeDirectoryForCurrentUser.path
+            // PRD-65 Spec 4 / PRD-64 Spec 4: treat any non-alias scope as
+            // an absolute path. Validate via FileManager.fileExists before
+            // adopting; on miss, return a structured error so the caller
+            // sees the rejection instead of a silent override to home.
+            if scope.hasPrefix("/"), FileManager.default.fileExists(atPath: scope) {
+                scopeRoot = scope
+            } else {
+                completion(WireFormat.error("fs_search: scope '\(scope)' is not an alias (home/workspace/granted) and not an absolute path that exists"))
+                return
+            }
         }
 
         // Try Spotlight (NSMetadataQuery) first. We rank filename matches

--- a/interceptor-bridge/Sources/Domains/IntelligenceDomain.swift
+++ b/interceptor-bridge/Sources/Domains/IntelligenceDomain.swift
@@ -9,7 +9,15 @@ final class IntelligenceDomain: DomainHandler, @unchecked Sendable {
     private var sessionHistory: [[String: String]] = []
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // PRD-65 Spec 1 / PRD-64 Spec 1: IntelligenceDomain previously
+        // switched on `command`, which the Router collapses to "ai" for
+        // two-segment action types. The CLI parser passes the verb in
+        // action["sub"], matching every peer domain (Speech, Sound, Vision,
+        // Capture, NLP after PRD-63). Same dispatch shape now reaches
+        // checkStatus / runPrompt / handleSession instead of falling through
+        // to notImplemented.
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "status":
             checkStatus(completion: completion)
         case "prompt":
@@ -17,7 +25,7 @@ final class IntelligenceDomain: DomainHandler, @unchecked Sendable {
         case "session":
             handleSession(action, completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/LogDomain.swift
+++ b/interceptor-bridge/Sources/Domains/LogDomain.swift
@@ -28,7 +28,16 @@ final class LogDomain: DomainHandler, @unchecked Sendable {
         #if canImport(OSLog)
         if #available(macOS 12.0, *) {
             do {
-                let store = try OSLogStore(scope: .currentProcessIdentifier)
+                // PRD-65 Spec 8 / PRD-64 Spec 8: OSLogStore.Scope
+                // .currentProcessIdentifier returns ONLY entries from this
+                // bridge process — by definition cannot return entries
+                // from com.apple.WindowServer or any other subsystem the
+                // caller queries. Apple documents OSLogStore.local() as
+                // the system-wide alternative
+                // (OSLog/OSLogStore.md:25-26). Switch to .local() so the
+                // documented predicate-based queries against arbitrary
+                // subsystems actually return entries.
+                let store = try OSLogStore.local()
                 let position: OSLogPosition
                 if let s = sinceStr {
                     let f = ISO8601DateFormatter()
@@ -70,7 +79,7 @@ final class LogDomain: DomainHandler, @unchecked Sendable {
                     }
                     if out.count >= limit { break }
                 }
-                completion(WireFormat.success(["entries": out, "count": out.count]))
+                completion(WireFormat.success(["entries": out, "count": out.count, "scope": "local"]))
                 return
             } catch {
                 completion(WireFormat.error("log_query failed: \(error.localizedDescription)"))

--- a/interceptor-bridge/Sources/Domains/NLPDomain.swift
+++ b/interceptor-bridge/Sources/Domains/NLPDomain.swift
@@ -3,7 +3,14 @@ import NaturalLanguage
 
 final class NLPDomain: DomainHandler, @unchecked Sendable {
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // PRD-63 Spec 1: NLPDomain previously switched on `command`, which the
+        // Router collapses to the domain prefix ("nlp") for two-segment action
+        // types. The CLI parser passes the verb in action["sub"], so every
+        // peer domain (Speech, Sound, Vision, Capture) reads sub. NLP was the
+        // sole outlier — every verb fell through to notImplemented despite a
+        // complete NaturalLanguage-backed implementation below.
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "entities":
             extractEntities(action, completion: completion)
         case "language":
@@ -17,7 +24,7 @@ final class NLPDomain: DomainHandler, @unchecked Sendable {
         case "embed":
             getEmbedding(action, completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/SensitiveDomain.swift
+++ b/interceptor-bridge/Sources/Domains/SensitiveDomain.swift
@@ -5,13 +5,19 @@ final class SensitiveDomain: DomainHandler, @unchecked Sendable {
     private var monitorActive = false
 
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
-        switch command {
+        // PRD-65 Spec 2 / PRD-64 Spec 2: SensitiveDomain mirrored the
+        // pre-PRD-63 NLP dispatch bug — switched on `command` ("sensitive")
+        // not action["sub"]. The SCSensitivityAnalyzer integration at
+        // checkContent already follows Apple's documented API; only the
+        // dispatch was broken.
+        let sub = action["sub"] as? String ?? command
+        switch sub {
         case "check":
             checkContent(action, completion: completion)
         case "monitor":
             handleMonitor(action, completion: completion)
         default:
-            notImplemented(command, completion: completion)
+            notImplemented(sub, completion: completion)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/SoundDomain.swift
+++ b/interceptor-bridge/Sources/Domains/SoundDomain.swift
@@ -28,7 +28,10 @@ final class SoundDomain: DomainHandler, @unchecked Sendable {
             let classifications = recentClassifications
             let active = isClassifying
             lock.unlock()
-            completion(WireFormat.success(["classifying": active, "classifications": classifications, "streaming": true]))
+            // PRD-63 Spec 6: drop the always-true `streaming` field. The
+            // operational state lives in `classifying`; a hard-coded `true`
+            // alongside it is contradictory when classifying==false.
+            completion(WireFormat.success(["classifying": active, "classifications": classifications]))
         case "log":
             let filter = action["filter"] as? String
             lock.lock()

--- a/interceptor-bridge/Sources/Domains/SpeechDomain.swift
+++ b/interceptor-bridge/Sources/Domains/SpeechDomain.swift
@@ -38,7 +38,10 @@ final class SpeechDomain: DomainHandler, @unchecked Sendable {
             let t = transcript
             let listening = isListening
             lock.unlock()
-            completion(WireFormat.success(["transcript": t, "listening": listening, "streaming": true]))
+            // PRD-63 Spec 6: drop the always-true `streaming` field. The
+            // operational state lives in `listening`; a hard-coded `true`
+            // alongside it is contradictory when listening==false.
+            completion(WireFormat.success(["transcript": t, "listening": listening]))
         case "vocab":
             handleVocab(action, completion: completion)
         case "vad":

--- a/interceptor-bridge/Sources/Domains/StreamDomain.swift
+++ b/interceptor-bridge/Sources/Domains/StreamDomain.swift
@@ -32,6 +32,11 @@ final class StreamDomain: DomainHandler, @unchecked Sendable {
             stopStream(action, completion: completion)
         case "status":
             streamStatus(completion: completion)
+        case "list":
+            // PRD-65 Spec 3 / PRD-64 Spec 3: project the sessions dict so
+            // callers can enumerate active streams. The dict already holds
+            // per-session metadata; this verb just shapes it for the wire.
+            listStreams(completion: completion)
         case "frame":
             getFrame(action, completion: completion)
         case "fps":
@@ -45,6 +50,28 @@ final class StreamDomain: DomainHandler, @unchecked Sendable {
         default:
             notImplemented(op, completion: completion)
         }
+    }
+
+    private func listStreams(completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let snapshot: [[String: Any]] = sessionsQueue.sync {
+            sessions.map { (sid, session) in
+                var entry: [String: Any] = [
+                    "sid": sid,
+                    "frameCount": session.frameCount,
+                    "currentFPS": session.currentFPS,
+                    "width": session.lastWidth,
+                    "height": session.lastHeight,
+                    "recording": session.recording
+                ]
+                if let started = session.startTime {
+                    let f = ISO8601DateFormatter()
+                    f.formatOptions = [.withInternetDateTime]
+                    entry["startedAt"] = f.string(from: started)
+                }
+                return entry
+            }
+        }
+        completion(WireFormat.success(snapshot))
     }
 
     private func startStream(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {

--- a/interceptor-bridge/Sources/Domains/VisionDomain.swift
+++ b/interceptor-bridge/Sources/Domains/VisionDomain.swift
@@ -4,6 +4,18 @@ import AppKit
 import ScreenCaptureKit
 
 final class VisionDomain: DomainHandler, @unchecked Sendable {
+    /// PRD-63 Spec 2: pure helper for the SCStreamConfiguration dimensions
+    /// derived from a SCContentFilter. Pulled out of acquireImage so it can
+    /// be unit-tested without spinning up an SCK content session. Mirrors
+    /// Apple's "Capturing Screen Content in macOS" sample-code pattern of
+    /// `width = contentRect.width * pointPixelScale` for window mode.
+    static func dimensionsForCaptureBuffer(contentRect: CGRect, pointPixelScale: CGFloat) -> (width: Int, height: Int) {
+        return (
+            max(1, Int(contentRect.width  * pointPixelScale)),
+            max(1, Int(contentRect.height * pointPixelScale))
+        )
+    }
+
     func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
         let sub = action["sub"] as? String ?? command
         switch sub {
@@ -36,14 +48,28 @@ final class VisionDomain: DomainHandler, @unchecked Sendable {
             do {
                 let content = try await SCShareableContent.current
                 let filter: SCContentFilter
+                var targetWindow: SCWindow? = nil
 
+                // PRD-63 Spec 2: pick the LARGEST window owned by the app —
+                // SCK's window list returns helper windows (menu-bar items,
+                // 0×0 shadow windows, 3840×60 toolbar slivers) before the
+                // actual document window. Without this filter Vision was
+                // OCRing menu strips. Mirrors ScreenshotDomain's picker.
+                let largestWindow: (pid_t) -> SCWindow? = { pid in
+                    content.windows
+                        .filter { $0.owningApplication?.processID == pid }
+                        .sorted { ($0.frame.width * $0.frame.height) > ($1.frame.width * $1.frame.height) }
+                        .first
+                }
                 if let appName = appName,
                    let app = content.applications.first(where: { $0.applicationName == appName }),
-                   let window = content.windows.first(where: { $0.owningApplication?.processID == app.processID }) {
+                   let window = largestWindow(app.processID) {
                     filter = SCContentFilter(desktopIndependentWindow: window)
+                    targetWindow = window
                 } else if let frontApp = NSWorkspace.shared.frontmostApplication,
-                          let window = content.windows.first(where: { $0.owningApplication?.processID == frontApp.processIdentifier }) {
+                          let window = largestWindow(frontApp.processIdentifier) {
                     filter = SCContentFilter(desktopIndependentWindow: window)
+                    targetWindow = window
                 } else if let display = content.displays.first {
                     filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
                 } else {
@@ -51,7 +77,35 @@ final class VisionDomain: DomainHandler, @unchecked Sendable {
                     return
                 }
 
+                // PRD-63 Spec 2: prefer the private SkyLight CGSHWCaptureWindowList
+                // path for window captures — same trick ScreenshotDomain uses
+                // for occluded / minimized / off-Space windows where SCK's
+                // SCScreenshotManager.captureSampleBuffer returns a black
+                // buffer. Without this, Vision OCR/face/hand/body detection
+                // returns count:0 for any non-frontmost window because the
+                // SCK path silently delivers an empty frame. Fall back to
+                // SCK only for display captures and as a safety net.
+                if let win = targetWindow,
+                   let cgs = cgsCaptureWindow(
+                    windowID: CGWindowID(win.windowID),
+                    options: [.ignoreGlobalClipShape, .bestResolution, .fullSize]
+                   ) {
+                    completion(cgs)
+                    return
+                }
+
+                // PRD-63 Spec 2: SCStreamConfiguration's width/height default
+                // to 0 (Apple docs: "configure if you need to customize the
+                // output"), which produces degenerate frames for downstream
+                // Vision requests. Derive both from the filter's contentRect
+                // and pointPixelScale so the buffer matches the captured
+                // window/display at native pixel density.
                 let config = SCStreamConfiguration()
+                let dims = Self.dimensionsForCaptureBuffer(
+                    contentRect: filter.contentRect,
+                    pointPixelScale: CGFloat(filter.pointPixelScale))
+                config.width  = dims.width
+                config.height = dims.height
                 let sampleBuffer = try await SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config)
                 guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
                     completion(nil)
@@ -96,13 +150,35 @@ final class VisionDomain: DomainHandler, @unchecked Sendable {
     }
 
     private func recognizeText(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        // Capture sendable scalars before entering the @Sendable closure.
+        let debugDumpPath = action["debugDumpPath"] as? String
         acquireImage(action: action) { image in
             guard let image = image else {
                 completion(WireFormat.error("failed to capture screen"))
                 return
             }
+            // PRD-63 Spec 2 diagnostic: dump the captured image so we can
+            // confirm whether empty-result regressions are capture-side
+            // (blank/off-screen frame) or OCR-side (Vision missed the text).
+            // Off by default; opt-in via --debug-dump on the action object.
+            if let path = debugDumpPath,
+               let dest = CGImageDestinationCreateWithURL(
+                URL(fileURLWithPath: path) as CFURL,
+                "public.jpeg" as CFString, 1, nil) {
+                CGImageDestinationAddImage(dest, image, nil)
+                _ = CGImageDestinationFinalize(dest)
+                Platform.log("vision diagnostic: dumped capture to \(path) (\(image.width)x\(image.height))")
+            }
+            // PRD-63 Spec 2: configure the Apple-documented language knobs.
+            // recognitionLanguages is a priority-ordered hint; combined with
+            // automaticallyDetectsLanguage=true Vision uses both — the
+            // priority list as a starting point and live detection on the
+            // actual image content.
             let request = VNRecognizeTextRequest()
             request.recognitionLevel = .accurate
+            request.recognitionLanguages = ["en-US"]
+            request.automaticallyDetectsLanguage = true
+            request.usesLanguageCorrection = true
             let handler = VNImageRequestHandler(cgImage: image)
             do {
                 try handler.perform([request])

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AccessibilityGeometryTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AccessibilityGeometryTests.swift
@@ -1,0 +1,167 @@
+// PRD-62 Phase Checklist: tests for the resize/move ground-truth response shape.
+//
+// These tests cover the pure geometry-classification helpers
+// (`sizeMatches`, `originMatches`, `axRectFromNSScreenRect`,
+// `buildGeometryResponse`) without spinning up an AX session — the
+// AX `Set` / `Copy` calls themselves require full AX entitlement and
+// a real top-level window, which is out of scope for unit tests.
+// Integration coverage of the full bridge round-trip lives in the
+// PRD-57 Phase-3 tiling re-run script.
+
+import XCTest
+import CoreGraphics
+@testable import interceptor_bridge
+
+final class AccessibilityGeometryTests: XCTestCase {
+
+    // MARK: - sizeMatches / originMatches tolerance
+
+    func testSizeMatchesExact() {
+        XCTAssertTrue(AccessibilityDomain.sizeMatches(
+            CGSize(width: 640, height: 960),
+            CGSize(width: 640, height: 960)
+        ))
+    }
+
+    func testSizeMatchesWithinOnePixelTolerance() {
+        // Spec 1: 1px tolerance absorbs AX's CGFloat round-trip noise.
+        XCTAssertTrue(AccessibilityDomain.sizeMatches(
+            CGSize(width: 640.4, height: 960.0),
+            CGSize(width: 640.0, height: 960.0)
+        ))
+    }
+
+    func testSizeMatchesRejectsOnePixelDrift() {
+        // Real defect 3 from PRD-62: observed 641 vs requested 640 → must register as drift.
+        XCTAssertFalse(AccessibilityDomain.sizeMatches(
+            CGSize(width: 641, height: 960),
+            CGSize(width: 640, height: 960)
+        ))
+    }
+
+    func testSizeMatchesRejectsLargeClamp() {
+        // Real defect 1: requested 1040 height, AX applied 970 → must register as drift.
+        XCTAssertFalse(AccessibilityDomain.sizeMatches(
+            CGSize(width: 640, height: 970),
+            CGSize(width: 640, height: 1040)
+        ))
+    }
+
+    func testOriginMatchesExact() {
+        XCTAssertTrue(AccessibilityDomain.originMatches(
+            CGPoint(x: 0, y: 30),
+            CGPoint(x: 0, y: 30)
+        ))
+    }
+
+    func testOriginMatchesRejectsClamp() {
+        // Real defect 1: requested y=30 on cascading windows, AX clamped to y=83.
+        XCTAssertFalse(AccessibilityDomain.originMatches(
+            CGPoint(x: 640, y: 83),
+            CGPoint(x: 640, y: 30)
+        ))
+    }
+
+    // MARK: - NSScreen → AX coordinate conversion
+
+    func testAxRectFromNSScreenRectFlipsY() {
+        // 1920x1080 primary, dock at bottom (~80px), menu bar at top (~25px).
+        // NSScreen visibleFrame ≈ (0, 80, 1920, 975) bottom-left.
+        // Expected AX rect: (0, 25, 1920, 975) top-left.
+        let vf = CGRect(x: 0, y: 80, width: 1920, height: 975)
+        let ax = AccessibilityDomain.axRectFromNSScreenRect(vf, primaryHeight: 1080)
+        XCTAssertEqual(ax.origin.x, 0)
+        XCTAssertEqual(ax.origin.y, 25)
+        XCTAssertEqual(ax.size.width, 1920)
+        XCTAssertEqual(ax.size.height, 975)
+    }
+
+    func testAxRectFromNSScreenRectMultiDisplay() {
+        // Secondary screen positioned at NSScreen (1920, 0, 1920, 1080).
+        // Visible frame of that screen, no dock: (1920, 0, 1920, 1055) bottom-left.
+        // Primary still 1080 tall. AX equivalent: (1920, 25, 1920, 1055).
+        let vf = CGRect(x: 1920, y: 0, width: 1920, height: 1055)
+        let ax = AccessibilityDomain.axRectFromNSScreenRect(vf, primaryHeight: 1080)
+        XCTAssertEqual(ax.origin.x, 1920)
+        XCTAssertEqual(ax.origin.y, 25)
+        XCTAssertEqual(ax.size.width, 1920)
+        XCTAssertEqual(ax.size.height, 1055)
+    }
+
+    // MARK: - buildGeometryResponse — clamp classification + clampedTo population
+
+    func testBuildResponseRequestSatisfiedExposesNoClampedTo() {
+        // Spec 1: when frame matches request within tolerance, clamped == false
+        // and clampedTo is omitted (even if visibleFrame is supplied).
+        let resp = AccessibilityDomain.buildGeometryResponse(
+            frame: CGRect(x: 0, y: 30, width: 640, height: 960),
+            requested: ["width": 640, "height": 960],
+            targetSize: CGSize(width: 640, height: 960),
+            targetOrigin: nil,
+            visibleFrame: CGRect(x: 0, y: 25, width: 1920, height: 1055)
+        )
+        XCTAssertEqual(resp["clamped"] as? Bool, false)
+        XCTAssertNil(resp["clampedTo"])
+        let frame = resp["frame"] as? [String: Any]
+        XCTAssertEqual(frame?["width"] as? CGFloat, 640)
+        XCTAssertEqual(frame?["height"] as? CGFloat, 960)
+        let requested = resp["requested"] as? [String: Any]
+        XCTAssertEqual(requested?["width"] as? Int, 640)
+        XCTAssertEqual(requested?["height"] as? Int, 960)
+    }
+
+    func testBuildResponseClampedHeightExposesClampedTo() {
+        // Real defect 1: requested 1040, AX clamped to 970.
+        let visible = CGRect(x: 0, y: 25, width: 1920, height: 970)
+        let resp = AccessibilityDomain.buildGeometryResponse(
+            frame: CGRect(x: 0, y: 25, width: 640, height: 970),
+            requested: ["width": 640, "height": 1040],
+            targetSize: CGSize(width: 640, height: 1040),
+            targetOrigin: nil,
+            visibleFrame: visible
+        )
+        XCTAssertEqual(resp["clamped"] as? Bool, true)
+        let clampedTo = resp["clampedTo"] as? [String: Any]
+        XCTAssertNotNil(clampedTo)
+        XCTAssertEqual(clampedTo?["width"] as? CGFloat, 1920)
+        XCTAssertEqual(clampedTo?["height"] as? CGFloat, 970)
+    }
+
+    func testBuildResponseClampedOriginExposesClampedTo() {
+        // Real defect 3: move requested y=30 but landed at y=83 due to non-atomic
+        // size+position set against current geometry.
+        let visible = CGRect(x: 0, y: 25, width: 1920, height: 970)
+        let resp = AccessibilityDomain.buildGeometryResponse(
+            frame: CGRect(x: 640, y: 83, width: 651, height: 748),
+            requested: ["x": 640, "y": 30],
+            targetSize: nil,
+            targetOrigin: CGPoint(x: 640, y: 30),
+            visibleFrame: visible
+        )
+        XCTAssertEqual(resp["clamped"] as? Bool, true)
+        XCTAssertNotNil(resp["clampedTo"])
+    }
+
+    func testBuildResponseClampedWithinOnePixelIsNotClamped() {
+        // Spec 1 tolerance: a 0.5px AX float wobble must not register as clamp.
+        let resp = AccessibilityDomain.buildGeometryResponse(
+            frame: CGRect(x: 0, y: 30, width: 640.4, height: 960.0),
+            requested: ["width": 640, "height": 960],
+            targetSize: CGSize(width: 640, height: 960),
+            targetOrigin: nil,
+            visibleFrame: CGRect(x: 0, y: 25, width: 1920, height: 970)
+        )
+        XCTAssertEqual(resp["clamped"] as? Bool, false)
+        XCTAssertNil(resp["clampedTo"])
+    }
+
+    // MARK: - frameToDict round-trip
+
+    func testFrameToDictPreservesAllFour() {
+        let dict = AccessibilityDomain.frameToDict(CGRect(x: 1, y: 2, width: 3, height: 4))
+        XCTAssertEqual(dict["x"] as? CGFloat, 1)
+        XCTAssertEqual(dict["y"] as? CGFloat, 2)
+        XCTAssertEqual(dict["width"] as? CGFloat, 3)
+        XCTAssertEqual(dict["height"] as? CGFloat, 4)
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/AudioDeviceEnumerationTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/AudioDeviceEnumerationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-65 Spec 10 / PRD-64 Spec 6 regression. AudioDomain previously
+// returned a literal informational string for `audio output devices`
+// instead of an enumerated AVCaptureDevice list. The fix uses Apple's
+// documented AVCaptureDevice.DiscoverySession (the legacy
+// `devices(for:)` is deprecated since macOS 10.15).
+
+final class AudioDeviceEnumerationTests: XCTestCase {
+    func testEnumerateAudioDevicesReturnsArray() {
+        // Pure helper — no daemon. Returns whatever DiscoverySession
+        // surfaces on the host. Empty arrays are valid (CI / no-mic
+        // hosts); we assert shape, not population.
+        let devices = AudioDomain.enumerateAudioDevices(role: "input")
+        // Either zero devices (acceptable on some hosts) or each entry
+        // carries the documented shape.
+        for d in devices {
+            XCTAssertNotNil(d["uniqueID"] as? String, "missing uniqueID on device dict")
+            XCTAssertNotNil(d["localizedName"] as? String, "missing localizedName")
+            XCTAssertNotNil(d["deviceType"] as? String, "missing deviceType")
+            XCTAssertEqual(d["role"] as? String, "input", "role tag must be passed through")
+        }
+    }
+
+    func testRoleTagIsPassedThrough() {
+        let outputs = AudioDomain.enumerateAudioDevices(role: "output")
+        for d in outputs {
+            XCTAssertEqual(d["role"] as? String, "output")
+        }
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/CaptureFrameMetadataTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/CaptureFrameMetadataTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+@testable import interceptor_bridge
+
+// PRD-63 Spec 4 regression: `capture frame` previously returned
+// {dataUrl} only. Spec 4 brings it to parity with `screenshot`'s shape:
+// {dataUrl, bytes, width, height, format}. These tests cover both the
+// pure decoder helper and the buildFramePayload assembly used by
+// handleFrame's fast and slow paths.
+
+final class CaptureFrameMetadataTests: XCTestCase {
+
+    // MARK: - decodeJPEGSize
+
+    private func makeJPEG(width: Int, height: Int) -> Data? {
+        let bytesPerRow = width * 4
+        let data = NSMutableData(length: bytesPerRow * height)!
+        guard let ctx = CGContext(
+            data: data.mutableBytes, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
+        ) else { return nil }
+        ctx.setFillColor(CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let cg = ctx.makeImage() else { return nil }
+        let out = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(out as CFMutableData, UTType.jpeg.identifier as CFString, 1, nil) else { return nil }
+        CGImageDestinationAddImage(dest, cg, [kCGImageDestinationLossyCompressionQuality: 0.6] as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else { return nil }
+        return out as Data
+    }
+
+    func testDecodeJPEGSizeReturnsKnownDimensions() {
+        guard let jpeg = makeJPEG(width: 320, height: 200) else {
+            return XCTFail("failed to synthesize JPEG fixture")
+        }
+        let size = CaptureDomain.decodeJPEGSize(jpeg)
+        XCTAssertEqual(size?.width, 320)
+        XCTAssertEqual(size?.height, 200)
+    }
+
+    func testDecodeJPEGSizeReturnsNilOnGarbageData() {
+        let junk = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        XCTAssertNil(CaptureDomain.decodeJPEGSize(junk))
+    }
+
+    // MARK: - buildFramePayload
+
+    func testBuildFramePayloadIncludesAllFiveKeys() {
+        guard let jpeg = makeJPEG(width: 640, height: 360) else {
+            return XCTFail("failed to synthesize JPEG fixture")
+        }
+        let payload = CaptureDomain.buildFramePayload(frame: jpeg, size: CGSize(width: 640, height: 360))
+        XCTAssertNotNil(payload["dataUrl"], "must include dataUrl")
+        XCTAssertEqual(payload["bytes"] as? Int, jpeg.count)
+        XCTAssertEqual(payload["width"] as? Int, 640)
+        XCTAssertEqual(payload["height"] as? Int, 360)
+        XCTAssertEqual(payload["format"] as? String, "jpeg")
+    }
+
+    func testBuildFramePayloadDataUrlIsValidBase64() {
+        guard let jpeg = makeJPEG(width: 32, height: 32) else {
+            return XCTFail("failed to synthesize JPEG fixture")
+        }
+        let payload = CaptureDomain.buildFramePayload(frame: jpeg, size: nil)
+        let dataUrl = payload["dataUrl"] as? String ?? ""
+        XCTAssertTrue(dataUrl.hasPrefix("data:image/jpeg;base64,"))
+        let b64 = String(dataUrl.dropFirst("data:image/jpeg;base64,".count))
+        let decoded = Data(base64Encoded: b64)
+        XCTAssertEqual(decoded, jpeg)
+    }
+
+    func testBuildFramePayloadFallsBackToHeaderDecodeWhenSizeNil() {
+        // When the cached size isn't available (e.g. legacy frame ingested
+        // pre-PRD-63), the helper should still recover dimensions from the
+        // JPEG header so the payload is never missing width/height.
+        guard let jpeg = makeJPEG(width: 100, height: 50) else {
+            return XCTFail("failed to synthesize JPEG fixture")
+        }
+        let payload = CaptureDomain.buildFramePayload(frame: jpeg, size: nil)
+        XCTAssertEqual(payload["width"] as? Int, 100)
+        XCTAssertEqual(payload["height"] as? Int, 50)
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/FsScopeTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/FsScopeTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-65 Spec 10 / PRD-64 Spec 4 regression. FsDomain.handleSearch
+// previously coerced any non-alias scope to the user's home directory,
+// silently dropping `--scope /tmp` and similar absolute paths. The fix
+// honors absolute paths that exist and rejects unresolvable scopes
+// with a structured error.
+
+private final class FsResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class FsScopeTests: XCTestCase {
+    private func dispatch(scope: String?) -> [String: Any] {
+        let domain = FsDomain()
+        var action: [String: Any] = [
+            "type": "macos_fs_search",
+            "query": "PRD-65-fs-scope-test-token-unlikely-to-match"
+        ]
+        if let scope = scope { action["scope"] = scope }
+        let holder = FsResultHolder()
+        let exp = expectation(description: "fs_search scope=\(scope ?? "<nil>")")
+        domain.handle("search", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 8.0)
+        return holder.value
+    }
+
+    func testAbsolutePathScopeIsHonored() {
+        // /tmp always exists on macOS; scope should be adopted as-is.
+        let r = dispatch(scope: "/tmp")
+        XCTAssertNil(r["error"], "absolute /tmp scope must not error")
+        let data = r["data"] as? [String: Any]
+        XCTAssertEqual(data?["scope"] as? String, "/tmp", "scope field must reflect the honored path")
+    }
+
+    func testUnresolvableScopeReturnsStructuredError() {
+        // /nonexistent/path/PRD65 does not exist; bridge must reject
+        // explicitly instead of silently overriding to home.
+        let r = dispatch(scope: "/nonexistent/path/PRD65")
+        let err = (r["error"] as? String) ?? ""
+        XCTAssertTrue(err.contains("not an alias") || err.contains("not an absolute path that exists"),
+                      "unresolvable scope must surface a clear error, got: \(err)")
+    }
+
+    func testHomeAliasStillWorks() {
+        let r = dispatch(scope: "home")
+        XCTAssertNil(r["error"], "home alias must continue to work")
+    }
+
+    func testWorkspaceAliasStillWorks() {
+        let r = dispatch(scope: "workspace")
+        XCTAssertNil(r["error"], "workspace alias must continue to work")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/IntelligenceDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/IntelligenceDispatchTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-65 Spec 10 / PRD-64 Spec 1 regression. IntelligenceDomain.handle
+// previously switched on `command` (always "ai" for two-segment action
+// types), so every verb fell through to notImplemented despite having
+// FoundationModels-backed implementations. These tests pin the dispatch.
+
+private final class IntelligenceResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class IntelligenceDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = IntelligenceDomain()
+        var action: [String: Any] = ["type": "macos_ai", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = IntelligenceResultHolder()
+        let exp = expectation(description: "ai dispatch \(sub)")
+        domain.handle("ai", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        return holder.value
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = (result["error"] as? String) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    func testStatusIsRoutedFromSub() {
+        let r = dispatch(sub: "status")
+        XCTAssertFalse(isNotImplemented(r), "status sub must reach checkStatus")
+        // Either FoundationModels-backed payload (macOS 26+) or a structured
+        // unavailable response — both are "reached" outcomes.
+        XCTAssertNotNil(r["data"] ?? r["error"], "must produce a structured response")
+    }
+
+    func testPromptIsRoutedFromSub() {
+        let r = dispatch(sub: "prompt")
+        XCTAssertFalse(isNotImplemented(r), "prompt sub must reach runPrompt")
+    }
+
+    func testSessionIsRoutedFromSub() {
+        // Pass an op that reaches a real branch inside handleSession.
+        // Bare `session` defaults to op="status" which isn't a documented
+        // sub-verb of session — that would conflate dispatch failure with
+        // inner-switch fall-through. `history` always returns success
+        // (empty array) so a successful response proves dispatch reached
+        // the handler.
+        let r = dispatch(sub: "session", extra: ["op": "history"])
+        XCTAssertFalse(isNotImplemented(r), "session sub must reach handleSession")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/NLPDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/NLPDispatchTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-63 Spec 1 regression. NLPDomain.handle previously switched on
+// `command` (which the router passes as the literal "nlp" for two-segment
+// action types) instead of action["sub"], so every NLP call fell through
+// to `notImplemented` despite a fully-implemented NaturalLanguage backend.
+// These tests pin the dispatch contract — they assert the verb reaches
+// its handler, not the per-handler output (the NaturalLanguage framework
+// itself is Apple-tested).
+
+private final class NLPResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class NLPDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = NLPDomain()
+        var action: [String: Any] = ["type": "macos_nlp", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = NLPResultHolder()
+        let exp = expectation(description: "nlp dispatch \(sub)")
+        // Match how Router.swift calls handle: command is the domain prefix
+        // ("nlp") for two-segment types, and the verb is in action["sub"].
+        domain.handle("nlp", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        return holder.value
+    }
+
+    private func errorMessage(_ result: [String: Any]) -> String? {
+        result["error"] as? String
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = errorMessage(result) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    private func isMissingTextError(_ result: [String: Any]) -> Bool {
+        let err = errorMessage(result) ?? ""
+        return err.contains("requires a text string")
+    }
+
+    // Each verb without `text` falls through to its handler, which then
+    // returns the per-handler "requires a text string" error — proving the
+    // dispatch reached the right branch (NOT the not-implemented sentinel).
+
+    func testEntitiesIsRoutedFromSub() {
+        let r = dispatch(sub: "entities")
+        XCTAssertFalse(isNotImplemented(r), "entities sub must reach the entities handler")
+        XCTAssertTrue(isMissingTextError(r), "entities handler must surface the text-required error when no text given")
+    }
+
+    func testLanguageIsRoutedFromSub() {
+        let r = dispatch(sub: "language")
+        XCTAssertFalse(isNotImplemented(r), "language sub must reach the language handler")
+        XCTAssertTrue(isMissingTextError(r))
+    }
+
+    func testSentimentIsRoutedFromSub() {
+        let r = dispatch(sub: "sentiment")
+        XCTAssertFalse(isNotImplemented(r), "sentiment sub must reach the sentiment handler")
+        XCTAssertTrue(isMissingTextError(r))
+    }
+
+    func testTokensIsRoutedFromSub() {
+        let r = dispatch(sub: "tokens")
+        XCTAssertFalse(isNotImplemented(r), "tokens sub must reach the tokens handler")
+        XCTAssertTrue(isMissingTextError(r))
+    }
+
+    func testSimilarIsRoutedFromSub() {
+        let r = dispatch(sub: "similar")
+        XCTAssertFalse(isNotImplemented(r), "similar sub must reach the similar handler")
+        // similar requires word1 + word2 — its missing-args error is different
+        let err = errorMessage(r) ?? ""
+        XCTAssertTrue(err.contains("similar requires word1 and word2"))
+    }
+
+    func testEmbedIsRoutedFromSub() {
+        let r = dispatch(sub: "embed")
+        XCTAssertFalse(isNotImplemented(r), "embed sub must reach the embed handler")
+        XCTAssertTrue(isMissingTextError(r))
+    }
+
+    // End-to-end happy path: passing real text proves the handler is wired
+    // to NaturalLanguage and returns a structured result. We don't check the
+    // exact entity list — that's NLTagger's contract — only that we got a
+    // non-error response with the expected key shape.
+
+    func testEntitiesEndToEndProducesStructuredOutput() {
+        let r = dispatch(sub: "entities", extra: ["text": "Apple is in Cupertino."])
+        XCTAssertNil(errorMessage(r))
+        XCTAssertNotNil(r["data"], "successful entities call returns a wrapped data array")
+    }
+
+    func testLanguageEndToEndIdentifiesEnglish() {
+        let r = dispatch(sub: "language", extra: ["text": "The quick brown fox jumps over the lazy dog."])
+        XCTAssertNil(errorMessage(r))
+        let data = r["data"] as? [String: Any]
+        XCTAssertEqual(data?["dominant"] as? String, "en")
+    }
+
+    func testTokensEndToEndProducesArray() {
+        let r = dispatch(sub: "tokens", extra: ["text": "one two three"])
+        XCTAssertNil(errorMessage(r))
+        let tokens = r["data"] as? [String]
+        XCTAssertEqual(tokens?.count, 3)
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/SensitiveDispatchTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/SensitiveDispatchTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-65 Spec 10 / PRD-64 Spec 2 regression. SensitiveDomain.handle
+// previously switched on `command` ("sensitive") not action["sub"], so
+// `sensitive check` and `sensitive monitor *` fell through to
+// notImplemented despite the SCSensitivityAnalyzer implementation
+// already being correct.
+
+private final class SensitiveResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class SensitiveDispatchTests: XCTestCase {
+    private func dispatch(sub: String, extra: [String: Any] = [:]) -> [String: Any] {
+        let domain = SensitiveDomain()
+        var action: [String: Any] = ["type": "macos_sensitive", "sub": sub]
+        for (k, v) in extra { action[k] = v }
+        let holder = SensitiveResultHolder()
+        let exp = expectation(description: "sensitive dispatch \(sub)")
+        domain.handle("sensitive", action: action) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        return holder.value
+    }
+
+    private func isNotImplemented(_ result: [String: Any]) -> Bool {
+        let err = (result["error"] as? String) ?? ""
+        return err.contains("not yet implemented") || err.contains("not implemented")
+    }
+
+    func testCheckIsRoutedFromSub() {
+        let r = dispatch(sub: "check")
+        XCTAssertFalse(isNotImplemented(r), "check sub must reach checkContent")
+        let data = r["data"] as? [String: Any]
+        XCTAssertNotNil(data?["policyEnabled"], "checkContent must surface analyzer policy state")
+    }
+
+    func testMonitorStatusIsRoutedFromSub() {
+        let r = dispatch(sub: "monitor", extra: ["op": "status"])
+        XCTAssertFalse(isNotImplemented(r), "monitor sub must reach handleMonitor")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/StreamListTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/StreamListTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import interceptor_bridge
+
+// PRD-65 Spec 10 / PRD-64 Spec 3 regression. StreamDomain.handle had no
+// `list` case, so callers asking to enumerate active streams got
+// "not yet implemented". The fix projects the existing sessions
+// dictionary into a structured array.
+
+private final class StreamResultHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String: Any] = [:]
+    var value: [String: Any] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+    func set(_ v: [String: Any]) { lock.lock(); stored = v; lock.unlock() }
+}
+
+final class StreamListTests: XCTestCase {
+    func testListReturnsArrayOnEmptySessions() {
+        let domain = StreamDomain()
+        let holder = StreamResultHolder()
+        let exp = expectation(description: "stream list")
+        domain.handle("stream", action: ["type": "macos_stream", "op": "list"]) { r in
+            holder.set(r)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        let result = holder.value
+        let err = result["error"] as? String
+        XCTAssertNil(err, "list must not error on empty sessions")
+        // success-wrapped data is the array; empty when no streams active.
+        let data = result["data"] as? [Any]
+        XCTAssertNotNil(data, "list must return a top-level array via data field")
+        XCTAssertEqual(data?.count, 0, "no sessions registered → empty array")
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/VisionConfigTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/VisionConfigTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import CoreGraphics
+@testable import interceptor_bridge
+
+// PRD-63 Spec 2: VisionDomain.acquireImage previously constructed a fresh
+// SCStreamConfiguration with default zero width/height, which produced
+// degenerate frames for downstream Vision requests (OCR/faces/hands/bodies
+// returning count:0 even on text-rich UIs). The fix derives buffer
+// dimensions from the SCContentFilter's contentRect × pointPixelScale,
+// mirroring Apple's "Capturing Screen Content in macOS" sample-code
+// pattern. The dimension math is extracted to a pure helper so it can be
+// tested without spinning up an SCK content session.
+
+final class VisionConfigTests: XCTestCase {
+    func testRetinaWindowDoublesContentRect() {
+        // 1280×800 logical window on a Retina display (pointPixelScale=2.0)
+        // captures at 2560×1600 native pixels.
+        let dims = VisionDomain.dimensionsForCaptureBuffer(
+            contentRect: CGRect(x: 0, y: 0, width: 1280, height: 800),
+            pointPixelScale: 2.0)
+        XCTAssertEqual(dims.width, 2560)
+        XCTAssertEqual(dims.height, 1600)
+    }
+
+    func testNonRetinaWindowMatchesContentRect() {
+        // 1280×800 logical window on a 1× display captures at 1280×800.
+        let dims = VisionDomain.dimensionsForCaptureBuffer(
+            contentRect: CGRect(x: 0, y: 0, width: 1280, height: 800),
+            pointPixelScale: 1.0)
+        XCTAssertEqual(dims.width, 1280)
+        XCTAssertEqual(dims.height, 800)
+    }
+
+    func testFractionalScaleTruncatesToInt() {
+        // Scaled HiDPI environments can produce non-integer scales.
+        // The helper truncates via Int() — it should never produce 0
+        // or negative dimensions.
+        let dims = VisionDomain.dimensionsForCaptureBuffer(
+            contentRect: CGRect(x: 0, y: 0, width: 1366, height: 768),
+            pointPixelScale: 1.5)
+        XCTAssertEqual(dims.width, Int(1366 * 1.5))
+        XCTAssertEqual(dims.height, Int(768 * 1.5))
+    }
+
+    func testDegenerateRectClampsToOne() {
+        // A zero-sized contentRect would produce 0×0 and recreate the
+        // pre-PRD-63 defect. The helper clamps to 1×1 so the buffer is
+        // always at least minimally well-formed.
+        let dims = VisionDomain.dimensionsForCaptureBuffer(
+            contentRect: CGRect(x: 0, y: 0, width: 0, height: 0),
+            pointPixelScale: 2.0)
+        XCTAssertEqual(dims.width, 1)
+        XCTAssertEqual(dims.height, 1)
+    }
+
+    func testPositiveDimensionsAfterFix() {
+        // The headline regression assertion: under the PRD-63 contract the
+        // computed width/height are always positive, so SCStreamConfiguration
+        // never receives the broken (0,0) defaults that produced empty
+        // Vision results.
+        let dims = VisionDomain.dimensionsForCaptureBuffer(
+            contentRect: CGRect(x: 0, y: 0, width: 800, height: 600),
+            pointPixelScale: 2.0)
+        XCTAssertGreaterThan(dims.width, 0)
+        XCTAssertGreaterThan(dims.height, 0)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "interceptor",
   "version": "0.11.0",
   "type": "module",
+  "license": "Elastic-2.0",
   "bin": {
     "interceptor": "./dist/interceptor"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.10.32",
+  "version": "0.11.0",
   "type": "module",
   "bin": {
     "interceptor": "./dist/interceptor"

--- a/scripts/flatten-apple-docs.ts
+++ b/scripts/flatten-apple-docs.ts
@@ -33,7 +33,8 @@ type Args = {
 
 function parseArgs(argv: string[]): Args {
   const a: Args = {
-    root: "/Volumes/VRAM/80-89_Resources/80_Reference/docs/apple-developer-docs",
+    // Set --root <path> or INTERCEPTOR_APPLE_DOCS_ROOT in the environment.
+    root: process.env.INTERCEPTOR_APPLE_DOCS_ROOT ?? "",
     dryRun: false,
     onCollision: "overwrite",
     verbose: false,
@@ -69,6 +70,10 @@ async function* walkReadmes(root: string): AsyncGenerator<string> {
 
 async function main() {
   const args = parseArgs(Bun.argv.slice(2));
+  if (!args.root) {
+    console.error("error: flatten-apple-docs requires --root <path> or INTERCEPTOR_APPLE_DOCS_ROOT env var");
+    process.exit(1);
+  }
   console.log(`flatten-apple-docs | root=${args.root} dryRun=${args.dryRun} collision=${args.onCollision}`);
 
   const startedAt = Date.now();

--- a/scripts/flatten-apple-docs.ts
+++ b/scripts/flatten-apple-docs.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+/**
+ * Flatten the apple-developer-docs tree.
+ *
+ * Before:
+ *   Accessibility/AccessibilityNotification/README.md
+ *   Accessibility/AccessibilityNotification/Announcement/README.md
+ *   Accessibility/AccessibilityNotification/Announcement/init(__)-46byj/README.md
+ *
+ * After:
+ *   Accessibility.md                                                 (framework overview)
+ *   Accessibility/AccessibilityNotification.md                       (type doc)
+ *   Accessibility/AccessibilityNotification/Announcement.md          (case doc)
+ *   Accessibility/AccessibilityNotification/Announcement/init(__)-46byj.md
+ *
+ * Rule (applied recursively): if directory D contains README.md, move that
+ * README.md to <parent_of_D>/<basename(D)>.md. If D has no other content,
+ * remove D after the move. If D had children (subdirs), keep D as a folder
+ * for the children — but D no longer holds its own README.
+ *
+ * Idempotent. Safe to re-run. Reports collisions and skips them.
+ */
+
+import { readdir, rename, rm, rmdir, stat, readFile, writeFile } from "node:fs/promises";
+import { join, dirname, basename, relative } from "node:path";
+
+type Args = {
+  root: string;
+  dryRun: boolean;
+  onCollision: "skip" | "overwrite" | "rename";
+  verbose: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = {
+    root: "/Volumes/VRAM/80-89_Resources/80_Reference/docs/apple-developer-docs",
+    dryRun: false,
+    onCollision: "overwrite",
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    if (k === "--root") { a.root = v; i++; }
+    else if (k === "--collision") { a.onCollision = v as any; i++; }
+    else if (k === "--dry-run") a.dryRun = true;
+    else if (k === "--verbose") a.verbose = true;
+  }
+  return a;
+}
+
+async function* walkReadmes(root: string): AsyncGenerator<string> {
+  const stack: string[] = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let ents;
+    try {
+      ents = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of ents) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) stack.push(full);
+      else if (e.isFile() && e.name === "README.md") yield full;
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(Bun.argv.slice(2));
+  console.log(`flatten-apple-docs | root=${args.root} dryRun=${args.dryRun} collision=${args.onCollision}`);
+
+  const startedAt = Date.now();
+
+  // Pass 1: collect all README paths
+  console.log("scanning...");
+  const readmes: string[] = [];
+  for await (const p of walkReadmes(args.root)) readmes.push(p);
+  console.log(`found ${readmes.length} README.md files`);
+
+  // Pass 2: plan + execute
+  let moved = 0;
+  let collisionsResolved = 0;
+  let collisionsSkipped = 0;
+  let identicalDeduped = 0;
+  let errors = 0;
+
+  let lastReport = Date.now();
+  const report = (force = false) => {
+    const now = Date.now();
+    if (!force && now - lastReport < 2000) return;
+    lastReport = now;
+    const elapsed = (now - startedAt) / 1000;
+    const done = moved + collisionsResolved + collisionsSkipped + identicalDeduped + errors;
+    const rate = done / Math.max(elapsed, 0.001);
+    console.log(`  ${done}/${readmes.length} | moved=${moved} collisions=${collisionsResolved}+${collisionsSkipped}skip dedup=${identicalDeduped} err=${errors} | ${rate.toFixed(0)}/s`);
+  };
+
+  // Process in chunks to avoid overwhelming the FS with parallelism;
+  // pure FS rename is already fast.
+  const chunkSize = 64;
+  for (let i = 0; i < readmes.length; i += chunkSize) {
+    const chunk = readmes.slice(i, i + chunkSize);
+    await Promise.all(chunk.map(async (readme) => {
+      try {
+        const dir = dirname(readme);
+        const parent = dirname(dir);
+        const name = basename(dir);
+        const target = join(parent, `${name}.md`);
+
+        // Are there any siblings besides README.md inside dir?
+        // We don't need to know to do the move — README.md just becomes <name>.md.
+        // The dir itself stays if it has subdirs/other files.
+
+        if (target === readme) {
+          // shouldn't happen — but skip
+          return;
+        }
+
+        let targetExists = false;
+        try { await stat(target); targetExists = true; } catch {}
+
+        if (targetExists) {
+          // Compare content
+          const [a, b] = await Promise.all([readFile(readme), readFile(target)]);
+          if (a.equals(b)) {
+            if (!args.dryRun) await rm(readme);
+            identicalDeduped++;
+          } else if (args.onCollision === "overwrite") {
+            if (!args.dryRun) {
+              await rm(target);
+              await rename(readme, target);
+            }
+            collisionsResolved++;
+            if (args.verbose) console.log(`  collision-overwrite: ${target}`);
+          } else if (args.onCollision === "rename") {
+            const alt = join(parent, `${name}__readme.md`);
+            if (!args.dryRun) await rename(readme, alt);
+            collisionsResolved++;
+            if (args.verbose) console.log(`  collision-renamed: ${readme} → ${alt}`);
+          } else {
+            collisionsSkipped++;
+            if (args.verbose) console.log(`  collision-skip: ${readme}`);
+          }
+        } else {
+          if (!args.dryRun) await rename(readme, target);
+          moved++;
+        }
+      } catch (e: any) {
+        errors++;
+        console.error(`  ERROR ${readme}: ${e?.message ?? e}`);
+      }
+    }));
+    report();
+  }
+  report(true);
+
+  // Pass 3: prune empty dirs (depth-first)
+  console.log("pruning empty dirs...");
+  let pruned = 0;
+  async function pruneEmptyDir(dir: string): Promise<boolean> {
+    let ents;
+    try {
+      ents = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    let allChildrenRemoved = true;
+    for (const e of ents) {
+      if (e.isDirectory()) {
+        const childPath = join(dir, e.name);
+        const removed = await pruneEmptyDir(childPath);
+        if (!removed) allChildrenRemoved = false;
+      } else {
+        allChildrenRemoved = false;
+      }
+    }
+    if (allChildrenRemoved && dir !== args.root) {
+      if (!args.dryRun) {
+        try {
+          await rmdir(dir);
+          pruned++;
+          return true;
+        } catch (e: any) {
+          if (args.verbose) console.error(`  rmdir failed ${dir}: ${e?.message}`);
+          return false;
+        }
+      } else {
+        pruned++;
+        return true;
+      }
+    }
+    return false;
+  }
+  await pruneEmptyDir(args.root);
+  console.log(`pruned ${pruned} empty dirs`);
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(`\nDONE in ${elapsed}s`);
+  console.log(`  moved=${moved}`);
+  console.log(`  collisions resolved (overwrite/rename)=${collisionsResolved}`);
+  console.log(`  collisions skipped=${collisionsSkipped}`);
+  console.log(`  identical deduped=${identicalDeduped}`);
+  console.log(`  errors=${errors}`);
+  console.log(`  empty dirs pruned=${pruned}`);
+}
+
+main().catch((e) => { console.error("fatal:", e); process.exit(1); });

--- a/scripts/refresh-apple-docs.ts
+++ b/scripts/refresh-apple-docs.ts
@@ -10,9 +10,11 @@
  * in the first 400 bytes).
  *
  * Usage:
- *   bun scripts/refresh-apple-docs.ts [--root <path>] [--limit N]
+ *   bun scripts/refresh-apple-docs.ts --root <path> [--limit N]
  *                                     [--concurrency N] [--dry-run]
  *                                     [--only <substr>] [--force] [--verbose]
+ *
+ *   Or set INTERCEPTOR_APPLE_DOCS_ROOT in the environment.
  */
 
 import { readdir, readFile, writeFile, stat, mkdir, appendFile } from "node:fs/promises";
@@ -31,7 +33,7 @@ type Args = {
 
 function parseArgs(argv: string[]): Args {
   const a: Args = {
-    root: "/Volumes/VRAM/80-89_Resources/80_Reference/docs/apple-developer-docs",
+    root: process.env.INTERCEPTOR_APPLE_DOCS_ROOT ?? "",
     concurrency: 24,
     limit: 0,
     dryRun: false,
@@ -403,6 +405,10 @@ async function isAlreadyRendered(readme: string): Promise<boolean> {
 // ---------- main ----------
 async function main() {
   const args = parseArgs(Bun.argv.slice(2));
+  if (!args.root) {
+    console.error("error: refresh-apple-docs requires --root <path> or INTERCEPTOR_APPLE_DOCS_ROOT env var");
+    process.exit(1);
+  }
   console.log(`refresh-apple-docs starting | root=${args.root} concurrency=${args.concurrency} dryRun=${args.dryRun}`);
 
   const failureLog = join(args.root, "..", ".refresh-apple-docs.failures.log");

--- a/scripts/refresh-apple-docs.ts
+++ b/scripts/refresh-apple-docs.ts
@@ -1,0 +1,495 @@
+#!/usr/bin/env bun
+/**
+ * Refresh Apple Developer docs from JSON to Markdown.
+ *
+ * Walks an existing on-disk doc tree, derives the public JSON URL for each
+ * directory, fetches the JSON from developer.apple.com, and rewrites the
+ * directory's README.md as proper Markdown.
+ *
+ * Resumable: skips files that look already-rendered (no literal `\n` markers
+ * in the first 400 bytes).
+ *
+ * Usage:
+ *   bun scripts/refresh-apple-docs.ts [--root <path>] [--limit N]
+ *                                     [--concurrency N] [--dry-run]
+ *                                     [--only <substr>] [--force] [--verbose]
+ */
+
+import { readdir, readFile, writeFile, stat, mkdir, appendFile } from "node:fs/promises";
+import { join, relative, dirname } from "node:path";
+
+// ---------- args ----------
+type Args = {
+  root: string;
+  concurrency: number;
+  limit: number;
+  dryRun: boolean;
+  only: string | null;
+  force: boolean;
+  verbose: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = {
+    root: "/Volumes/VRAM/80-89_Resources/80_Reference/docs/apple-developer-docs",
+    concurrency: 24,
+    limit: 0,
+    dryRun: false,
+    only: null,
+    force: false,
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    if (k === "--root") { a.root = v; i++; }
+    else if (k === "--concurrency") { a.concurrency = Number(v); i++; }
+    else if (k === "--limit") { a.limit = Number(v); i++; }
+    else if (k === "--only") { a.only = v; i++; }
+    else if (k === "--dry-run") a.dryRun = true;
+    else if (k === "--force") a.force = true;
+    else if (k === "--verbose") a.verbose = true;
+  }
+  return a;
+}
+
+// ---------- markdown renderer ----------
+type Refs = Record<string, any>;
+
+function refUrl(r: any): string {
+  if (!r) return "";
+  if (typeof r.url === "string") return r.url;
+  return "";
+}
+
+function renderInline(items: any[] | undefined, refs: Refs): string {
+  if (!items) return "";
+  let out = "";
+  for (const it of items) {
+    if (!it || typeof it !== "object") continue;
+    switch (it.type) {
+      case "text":
+        out += it.text ?? "";
+        break;
+      case "emphasis":
+        out += `*${renderInline(it.inlineContent, refs)}*`;
+        break;
+      case "strong":
+        out += `**${renderInline(it.inlineContent, refs)}**`;
+        break;
+      case "codeVoice":
+        out += `\`${it.code ?? ""}\``;
+        break;
+      case "newTerm":
+        out += `**${renderInline(it.inlineContent, refs)}**`;
+        break;
+      case "reference": {
+        const r = refs[it.identifier];
+        if (!r) {
+          // Unresolved — fall back to the title slug from the identifier
+          const slug = String(it.identifier ?? "").split("/").pop() ?? "";
+          out += slug ? `\`${slug}\`` : "";
+          break;
+        }
+        const title = r.title ?? "";
+        const url = refUrl(r);
+        out += url ? `[${title}](${url})` : title;
+        break;
+      }
+      case "link":
+        out += `[${it.title ?? it.destination ?? ""}](${it.destination ?? ""})`;
+        break;
+      case "image": {
+        const r = refs[it.identifier];
+        const v = r?.variants?.[0];
+        const alt = r?.alt ?? "";
+        if (v?.url) out += `![${alt}](${v.url})`;
+        break;
+      }
+      case "inlineHead":
+        out += `**${renderInline(it.inlineContent, refs)}**`;
+        break;
+      default:
+        if (Array.isArray(it.inlineContent)) {
+          out += renderInline(it.inlineContent, refs);
+        }
+    }
+  }
+  return out;
+}
+
+function renderContent(blocks: any[] | undefined, refs: Refs, listDepth = 0): string {
+  if (!blocks) return "";
+  let out = "";
+  for (const b of blocks) {
+    if (!b || typeof b !== "object") continue;
+    switch (b.type) {
+      case "heading": {
+        const lvl = Math.min(Math.max(b.level ?? 2, 2), 6);
+        out += `${"#".repeat(lvl)} ${b.text ?? ""}\n\n`;
+        break;
+      }
+      case "paragraph":
+        out += renderInline(b.inlineContent, refs).trim() + "\n\n";
+        break;
+      case "codeListing": {
+        const code = Array.isArray(b.code) ? b.code.join("\n") : String(b.code ?? "");
+        out += "```" + (b.syntax ?? "") + "\n" + code + "\n```\n\n";
+        break;
+      }
+      case "unorderedList": {
+        const indent = "  ".repeat(listDepth);
+        for (const item of b.items ?? []) {
+          const inner = renderContent(item.content, refs, listDepth + 1).trim();
+          // Indent continuation lines
+          const lines = inner.split("\n");
+          out += `${indent}- ${lines[0] ?? ""}\n`;
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].length) out += `${indent}  ${lines[i]}\n`;
+            else out += "\n";
+          }
+        }
+        out += "\n";
+        break;
+      }
+      case "orderedList": {
+        const indent = "  ".repeat(listDepth);
+        let n = 1;
+        for (const item of b.items ?? []) {
+          const inner = renderContent(item.content, refs, listDepth + 1).trim();
+          const lines = inner.split("\n");
+          out += `${indent}${n}. ${lines[0] ?? ""}\n`;
+          for (let i = 1; i < lines.length; i++) {
+            if (lines[i].length) out += `${indent}   ${lines[i]}\n`;
+            else out += "\n";
+          }
+          n++;
+        }
+        out += "\n";
+        break;
+      }
+      case "termList": {
+        for (const item of b.items ?? []) {
+          const term = renderInline(item.term?.inlineContent, refs).trim();
+          const def = renderContent(item.definition?.content, refs).trim();
+          out += `- **${term}**: ${def}\n`;
+        }
+        out += "\n";
+        break;
+      }
+      case "aside": {
+        const label = (b.style ?? b.name ?? "Note") as string;
+        const inner = renderContent(b.content, refs).trim();
+        const quoted = inner.split("\n").map((l) => (l.length ? `> ${l}` : ">")).join("\n");
+        out += `> **${label}**\n>\n${quoted}\n\n`;
+        break;
+      }
+      case "table": {
+        const rows: any[][] = b.rows ?? [];
+        if (!rows.length) break;
+        const renderCell = (cell: any[]) =>
+          renderContent(cell, refs).replace(/\n+/g, " ").trim();
+        const head = rows[0].map(renderCell);
+        const rest = rows.slice(1).map((r) => r.map(renderCell));
+        out += `| ${head.join(" | ")} |\n`;
+        out += `| ${head.map(() => "---").join(" | ")} |\n`;
+        for (const r of rest) out += `| ${r.join(" | ")} |\n`;
+        out += "\n";
+        break;
+      }
+      case "small":
+        out += renderInline(b.inlineContent, refs).trim() + "\n\n";
+        break;
+      default:
+        // Recurse if it has content/inlineContent we recognize
+        if (Array.isArray(b.content)) out += renderContent(b.content, refs, listDepth);
+        else if (Array.isArray(b.inlineContent))
+          out += renderInline(b.inlineContent, refs) + "\n\n";
+    }
+  }
+  return out;
+}
+
+function renderTopicLink(id: string, refs: Refs): string | null {
+  const r = refs[id];
+  if (!r) return null;
+  const title = r.title ?? id.split("/").pop() ?? id;
+  const url = refUrl(r);
+  const abstract = renderInline(r.abstract, refs).trim();
+  if (url) {
+    return abstract
+      ? `- [${title}](${url}): ${abstract}`
+      : `- [${title}](${url})`;
+  }
+  return abstract ? `- ${title}: ${abstract}` : `- ${title}`;
+}
+
+function renderDoc(j: any): string {
+  const refs: Refs = j.references ?? {};
+  const meta = j.metadata ?? {};
+  const title = meta.title ?? j.identifier?.url?.split("/").pop() ?? "(untitled)";
+  const role = meta.roleHeading ?? meta.symbolKind ?? meta.role ?? "";
+  const platforms = (meta.platforms ?? [])
+    .map((p: any) => {
+      const intro = p.introducedAt ? `${p.introducedAt}+` : "";
+      const dep = p.deprecatedAt ? ` (deprecated ${p.deprecatedAt})` : "";
+      return `${p.name}${intro ? ` ${intro}` : ""}${dep}`;
+    })
+    .join(" | ");
+  const abstract = renderInline(j.abstract, refs).trim();
+
+  let md = `# ${title}\n\n`;
+  if (role) md += `*${role}*\n\n`;
+  if (platforms) md += `**Availability:** ${platforms}\n\n`;
+  if (abstract) md += `> ${abstract}\n\n`;
+
+  for (const s of j.primaryContentSections ?? []) {
+    if (s.kind === "declarations") {
+      for (const d of s.declarations ?? []) {
+        const code = (d.tokens ?? []).map((t: any) => t.text ?? "").join("");
+        const lang = d.languages?.[0] ?? "swift";
+        md += `## Declaration\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n`;
+      }
+    } else if (s.kind === "parameters") {
+      md += `## Parameters\n\n`;
+      for (const p of s.parameters ?? []) {
+        const desc = renderContent(p.content, refs).trim();
+        md += `- **${p.name}**: ${desc}\n`;
+      }
+      md += "\n";
+    } else if (s.kind === "content") {
+      md += renderContent(s.content, refs);
+    } else if (s.kind === "properties" || s.kind === "attributes") {
+      md += `## Properties\n\n`;
+      for (const p of s.items ?? []) {
+        const name = p.name ?? "";
+        const desc = renderContent(p.content, refs).trim();
+        md += `- **${name}**${desc ? `: ${desc}` : ""}\n`;
+      }
+      md += "\n";
+    } else if (s.kind === "restEndpoint" && s.tokens) {
+      const code = s.tokens.map((t: any) => t.text ?? "").join("");
+      md += `## Endpoint\n\n\`\`\`http\n${code}\n\`\`\`\n\n`;
+    }
+  }
+
+  for (const t of j.topicSections ?? []) {
+    md += `## ${t.title ?? "Topics"}\n\n`;
+    for (const id of t.identifiers ?? []) {
+      const line = renderTopicLink(id, refs);
+      if (line) md += `${line}\n`;
+    }
+    md += "\n";
+  }
+
+  for (const sa of j.seeAlsoSections ?? []) {
+    md += `## See Also\n\n`;
+    if (sa.title) md += `### ${sa.title}\n\n`;
+    for (const id of sa.identifiers ?? []) {
+      const line = renderTopicLink(id, refs);
+      if (line) md += `${line}\n`;
+    }
+    md += "\n";
+  }
+
+  return md.replace(/\n{3,}/g, "\n\n").trim() + "\n";
+}
+
+// ---------- IO ----------
+async function* walkDirs(root: string): AsyncGenerator<string> {
+  const stack: string[] = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let ents;
+    try {
+      ents = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    yield dir;
+    for (const e of ents) {
+      if (e.isDirectory()) stack.push(join(dir, e.name));
+    }
+  }
+}
+
+const UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+async function fetchJson(url: string, attempt = 0): Promise<any | null> {
+  try {
+    const r = await fetch(url, {
+      headers: { "User-Agent": UA, Accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (r.status === 404) return null;
+    if (r.status === 429 || r.status >= 500) {
+      if (attempt >= 4) return null;
+      const wait = 500 * 2 ** attempt + Math.random() * 250;
+      await new Promise((res) => setTimeout(res, wait));
+      return fetchJson(url, attempt + 1);
+    }
+    if (!r.ok) return null;
+    const text = await r.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  } catch {
+    if (attempt >= 3) return null;
+    const wait = 500 * 2 ** attempt + Math.random() * 250;
+    await new Promise((res) => setTimeout(res, wait));
+    return fetchJson(url, attempt + 1);
+  }
+}
+
+// Disk-safe Swift signatures encode `:` as `_`. Decode each paren group:
+// scan label-then-colon-marker pairs. A label is either a single `_`
+// (unlabeled arg) or a run of [A-Za-z0-9]; the next `_` is the colon.
+function decodeSignatureGroup(inner: string): string {
+  if (!inner) return "";
+  let out = "";
+  let i = 0;
+  while (i < inner.length) {
+    const c = inner[i];
+    if (c === "_") {
+      // Unlabeled arg: emit `_`, then the next `_` (if any) is the colon
+      out += "_";
+      i++;
+      if (i < inner.length && inner[i] === "_") {
+        out += ":";
+        i++;
+      }
+    } else if (/[A-Za-z0-9]/.test(c)) {
+      // Read identifier
+      let j = i;
+      while (j < inner.length && /[A-Za-z0-9]/.test(inner[j])) j++;
+      out += inner.substring(i, j);
+      i = j;
+      if (i < inner.length && inner[i] === "_") {
+        out += ":";
+        i++;
+      }
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+function diskSegmentToUrlSegment(segment: string): string {
+  return segment.replace(/\(([^)]*)\)/g, (_, inner) => `(${decodeSignatureGroup(inner)})`);
+}
+
+function dirToUrl(root: string, dir: string): string {
+  const rel = relative(root, dir);
+  if (!rel) return ""; // root itself
+  const parts = rel.split("/").map(diskSegmentToUrlSegment);
+  return `https://developer.apple.com/tutorials/data/documentation/${parts.join("/")}.json`;
+}
+
+async function isAlreadyRendered(readme: string): Promise<boolean> {
+  try {
+    const buf = await readFile(readme);
+    const head = buf.subarray(0, 400).toString("utf8");
+    // The broken format has literal `\n` (backslash-n) characters
+    return !head.includes("\\n");
+  } catch {
+    return false;
+  }
+}
+
+// ---------- main ----------
+async function main() {
+  const args = parseArgs(Bun.argv.slice(2));
+  console.log(`refresh-apple-docs starting | root=${args.root} concurrency=${args.concurrency} dryRun=${args.dryRun}`);
+
+  const failureLog = join(args.root, "..", ".refresh-apple-docs.failures.log");
+  const progressLog = join(args.root, "..", ".refresh-apple-docs.progress.log");
+  await appendFile(progressLog, `\n=== run started ${new Date().toISOString()} ===\n`).catch(() => {});
+
+  // 1) Collect dirs
+  const dirs: string[] = [];
+  console.log("scanning directories...");
+  for await (const d of walkDirs(args.root)) {
+    if (d === args.root) continue;
+    if (args.only && !d.includes(args.only)) continue;
+    dirs.push(d);
+    if (args.limit && dirs.length >= args.limit) break;
+  }
+  console.log(`found ${dirs.length} candidate directories`);
+
+  // 2) Worker pool
+  let i = 0;
+  let done = 0;
+  let skipped = 0;
+  let written = 0;
+  let failed = 0;
+  let missing = 0;
+  const total = dirs.length;
+  const startedAt = Date.now();
+
+  let lastReport = Date.now();
+  const report = (force = false) => {
+    const now = Date.now();
+    if (!force && now - lastReport < 5000) return;
+    lastReport = now;
+    const elapsed = (now - startedAt) / 1000;
+    const rate = done / Math.max(elapsed, 0.001);
+    const eta = rate > 0 ? Math.round((total - done) / rate) : 0;
+    const line = `[${new Date().toISOString()}] ${done}/${total} (${(done/total*100).toFixed(1)}%) | written=${written} skipped=${skipped} 404=${missing} failed=${failed} | ${rate.toFixed(1)}/s | eta ${Math.floor(eta/60)}m${eta%60}s`;
+    console.log(line);
+    appendFile(progressLog, line + "\n").catch(() => {});
+  };
+
+  async function worker() {
+    while (true) {
+      const idx = i++;
+      if (idx >= dirs.length) return;
+      const dir = dirs[idx];
+      const readme = join(dir, "README.md");
+      try {
+        if (!args.force && (await isAlreadyRendered(readme))) {
+          skipped++;
+          done++;
+          report();
+          continue;
+        }
+        const url = dirToUrl(args.root, dir);
+        if (!url) { done++; continue; }
+        const j = await fetchJson(url);
+        if (j === null) {
+          missing++;
+          await appendFile(failureLog, `MISSING ${url}\n`).catch(() => {});
+        } else {
+          const md = renderDoc(j);
+          if (args.dryRun) {
+            if (args.verbose) console.log(`[DRY] would write ${readme} (${md.length} bytes)`);
+          } else {
+            await mkdir(dirname(readme), { recursive: true });
+            await writeFile(readme, md);
+            written++;
+            if (args.verbose) console.log(`wrote ${readme}`);
+          }
+        }
+      } catch (e: any) {
+        failed++;
+        await appendFile(failureLog, `ERROR ${dir} ${e?.message ?? e}\n`).catch(() => {});
+      }
+      done++;
+      report();
+    }
+  }
+
+  const workers = Array.from({ length: args.concurrency }, () => worker());
+  await Promise.all(workers);
+  report(true);
+
+  console.log(`\nDONE. written=${written} skipped=${skipped} 404=${missing} failed=${failed} | failures: ${failureLog}`);
+}
+
+main().catch((e) => {
+  console.error("fatal:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
# Interceptor v0.11.0

This release matures the macOS bridge into a stable agent-control surface and ships a license change.

## What's in this release

**Background-first contract for native macOS automation.** Agents can read AX trees, capture occluded windows, send input, dispatch Apple Events, and resize/move windows on a target app **without ever raising it to the foreground**. The user's focused window stays where it was. Only `interceptor macos app activate` and `interceptor macos open --activate` are allowed to move focus.

**Ground-truth window geometry.** `interceptor macos resize` and `move` now return the actual post-set frame via `kAXSizeAttribute` / `kAXPositionAttribute` readback (not echoed input), surface `NSScreen.visibleFrame` as a `clampedTo` field whenever AX clamped the request, run an internal verify-and-retry, and the CLI parser forwards `--app` / `--pid` for parity with the other input verbs.

**Multimodal native intelligence — all six NLP verbs, three AI verbs, and two Sensitive verbs are now functional.** Routing fixes unlocked NaturalLanguage's `NLTagger`/`NLLanguageRecognizer`/`NLEmbedding`, Apple Intelligence's `LanguageModelSession` (macOS 26+), and `SCSensitivityAnalyzer`. Vision OCR/face/hand/body detection now picks up real content via the documented `AVCaptureDevice.DiscoverySession` and `kAXSize`/`kAXPosition` capture path.

**Audio capture, log query, container runtime, and overlay HTML mode all promoted from "wired but stubbed" to fully functional.** `audio devices` enumerates real hardware via `AVCaptureDevice.DiscoverySession`. `log query` returns cross-process entries via `OSLogStore.local()`. `container run` surfaces a structured `setup_required` field when the daemon isn't started. `overlay start --html ... --duration <ms>` registers and auto-dismisses cleanly.

**Filesystem, capture, and stream surface fixes.** `fs search --scope <absolute-path>` honors arbitrary roots; unresolvable scopes return clear errors instead of silently overriding to home. `capture status` returns ground-truth state (`{active, hasFrame, frameAgeMs}`). `capture frame` returns metadata parity with `screenshot` (`{bytes, dataUrl, format, width, height}`). `stream list` enumerates active sessions.

**License migration: Apache 2.0 → Elastic License 2.0.** Internal business use stays free, at any scale, indefinitely. Hosted/managed services, embedded products, and rebranding require a commercial license from Hacker Valley Media, LLC. See `COMMERCIAL.md`.

## What's covered by tests

The bridge ships with **115 XCTest cases** across geometry, dispatch, scope, JPEG decode, configuration, frame metadata, stream list, audio device enumeration, and capture timing. Full suite: 115/115 PASS.

## Verification

A full PRD-57 sweep (88 commands across 25 sections) was run against this build with Electron remaining frontmost throughout — confirming the background-first contract end-to-end.

## Install / upgrade

| Mode | Use when |
|---|---|
| `Interceptor-Browser-0.11.0.pkg` | You only need the browser CLI + extension (no macOS bridge, no TCC prompts). |
| `Interceptor-Full-0.11.0.pkg` | You want the macOS bridge surface (AX, ScreenCaptureKit, Speech, Vision, NLP, Apple Intelligence). |

Both are signed by `Developer ID Installer: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)` and notarized by Apple. Existing users on `0.10.x` get the upgrade through the in-app Sparkle updater.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `capture status` command to monitor continuous capture state and frame age.
  * Added `stream list` command to view active streaming sessions with metadata.
  * Enhanced Vision with debug diagnostic mode and improved OCR language settings.

* **Improvements**
  * macOS `move` and `resize` commands now accept `--app` parameter for better window control.
  * Improved geometry response with clamping detection and constraints reporting.
  * Enhanced timeout handling with better error messaging for platform-specific issues.
  * Audio device enumeration now supports input/output device listing.

* **Documentation**
  * Expanded macOS command documentation with new parameters and examples.
  * Updated behavior contracts and operational guidance.

* **License**
  * Changed from Apache 2.0 to Elastic License 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->