### PR TITLE
chore(release): bump to v0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
Patch release for the `events --json` regression on the non-tail branch (closes #74 sub-bug 3).

The functional fix landed in 9eb4db5 (merged via #80). `parseMetaCommand`'s non-tail loop now consults the plumbed `jsonMode` parameter and emits raw NDJSON when `--json` is set; pretty output is preserved when it isn't.

Verified locally on v0.13.1 install:
- `interceptor events --json` → raw NDJSON
- `interceptor events` → pretty
- `interceptor monitor export <sid> --json|--plan|<default>` → all three formats distinct
- `interceptor macos monitor export <sid> --json|--plan|<default>` → all three formats distinct

Sub-bugs (1) and (2) of #74 were already resolved by the strip-set change in 9075f19 (v0.12.0); only the bump and this single fix land here.