### PR TITLE
fix(cli): respect --json on events non-tail branch

### DIFF
--- a/cli/commands/meta.ts
+++ b/cli/commands/meta.ts
@@ -111,7 +111,11 @@ export async function parseMetaCommand(filtered: string[], jsonMode = false): Pr
           try {
             const event = JSON.parse(line)
             if (since && new Date(event.timestamp).getTime() < since) continue
-            console.log(`${event.timestamp} ${event.event}${event.requestId ? ` [${event.requestId.slice(0, 8)}]` : ""}${event.action ? ` ${event.action}` : ""}${event.duration !== undefined ? ` ${event.duration}ms` : ""}${event.error ? ` error=${event.error}` : ""}`)
+            if (jsonMode) {
+              console.log(line)
+            } else {
+              console.log(`${event.timestamp} ${event.event}${event.requestId ? ` [${event.requestId.slice(0, 8)}]` : ""}${event.action ? ` ${event.action}` : ""}${event.duration !== undefined ? ` ${event.duration}ms` : ""}${event.error ? ` error=${event.error}` : ""}`)
+            }
           } catch {}
         }
       }


### PR DESCRIPTION
Closes the third sub-bug of #74.

`interceptor events --json` (non-tail) was pretty-printing regardless of the global `--json` flag, even though `parseMetaCommand` already receives `jsonMode` plumbed in from `cli/index.ts`. The non-tail loop now consults `jsonMode`: emits the raw NDJSON `line` when true, the pretty-printed summary when false. `--since` filtering still applies to both modes.

Verified locally:
- `bun cli/index.ts events --json` → raw NDJSON, one JSON object per line.
- `bun cli/index.ts events` → `$timestamp $event` pretty output (unchanged).

### Out of scope

The `--tail` branch's documented asymmetry (raw NDJSON via `Bun.spawn("tail -f")` with no text-format path) is unchanged and remains a separate question. Sub-bugs (1) and (2) of #74 were already resolved by the strip-set change in 9075f19 (v0.12.0) — see the issue thread for verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI events command now supports conditional JSON output. Enable it to display raw JSONL data or keep it disabled for formatted human-readable output with timestamps, event details, and duration information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->