### PR TITLE
Interceptor v0.13.4 — Edge + Vivaldi + Linux + bridge resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,3 +1290,5 @@ bash scripts/build.sh # Build compiled host binaries and extension bundles
 - [Ron Eddings](https://github.com/ronaldeddings/) created Interceptor.
 - [Pedram Amini](https://github.com/pedramamini/) provided early feedback on the project. Pedram's platform, [Maestro](https://runmaestro.ai), was used as part of developing this project.
 - [Daniel Miessler](https://github.com/danielmiessler/) for graciously coming up with the name `Interceptor` and EPIC project, [PAI](https://github.com/danielmiessler/PAI))
+- [Klaus Agnoletti](https://github.com/klausagnoletti/) contributed Microsoft Edge and Vivaldi installer support — [PR #75](https://github.com/Hacker-Valley-Media/Interceptor/pull/75).
+- [Alex Tabisz](https://github.com/atabisz/) contributed Linux (browser-only) support and made the macOS CoreGraphics FFI lazy so the daemon imports cleanly on non-Darwin — [PR #83](https://github.com/Hacker-Valley-Media/Interceptor/pull/83).

--- a/bench-head-to-head/config/models.json
+++ b/bench-head-to-head/config/models.json
@@ -1,7 +1,7 @@
 {
   "agent": {
     "provider": "codex",
-    "model": "gpt-5.2",
+    "model": "gpt-5.4",
     "reasoningEffort": "high",
     "sandbox": "danger-full-access",
     "approvalPolicy": "never",
@@ -10,7 +10,7 @@
   },
   "judge": {
     "provider": "codex",
-    "model": "gpt-5.2",
+    "model": "gpt-5.4",
     "reasoningEffort": "high",
     "sandbox": "read-only",
     "approvalPolicy": "never",

--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -20,6 +20,13 @@ export type StatusSnapshot = {
   bridgePid: number | null
   bridgeSocket: string | null
   launchAgentInstalled: boolean
+  // The plist path that's actually on disk (system-scoped preferred when both
+  // exist, since pkg installs land there). Null when neither file exists.
+  launchAgentPath: string | null
+  // True iff `launchctl print gui/<uid>/com.interceptor.bridge` succeeds —
+  // i.e. the plist isn't just on disk, it's actually bootstrapped into the
+  // user's GUI domain. Distinguishes "needs kickstart" from "needs bootstrap".
+  launchAgentLoaded: boolean
   // #52 browser-config block — populated only on macOS in verbose mode
   browser?: {
     configured: ("chrome" | "brave")[]   // browsers with NMH manifest installed
@@ -31,6 +38,30 @@ export type StatusSnapshot = {
     probed: boolean
     reachable: boolean
     reason?: string
+  }
+}
+
+const BRIDGE_LABEL = "com.interceptor.bridge"
+
+/**
+ * Run `launchctl print gui/<uid>/com.interceptor.bridge` and return true iff
+ * the service is actually bootstrapped into the user's GUI domain. A plist
+ * file sitting in ~/Library/LaunchAgents/ or /Library/LaunchAgents/ does NOT
+ * mean it's loaded — the pkg postinstall's `launchctl bootstrap` call can
+ * (and does) fail silently when the GUI session isn't reachable. This is the
+ * difference between "kickstart" being the right fix and "bootstrap" being
+ * the right fix.
+ */
+export function isLaunchAgentLoaded(uid: number): boolean {
+  if (process.platform !== "darwin") return false
+  try {
+    const result = spawnSync("launchctl", ["print", `gui/${uid}/${BRIDGE_LABEL}`], {
+      encoding: "utf-8",
+      stdio: ["ignore", "ignore", "ignore"],
+    })
+    return result.status === 0
+  } catch {
+    return false
   }
 }
 
@@ -56,7 +87,17 @@ export function readStatusSnapshot(): StatusSnapshot {
   const BRIDGE_SOCK_PATH = "/tmp/interceptor-bridge.sock"
   const LAUNCH_AGENT_PATH_USER = `${process.env.HOME || ""}/Library/LaunchAgents/com.interceptor.bridge.plist`
   const LAUNCH_AGENT_PATH_SYSTEM = "/Library/LaunchAgents/com.interceptor.bridge.plist"
-  const launchAgentInstalled = !IS_WIN && (existsSync(LAUNCH_AGENT_PATH_USER) || existsSync(LAUNCH_AGENT_PATH_SYSTEM))
+  const userPlistPresent = !IS_WIN && existsSync(LAUNCH_AGENT_PATH_USER)
+  const systemPlistPresent = !IS_WIN && existsSync(LAUNCH_AGENT_PATH_SYSTEM)
+  const launchAgentInstalled = userPlistPresent || systemPlistPresent
+  // Prefer the system plist when both exist — that's the pkg-install path,
+  // and it's the path the user's hint needs to reference for bootstrap.
+  const launchAgentPath = systemPlistPresent
+    ? LAUNCH_AGENT_PATH_SYSTEM
+    : (userPlistPresent ? LAUNCH_AGENT_PATH_USER : null)
+  const launchAgentLoaded = launchAgentInstalled && process.getuid
+    ? isLaunchAgentLoaded(process.getuid())
+    : false
   const bridgeSockExists = !IS_WIN && existsSync(BRIDGE_SOCK_PATH)
   let bridgePid: number | null = null
   let bridgeAlive = false
@@ -90,7 +131,48 @@ export function readStatusSnapshot(): StatusSnapshot {
     bridgePid,
     bridgeSocket: bridgeSockExists ? BRIDGE_SOCK_PATH : null,
     launchAgentInstalled,
+    launchAgentPath,
+    launchAgentLoaded,
   }
+}
+
+/**
+ * Pure function — compute the bridge-section hint lines from a snapshot.
+ * Extracted so it can be unit-tested without spawning launchctl. Called from
+ * formatStatus. Returns [] when the bridge is healthy and nothing needs to
+ * be said.
+ */
+export function computeBridgeHint(input: {
+  bridge: boolean
+  mode: StatusSnapshot["mode"]
+  launchAgentInstalled: boolean
+  launchAgentLoaded: boolean
+  launchAgentPath: string | null
+}): string[] {
+  if (input.bridge) return []
+  if (input.mode === "unknown") {
+    // Bridge alive but plist file missing — handled by the caller already
+    // (mode === "unknown" implies bridge is alive). Defensive default.
+    return [
+      "  note: bridge is alive but no LaunchAgent plist found at ~/Library/LaunchAgents/com.interceptor.bridge.plist or /Library/LaunchAgents/com.interceptor.bridge.plist.",
+      "        Run 'interceptor upgrade --full' to install the LaunchAgent for persistence.",
+    ]
+  }
+  if (input.launchAgentInstalled && !input.launchAgentLoaded) {
+    const path = input.launchAgentPath ?? "/Library/LaunchAgents/com.interceptor.bridge.plist"
+    return [
+      `  hint: LaunchAgent plist is on disk at ${path} but is NOT bootstrapped into your gui/$(id -u) domain — the pkg postinstall's bootstrap call likely failed (common when the installer ran without an aqua-session ancestor).`,
+      `        Fix: launchctl bootstrap gui/$(id -u) ${path}`,
+      "        Then: launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge",
+      "        Or simpler: log out and back in — macOS auto-loads /Library/LaunchAgents/ at login.",
+    ]
+  }
+  if (input.launchAgentInstalled && input.launchAgentLoaded) {
+    return ["  hint: LaunchAgent is loaded but bridge is not running. Try: launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge"]
+  }
+  // launchAgentInstalled === false, mode === "full" — shouldn't be reachable
+  // (mode === "full" implies launchAgentInstalled), but kept for completeness.
+  return []
 }
 
 /**
@@ -180,11 +262,14 @@ export function formatStatus(snap: StatusSnapshot, opts: { verbose?: boolean }):
     }
     if (snap.bridgePid) lines.push(`  pid: ${snap.bridgePid}`)
     lines.push(`  socket: ${snap.bridgeSocket ?? "not found"}`)
-    if (snap.mode === "unknown") {
-      lines.push("  note: bridge is alive but no LaunchAgent plist found at ~/Library/LaunchAgents/com.interceptor.bridge.plist or /Library/LaunchAgents/com.interceptor.bridge.plist.")
-      lines.push("        Run 'interceptor upgrade --full' to install the LaunchAgent for persistence.")
-    } else if (!snap.bridge) {
-      lines.push("  hint: LaunchAgent installed but bridge is not running. Try: launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge")
+    for (const line of computeBridgeHint({
+      bridge: snap.bridge,
+      mode: snap.mode,
+      launchAgentInstalled: snap.launchAgentInstalled,
+      launchAgentLoaded: snap.launchAgentLoaded,
+      launchAgentPath: snap.launchAgentPath,
+    })) {
+      lines.push(line)
     }
   } else if (!IS_WIN) {
     lines.push("")
@@ -245,6 +330,8 @@ export function snapshotToJson(snap: StatusSnapshot): Record<string, unknown> {
     bridgePid: snap.bridgePid,
     bridgeSocket: snap.bridgeSocket,
     launchAgentInstalled: snap.launchAgentInstalled,
+    launchAgentPath: snap.launchAgentPath,
+    launchAgentLoaded: snap.launchAgentLoaded,
   }
   if (snap.browser) base.browser = snap.browser
   if (snap.extension) base.extension = snap.extension

--- a/daemon/bridge-recovery.ts
+++ b/daemon/bridge-recovery.ts
@@ -150,11 +150,20 @@ export function getBridgeRecoveryActions(layout: BridgeRecoveryLayout, exists: E
   return actions
 }
 
-export function formatBridgeUnavailableError(layout: BridgeRecoveryLayout): string {
+export function formatBridgeUnavailableError(
+  layout: BridgeRecoveryLayout,
+  opts: { launchAgentLoaded?: boolean } = {},
+): string {
   if (layout.mode === "browser-only") {
     return "Interceptor macOS control requires a full install. Run `interceptor upgrade --full`."
   }
   if (layout.mode === "full-install") {
+    // Plist file on disk but never bootstrapped into launchd: kickstart will
+    // fail with "Could not find service ... in domain". Tell the user to
+    // bootstrap, not kickstart.
+    if (layout.launchAgentInstalled && opts.launchAgentLoaded === false && layout.launchAgentPath) {
+      return `Interceptor bridge is not reachable. The LaunchAgent plist at ${layout.launchAgentPath} is on disk but is NOT bootstrapped into your gui/$(id -u) domain (the pkg postinstall's bootstrap likely failed silently). Fix: \`launchctl bootstrap gui/$(id -u) ${layout.launchAgentPath} && launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge\`, or log out and back in.`
+    }
     return "Interceptor bridge is not reachable. Run `interceptor status` and restart `com.interceptor.bridge` with `launchctl kickstart -k gui/$(id -u)/com.interceptor.bridge`."
   }
   return "Interceptor bridge is not reachable from this source checkout. Run `bash scripts/build-bridge.sh && bash scripts/install-bridge.sh`."

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -1,5 +1,5 @@
 import { unlinkSync, existsSync, appendFileSync, statSync, readFileSync, writeFileSync } from "node:fs"
-import { spawn } from "node:child_process"
+import { spawn, spawnSync } from "node:child_process"
 import { osClick, osKey, osType, osMove, generateBezierPath, translateCoords } from "./os-input-loader"
 import { IS_WIN, SOCKET_PATH, IPC_PORT, PID_PATH, LOG_PATH, EVENTS_PATH, WS_PORT, EVENTS_MAX_SIZE, transportLabel } from "../shared/platform"
 import {
@@ -49,6 +49,25 @@ function readBridgeRecoveryLayout() {
     importMetaUrl: import.meta.url,
     uid: typeof process.getuid === "function" ? process.getuid() : null,
   })
+}
+
+// Probe whether the bridge LaunchAgent is actually bootstrapped into the
+// user's GUI domain. A plist file existing on disk doesn't mean it's loaded —
+// pkg postinstalls can (and do) fail the bootstrap call silently, leaving the
+// agent unregistered. Distinguishes "user should kickstart" from "user must
+// bootstrap first". Returns false on non-darwin or when the probe fails.
+function isLaunchAgentBootstrapped(): boolean {
+  if (process.platform !== "darwin") return false
+  if (typeof process.getuid !== "function") return false
+  try {
+    const result = spawnSync("launchctl", ["print", `gui/${process.getuid()}/com.interceptor.bridge`], {
+      encoding: "utf-8",
+      stdio: ["ignore", "ignore", "ignore"],
+    })
+    return result.status === 0
+  } catch {
+    return false
+  }
 }
 
 async function waitForBridgeSocket(timeoutMs: number): Promise<boolean> {
@@ -888,7 +907,7 @@ try {
                 } else {
                   socketWriteFramed(socket, JSON.stringify({
                     id,
-                    result: { success: false, error: formatBridgeUnavailableError(readBridgeRecoveryLayout()) },
+                    result: { success: false, error: formatBridgeUnavailableError(readBridgeRecoveryLayout(), { launchAgentLoaded: isLaunchAgentBootstrapped() }) },
                   }))
                 }
               })

--- a/daemon/os-input.ts
+++ b/daemon/os-input.ts
@@ -2,7 +2,15 @@ import { dlopen, FFIType } from "bun:ffi"
 
 const CG_PATH = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
 
-const cg = dlopen(CG_PATH, {
+// PR #83:CoreGraphics is macOS-only. Loading it on Linux throws
+// ERR_DLOPEN_FAILED at module load time and crashes the daemon before the
+// native-messaging handshake (port 19222 stays unbound; extension reports
+// "native host disconnected"). Gating the dlopen lets this module import
+// cleanly on Linux; each exported os* function short-circuits to UNSUPPORTED
+// below.
+const IS_DARWIN = process.platform === "darwin"
+
+const cg = IS_DARWIN ? dlopen(CG_PATH, {
   CGEventCreateMouseEvent: {
     args: [FFIType.ptr, FFIType.i32, FFIType.f64, FFIType.f64, FFIType.i32],
     returns: FFIType.ptr,
@@ -39,7 +47,9 @@ const cg = dlopen(CG_PATH, {
     args: [FFIType.ptr],
     returns: FFIType.void,
   },
-})
+}) : null
+
+const UNSUPPORTED = { success: false as const, error: "act --os not supported on this platform (macOS only)" }
 
 const kCGHIDEventTap = 0
 const kCGSessionEventTap = 1
@@ -79,7 +89,7 @@ function getSource(): number | null {
     // `isTrusted: true` user input. The previous value
     // kCGEventSourceStateCombinedSessionState (0) is for observing the merged
     // session stream — events posted from that source land on the page but
-    // are not treated as trusted by Chromium, which made `--os` clicks
+    // are not treated as trusted by Chromium, which made `--trusted` clicks
     // silently fail any `event.isTrusted` gate (e.g. bench S8 Trusted Input
     // Gate; the bench's prior S8 PASS rate came from agent hallucination,
     // not from the click actually flipping the page state).
@@ -89,7 +99,7 @@ function getSource(): number | null {
   return eventSource
 }
 
-const sym = cg.symbols as Record<string, (...args: any[]) => any>
+const sym = (cg ? cg.symbols : {}) as Record<string, (...args: any[]) => any>
 
 function createMouseEvent(type: number, x: number, y: number, button: number = kCGMouseButtonLeft): number | null {
   const src = getSource()
@@ -125,6 +135,7 @@ export async function osClick(
   button: "left" | "right" = "left",
   clickCount: number = 1
 ): Promise<{ success: boolean; error?: string }> {
+  if (!IS_DARWIN) return UNSUPPORTED
   try {
     const isRight = button === "right"
     const cgButton = isRight ? kCGMouseButtonRight : kCGMouseButtonLeft
@@ -192,6 +203,7 @@ export async function osKey(
   key: string,
   modifiers: string[] = []
 ): Promise<{ success: boolean; error?: string }> {
+  if (!IS_DARWIN) return UNSUPPORTED
   try {
     const keyCode = KEY_MAP[key] ?? KEY_MAP[key.toLowerCase()]
     if (keyCode === undefined) {
@@ -260,6 +272,7 @@ export async function osKey(
 }
 
 export async function osType(text: string): Promise<{ success: boolean; error?: string }> {
+  if (!IS_DARWIN) return UNSUPPORTED
   try {
     for (const char of text) {
       const keyCode = KEY_MAP[char] ?? KEY_MAP[char.toLowerCase()]
@@ -291,8 +304,17 @@ export async function osType(text: string): Promise<{ success: boolean; error?: 
       } else {
         const down = createKeyboardEvent(0, true)
         if (!down) continue
-        const encoded = new Uint16Array([char.charCodeAt(0)])
-        sym.CGEventKeyboardSetUnicodeString(down, 1, encoded)
+        // PR #83:encode the full UTF-16 code-unit sequence of the
+        // iterated grapheme. `for…of` yields one code point per iteration,
+        // which is 1 UTF-16 code unit for BMP characters and 2 (surrogate
+        // pair) for astral-plane characters / emoji. Apple's
+        // keyboardSetUnicodeString takes `stringLength` in UniChar
+        // (UTF-16 code units) per CoreGraphics/CGEvent/
+        // keyboardSetUnicodeString(stringLength_unicodeString_).md:12 —
+        // sending length=1 for an astral pair dropped the trailing
+        // surrogate and produced a mojibake codepoint.
+        const encoded = Uint16Array.from({ length: char.length }, (_, i) => char.charCodeAt(i))
+        sym.CGEventKeyboardSetUnicodeString(down, encoded.length, encoded)
         postEvent(down)
         releaseEvent(down)
 
@@ -300,7 +322,7 @@ export async function osType(text: string): Promise<{ success: boolean; error?: 
 
         const up = createKeyboardEvent(0, false)
         if (up) {
-          sym.CGEventKeyboardSetUnicodeString(up, 1, encoded)
+          sym.CGEventKeyboardSetUnicodeString(up, encoded.length, encoded)
           postEvent(up)
           releaseEvent(up)
         }
@@ -319,6 +341,7 @@ export async function osMove(
   points: Array<{ x: number; y: number }>,
   durationMs: number = 100
 ): Promise<{ success: boolean; error?: string }> {
+  if (!IS_DARWIN) return UNSUPPORTED
   try {
     if (points.length === 0) return { success: false, error: "empty path" }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.10.8",
+  "version": "0.13.4",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,13 +13,17 @@ $template | ConvertTo-Json -Depth 10 | Set-Content -Path $GeneratedManifest -NoN
 
 $chromeKey = 'HKCU:\Software\Google\Chrome\NativeMessagingHosts\com.interceptor.host'
 $braveKey = 'HKCU:\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.interceptor.host'
+$edgeKey  = 'HKCU:\Software\Microsoft\Edge\NativeMessagingHosts\com.interceptor.host'
 
 New-Item -Path $chromeKey -Force | Out-Null
 Set-ItemProperty -Path $chromeKey -Name '(default)' -Value $GeneratedManifest
 New-Item -Path $braveKey -Force | Out-Null
 Set-ItemProperty -Path $braveKey -Name '(default)' -Value $GeneratedManifest
+New-Item -Path $edgeKey -Force | Out-Null
+Set-ItemProperty -Path $edgeKey -Name '(default)' -Value $GeneratedManifest
 
 Write-Host "Installed manifest registry keys:"
 Write-Host "  Chrome: $chromeKey"
 Write-Host "  Brave:  $braveKey"
+Write-Host "  Edge:   $edgeKey"
 Write-Host "Manifest: $GeneratedManifest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,75 @@ GENERATED_MANIFEST="$GENERATED_DIR/com.interceptor.host.json"
 EXTENSION_DIR="$ROOT/extension/dist"
 INSTALL_BRIDGE_SCRIPT="$ROOT/scripts/install-bridge.sh"
 
+# ── Platform detection ────────────────────────────────────────────────────────
+PLATFORM="$(uname -s)"   # Darwin | Linux
+
+# Profile root (Chromium "User Data" dir) for a browser target on this platform.
+# Edge and Vivaldi are Darwin-only in this revision (Linux support deferred to a
+# follow-up PRD; their User Data dirs on Linux are ~/.config/microsoft-edge and
+# ~/.config/vivaldi but install-detection across distros isn't covered yet).
+profile_root_for() {
+  case "$PLATFORM:$1" in
+    Darwin:brave)   echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
+    Darwin:chrome)  echo "$HOME/Library/Application Support/Google/Chrome" ;;
+    Darwin:edge)    echo "$HOME/Library/Application Support/Microsoft Edge" ;;
+    Darwin:vivaldi) echo "$HOME/Library/Application Support/Vivaldi" ;;
+    Linux:brave)    echo "$HOME/.config/BraveSoftware/Brave-Browser" ;;
+    Linux:chrome)   echo "$HOME/.config/google-chrome" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Native messaging hosts dir for a browser target on this platform.
+nm_dir_for() {
+  case "$PLATFORM:$1" in
+    Darwin:brave)   echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
+    Darwin:chrome)  echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts" ;;
+    Darwin:edge)    echo "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts" ;;
+    Darwin:vivaldi) echo "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts" ;;
+    Linux:brave)    echo "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
+    Linux:chrome)   echo "$HOME/.config/google-chrome/NativeMessagingHosts" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Detect whether a browser is installed on this platform. Echoes 1/0.
+browser_installed() {
+  case "$PLATFORM:$1" in
+    Darwin:brave)   [[ -d "/Applications/Brave Browser.app" ]]  && echo 1 || echo 0 ;;
+    Darwin:chrome)  [[ -d "/Applications/Google Chrome.app" ]]  && echo 1 || echo 0 ;;
+    Darwin:edge)    [[ -d "/Applications/Microsoft Edge.app" ]] && echo 1 || echo 0 ;;
+    Darwin:vivaldi) [[ -d "/Applications/Vivaldi.app" ]]        && echo 1 || echo 0 ;;
+    Linux:brave)    command -v brave-browser >/dev/null 2>&1 && echo 1 || echo 0 ;;
+    Linux:chrome)   ( command -v google-chrome >/dev/null 2>&1 \
+                  || command -v google-chrome-stable >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
+    *) echo 0 ;;
+  esac
+}
+
+# Resolve the launchable executable / app reference for a browser target.
+# On macOS this is the .app bundle's main binary (used with `open -a` for the
+# parent bundle and pgrep). On Linux this is the binary basename (used with
+# pgrep + direct exec).
+browser_bin_for() {
+  case "$PLATFORM:$1" in
+    Darwin:brave)   echo "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" ;;
+    Darwin:chrome)  echo "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ;;
+    Darwin:edge)    echo "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" ;;
+    Darwin:vivaldi) echo "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi" ;;
+    Linux:brave)
+      if command -v brave-browser >/dev/null 2>&1; then echo brave-browser
+      else return 1; fi
+      ;;
+    Linux:chrome)
+      if command -v google-chrome >/dev/null 2>&1; then echo google-chrome
+      elif command -v google-chrome-stable >/dev/null 2>&1; then echo google-chrome-stable
+      else return 1; fi
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 # ── Parse flags ────────────────────────────────────────────────────────────────
 SKIP_EXTENSION=0
 BROWSER=""
@@ -21,8 +90,10 @@ while [[ $i -le $# ]]; do
   arg="${!i}"
   case "$arg" in
     --skip-extension) SKIP_EXTENSION=1 ;;
-    --brave)  BROWSER="brave" ;;
-    --chrome) BROWSER="chrome" ;;
+    --brave)   BROWSER="brave" ;;
+    --chrome)  BROWSER="chrome" ;;
+    --edge)    BROWSER="edge" ;;
+    --vivaldi) BROWSER="vivaldi" ;;
     --profile)
       i=$((i + 1))
       PROFILE="${!i}"
@@ -55,6 +126,8 @@ while [[ $i -le $# ]]; do
        echo "Browser:"
        echo "  --brave           Target Brave Browser"
        echo "  --chrome          Target Google Chrome"
+       echo "  --edge            Target Microsoft Edge (macOS only in this revision)"
+       echo "  --vivaldi         Target Vivaldi (macOS only in this revision)"
        echo "  --profile <name>  Profile directory name (e.g. \"Default\", \"Profile 2\")"
        echo "  --profiles        List available profiles and exit"
        echo ""
@@ -69,15 +142,14 @@ done
 # ── List profiles ──────────────────────────────────────────────────────────────
 if [[ "$LIST_PROFILES" == "1" ]]; then
   if [[ -z "$BROWSER" ]]; then
-    if [[ -d "/Applications/Brave Browser.app" ]]; then BROWSER="brave"
-    elif [[ -d "/Applications/Google Chrome.app" ]]; then BROWSER="chrome"
+    if   [[ "$(browser_installed brave)"   == "1" ]]; then BROWSER="brave"
+    elif [[ "$(browser_installed chrome)"  == "1" ]]; then BROWSER="chrome"
+    elif [[ "$(browser_installed edge)"    == "1" ]]; then BROWSER="edge"
+    elif [[ "$(browser_installed vivaldi)" == "1" ]]; then BROWSER="vivaldi"
     fi
   fi
-  case "$BROWSER" in
-    brave)  PROFILE_ROOT="$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
-    chrome) PROFILE_ROOT="$HOME/Library/Application Support/Google/Chrome" ;;
-    *) echo "No supported browser found."; exit 1 ;;
-  esac
+  PROFILE_ROOT="$(profile_root_for "$BROWSER" || true)"
+  if [[ -z "$PROFILE_ROOT" ]]; then echo "No supported browser found."; exit 1; fi
 
   echo "Available profiles:"
   echo ""
@@ -86,12 +158,18 @@ if [[ "$LIST_PROFILES" == "1" ]]; then
   for dir in "$PROFILE_ROOT"/*/; do
     name=$(basename "$dir")
     if [[ -f "$dir/Preferences" ]]; then
-      display=$(plutil -extract profile.name raw -o - "$dir/Preferences" 2>/dev/null || echo "(unknown)")
+      if [[ "$PLATFORM" == "Darwin" ]] && command -v plutil >/dev/null 2>&1; then
+        display=$(plutil -extract profile.name raw -o - "$dir/Preferences" 2>/dev/null || echo "(unknown)")
+      else
+        display=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("profile",{}).get("name","(unknown)"))' "$dir/Preferences" 2>/dev/null || echo "(unknown)")
+      fi
       printf "  %-20s %s\n" "$name" "$display"
     fi
   done
   echo ""
   echo "Usage: bash scripts/install.sh --brave --profile \"Profile 2\""
+  echo "       bash scripts/install.sh --edge --profiles"
+  echo "       bash scripts/install.sh --vivaldi --profiles"
   exit 0
 fi
 
@@ -142,23 +220,29 @@ if [[ "$DRY_RUN" == "1" ]]; then
 fi
 
 # ── Browser resolution ────────────────────────────────────────────────────────
-# If neither --chrome nor --brave was passed, prompt or fall back to a
-# deterministic default in non-interactive contexts. Valid resolved values:
-#   "chrome" | "brave" | "both"
+# If none of --chrome / --brave / --edge / --vivaldi was passed, prompt or fall
+# back to a deterministic default in non-interactive contexts. Valid resolved
+# values: "chrome" | "brave" | "edge" | "vivaldi" | "both" (both = chrome+brave
+# only — preserved from the upstream contract).
 if [[ -z "$BROWSER" ]]; then
-  CHROME_INSTALLED=0
-  BRAVE_INSTALLED=0
-  [[ -d "/Applications/Google Chrome.app" ]] && CHROME_INSTALLED=1
-  [[ -d "/Applications/Brave Browser.app" ]] && BRAVE_INSTALLED=1
+  CHROME_INSTALLED=$(browser_installed chrome)
+  BRAVE_INSTALLED=$(browser_installed brave)
+  EDGE_INSTALLED=$(browser_installed edge)
+  VIVALDI_INSTALLED=$(browser_installed vivaldi)
+  TOTAL_INSTALLED=$(( CHROME_INSTALLED + BRAVE_INSTALLED + EDGE_INSTALLED + VIVALDI_INSTALLED ))
 
-  if (( CHROME_INSTALLED + BRAVE_INSTALLED == 0 )); then
-    echo "ERROR: No supported browser found in /Applications/." >&2
-    echo "       Install Google Chrome or Brave Browser, then re-run." >&2
+  if (( TOTAL_INSTALLED == 0 )); then
+    echo "ERROR: No supported browser found." >&2
+    echo "       Install Chrome, Brave, Edge, or Vivaldi, then re-run." >&2
     exit 1
   fi
 
-  if (( CHROME_INSTALLED + BRAVE_INSTALLED == 1 )); then
-    [[ "$CHROME_INSTALLED" == "1" ]] && BROWSER="chrome" || BROWSER="brave"
+  if (( TOTAL_INSTALLED == 1 )); then
+    if   [[ "$CHROME_INSTALLED"  == "1" ]]; then BROWSER="chrome"
+    elif [[ "$BRAVE_INSTALLED"   == "1" ]]; then BROWSER="brave"
+    elif [[ "$EDGE_INSTALLED"    == "1" ]]; then BROWSER="edge"
+    else                                          BROWSER="vivaldi"
+    fi
     echo "==> Browser: $BROWSER (only supported browser found)"
   elif [[ "$DRY_RUN" == "1" || ! -t 0 ]]; then
     BROWSER="chrome"
@@ -166,16 +250,18 @@ if [[ -z "$BROWSER" ]]; then
   else
     echo ""
     echo "Choose target browser:"
-    echo "  chrome   Google Chrome"
-    echo "  brave    Brave Browser"
-    echo "  both     Install for both"
+    [[ "$CHROME_INSTALLED"  == "1" ]] && echo "  chrome     Google Chrome"
+    [[ "$BRAVE_INSTALLED"   == "1" ]] && echo "  brave      Brave Browser"
+    [[ "$EDGE_INSTALLED"    == "1" ]] && echo "  edge       Microsoft Edge"
+    [[ "$VIVALDI_INSTALLED" == "1" ]] && echo "  vivaldi    Vivaldi"
+    [[ "$CHROME_INSTALLED" == "1" && "$BRAVE_INSTALLED" == "1" ]] && echo "  both       Chrome and Brave"
     echo ""
-    read -r -p "Browser [chrome/brave/both] (default: chrome): " ANSWER
+    read -r -p "Browser (default: chrome): " ANSWER
     ANSWER="${ANSWER:-chrome}"
     case "$ANSWER" in
-      chrome|brave|both) BROWSER="$ANSWER" ;;
+      chrome|brave|edge|vivaldi|both) BROWSER="$ANSWER" ;;
       *)
-        echo "Unrecognized browser '$ANSWER'. Use chrome, brave, or both." >&2
+        echo "Unrecognized browser '$ANSWER'." >&2
         exit 1 ;;
     esac
   fi
@@ -207,11 +293,13 @@ fi
 echo "==> [browser] Installing native messaging symlink(s)..."
 NM_DIRS=()
 case "$BROWSER" in
-  chrome) NM_DIRS+=("$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts") ;;
-  brave)  NM_DIRS+=("$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts") ;;
+  chrome)  NM_DIRS+=("$(nm_dir_for chrome)") ;;
+  brave)   NM_DIRS+=("$(nm_dir_for brave)") ;;
+  edge)    NM_DIRS+=("$(nm_dir_for edge)") ;;
+  vivaldi) NM_DIRS+=("$(nm_dir_for vivaldi)") ;;
   both)
-    NM_DIRS+=("$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts")
-    NM_DIRS+=("$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    NM_DIRS+=("$(nm_dir_for chrome)")
+    NM_DIRS+=("$(nm_dir_for brave)")
     ;;
 esac
 
@@ -223,24 +311,17 @@ for dir in "${NM_DIRS[@]}"; do
     mkdir -p "$dir"
     ln -sfn "$GENERATED_MANIFEST" "$dir/com.interceptor.host.json"
     case "$dir" in
-      *Google/Chrome*) echo "    Chrome: $dir/com.interceptor.host.json" ;;
-      *Brave-Browser*) echo "    Brave:  $dir/com.interceptor.host.json" ;;
+      *Google/Chrome*|*google-chrome*)   echo "    Chrome:  $dir/com.interceptor.host.json" ;;
+      *Brave-Browser*|*BraveSoftware*)   echo "    Brave:   $dir/com.interceptor.host.json" ;;
+      *Microsoft\ Edge*)                 echo "    Edge:    $dir/com.interceptor.host.json" ;;
+      *Vivaldi*)                         echo "    Vivaldi: $dir/com.interceptor.host.json" ;;
     esac
   fi
 done
 
 # ── Step 3: Load extension into browser via --load-extension ──────────────────
-# Takes one arg: "chrome" | "brave". Reads $SKIP_EXTENSION, $PROFILE, $DRY_RUN,
-# $EXTENSION_DIR from the surrounding scope.
-
-# Resolve the profile root for a given browser target.
-profile_root_for() {
-  case "$1" in
-    brave)  echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
-    chrome) echo "$HOME/Library/Application Support/Google/Chrome" ;;
-    *) return 1 ;;
-  esac
-}
+# Takes one arg: "chrome" | "brave" | "edge" | "vivaldi". Reads $SKIP_EXTENSION,
+# $PROFILE, $DRY_RUN, $EXTENSION_DIR from the surrounding scope.
 
 # Read extensions.ui.developer_mode from a profile's Preferences JSON.
 # Echoes "true" / "false" / "unknown" (file missing, malformed, or key absent).
@@ -307,20 +388,41 @@ load_extension() {
 
   local BROWSER_APP BROWSER_BIN BROWSER_NAME
   case "$target" in
-    brave)
-      BROWSER_APP="/Applications/Brave Browser.app"
-      BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Brave Browser"
-      BROWSER_NAME="Brave"
-      ;;
-    chrome)
-      BROWSER_APP="/Applications/Google Chrome.app"
-      BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome"
-      BROWSER_NAME="Chrome"
-      ;;
+    brave)   BROWSER_NAME="Brave" ;;
+    chrome)  BROWSER_NAME="Chrome" ;;
+    edge)    BROWSER_NAME="Edge" ;;
+    vivaldi) BROWSER_NAME="Vivaldi" ;;
     *)
       echo "ERROR: load_extension called with unknown browser '$target'." >&2
       return 1 ;;
   esac
+  if [[ "$PLATFORM" == "Darwin" ]]; then
+    case "$target" in
+      brave)
+        BROWSER_APP="/Applications/Brave Browser.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Brave Browser"
+        ;;
+      chrome)
+        BROWSER_APP="/Applications/Google Chrome.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome"
+        ;;
+      edge)
+        BROWSER_APP="/Applications/Microsoft Edge.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Microsoft Edge"
+        ;;
+      vivaldi)
+        BROWSER_APP="/Applications/Vivaldi.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Vivaldi"
+        ;;
+    esac
+  else
+    BROWSER_APP=""
+    BROWSER_BIN="$(browser_bin_for "$target" || true)"
+    if [[ -z "$BROWSER_BIN" ]]; then
+      echo "ERROR: $BROWSER_NAME binary not found in PATH on this platform." >&2
+      return 1
+    fi
+  fi
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "==> [browser] DRY: would launch $BROWSER_NAME --load-extension=$EXTENSION_DIR"
@@ -351,7 +453,7 @@ load_extension() {
     echo ""
     echo "    Manual remediation:"
     echo "      1. Quit $BROWSER_NAME entirely."
-    echo "      2. Re-launch $BROWSER_NAME, open $(case "$target" in brave) echo brave://extensions/ ;; chrome) echo chrome://extensions/ ;; esac), toggle Developer mode ON."
+    echo "      2. Re-launch $BROWSER_NAME, open $(case "$target" in brave) echo brave://extensions/ ;; chrome) echo chrome://extensions/ ;; edge) echo edge://extensions/ ;; vivaldi) echo vivaldi://extensions/ ;; esac), toggle Developer mode ON."
     echo "      3. Quit $BROWSER_NAME again."
     echo "      4. Re-run: bash scripts/install.sh ${MODE:+--$MODE} --$target${PROFILE:+ --profile \"$PROFILE\"}"
 
@@ -411,8 +513,12 @@ load_extension() {
     read -p "      Quit $BROWSER_NAME and relaunch with extension? [y/N] " CONFIRM
     if [[ "${CONFIRM:-n}" == "y" || "${CONFIRM:-n}" == "Y" ]]; then
       echo "    Quitting $BROWSER_NAME..."
-      osascript -e "tell application \"$BROWSER_NAME Browser\" to quit" 2>/dev/null || \
-      osascript -e "tell application \"$BROWSER_NAME\" to quit" 2>/dev/null || true
+      if [[ "$PLATFORM" == "Darwin" ]]; then
+        osascript -e "tell application \"$BROWSER_NAME Browser\" to quit" 2>/dev/null || \
+        osascript -e "tell application \"$BROWSER_NAME\" to quit" 2>/dev/null || true
+      else
+        pkill -TERM -f "$BROWSER_BIN" 2>/dev/null || true
+      fi
       sleep 2
       for j in {1..10}; do
         if ! pgrep -f "$BROWSER_BIN" >/dev/null 2>&1; then break; fi
@@ -424,11 +530,19 @@ load_extension() {
     fi
   fi
 
-  if [[ "$target" == "chrome" ]]; then
+  # Chrome and Edge (both branded Chromium builds) ignore --load-extension on
+  # macOS and Windows desktop. Surface the developer-flow remediation rather
+  # than launch a no-op. Brave and Vivaldi respect --load-extension.
+  if [[ "$target" == "chrome" || "$target" == "edge" ]]; then
+    local SCHEMA
+    case "$target" in
+      chrome) SCHEMA="chrome" ;;
+      edge)   SCHEMA="edge" ;;
+    esac
     echo ""
-    echo "==> Google Chrome ignores --load-extension in branded desktop builds."
+    echo "==> $BROWSER_NAME ignores --load-extension in branded desktop builds."
     echo "    Use one of these paths instead:"
-    echo "      1. Developer flow: open chrome://extensions, enable Developer Mode,"
+    echo "      1. Developer flow: open ${SCHEMA}://extensions, enable Developer Mode,"
     echo "         then Load unpacked -> $EXTENSION_DIR"
     echo ""
     echo "    Native messaging metadata has already been installed."
@@ -446,7 +560,12 @@ load_extension() {
     echo "    Profile:   $PROFILE"
   fi
 
-  open -a "$BROWSER_APP" --args "${LAUNCH_ARGS[@]}"
+  if [[ "$PLATFORM" == "Darwin" ]]; then
+    open -a "$BROWSER_APP" --args "${LAUNCH_ARGS[@]}"
+  else
+    nohup "$BROWSER_BIN" "${LAUNCH_ARGS[@]}" >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+  fi
 
   # ── Post-launch reachability probe ──────────────────────────────────────────
   # Wait briefly for the extension to initialize, then probe via
@@ -475,8 +594,10 @@ load_extension() {
     echo ""
     echo "    Verify in $BROWSER_NAME:"
     case "$target" in
-      brave)  echo "      1. Open brave://extensions/" ;;
-      chrome) echo "      1. Open chrome://extensions/" ;;
+      brave)   echo "      1. Open brave://extensions/" ;;
+      chrome)  echo "      1. Open chrome://extensions/" ;;
+      edge)    echo "      1. Open edge://extensions/" ;;
+      vivaldi) echo "      1. Open vivaldi://extensions/" ;;
     esac
     echo "      2. Confirm Developer mode is ON (top-right toggle)."
     echo "      3. Confirm 'Interceptor' appears with ID hkjbaciefhhgekldhncknbjkofbpenng."
@@ -490,7 +611,7 @@ load_extension() {
 }
 
 case "$BROWSER" in
-  chrome|brave) load_extension "$BROWSER" ;;
+  chrome|brave|edge|vivaldi) load_extension "$BROWSER" ;;
   both)
     load_extension chrome
     load_extension brave

--- a/scripts/publish-sparkle.sh
+++ b/scripts/publish-sparkle.sh
@@ -1,0 +1,325 @@
+#!/bin/bash
+# scripts/publish-sparkle.sh
+#
+# Publish already-signed-and-notarized Interceptor .pkgs to the Sparkle update
+# feed. Decoupled from scripts/release.sh on purpose — release.sh produces the
+# .pkgs, you TEST them locally, and only when you're happy do you run this to
+# push the appcast (which auto-updates users with auto-update enabled).
+#
+# Reads the pkgs from dist/release/Interceptor-{Browser,Full}-<version>.pkg
+# (where <version> comes from package.json, or --version=X.Y.Z).
+#
+# Pipeline (per mode):
+#   1. cp pkg → $SPARKLE_HOST_DIR/public/
+#   2. sign_update → EdDSA signature + length
+#   3. python3 mutates appcast.xml: drop any prior <item> for the same
+#      (version, title) pair (idempotent re-publish), then prepend a new <item>
+#   4. (optional) deploy host via `rwh` if it's on PATH
+#
+# Env overrides (same defaults as release.sh):
+#   INTERCEPTOR_SPARKLE_VERSION       Sparkle tool version (default 2.9.1)
+#   INTERCEPTOR_SPARKLE_TOOLS_DIR     cached sign_update install
+#   INTERCEPTOR_SPARKLE_HOST_DIR      checkout of Interceptor-Updates-Sparkle
+#   INTERCEPTOR_DOWNLOAD_URL_PREFIX   base URL the appcast embeds (default
+#                                     https://updates.hackervalley.media/)
+#
+# Why this is a separate script:
+# Auto-pushing the appcast inside release.sh meant a freshly-notarized .pkg
+# went straight into the auto-update pipeline, with no human-in-the-loop test
+# gate between "the build worked" and "every user with auto-update on gets
+# the new version". This split forces the test-before-publish gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+SPARKLE_VERSION="${INTERCEPTOR_SPARKLE_VERSION:-2.9.1}"
+SPARKLE_TOOLS_DIR="${INTERCEPTOR_SPARKLE_TOOLS_DIR:-$HOME/.cache/interceptor-sparkle/$SPARKLE_VERSION}"
+SPARKLE_HOST_DIR="${INTERCEPTOR_SPARKLE_HOST_DIR:-$REPO_ROOT/../Interceptor-Updates-Sparkle}"
+DOWNLOAD_URL_PREFIX="${INTERCEPTOR_DOWNLOAD_URL_PREFIX:-https://updates.hackervalley.media/}"
+RELEASE_DIR="$REPO_ROOT/dist/release"
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+VERSION=""
+MODE_FLAG=""   # "" | "browser-only" | "full"
+DRY_RUN=0
+DEPLOY=1       # default: try rwh deploy. --no-deploy to stop after appcast.xml write.
+
+i=1
+while [[ $i -le $# ]]; do
+  arg="${!i}"
+  case "$arg" in
+    --browser-only)
+      [[ "$MODE_FLAG" == "full" ]] && { echo "ERROR: --browser-only and --full are mutually exclusive." >&2; exit 1; }
+      MODE_FLAG="browser-only" ;;
+    --full)
+      [[ "$MODE_FLAG" == "browser-only" ]] && { echo "ERROR: --browser-only and --full are mutually exclusive." >&2; exit 1; }
+      MODE_FLAG="full" ;;
+    --version=*) VERSION="${arg#--version=}" ;;
+    --version)
+      i=$((i + 1)); VERSION="${!i:-}" ;;
+    --no-deploy) DEPLOY=0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      echo ""
+      echo "Usage: bash scripts/publish-sparkle.sh [MODE] [--version=X.Y.Z] [--no-deploy] [--dry-run]"
+      echo ""
+      echo "Publishes signed+notarized .pkgs from dist/release/ to the Sparkle"
+      echo "update feed. Requires the .pkgs to already exist — run release.sh first."
+      echo ""
+      echo "Modes (mutually exclusive; default publishes both if both pkgs exist):"
+      echo "  --browser-only   Publish only Interceptor-Browser-<v>.pkg"
+      echo "  --full           Publish only Interceptor-Full-<v>.pkg"
+      echo "  (no mode flag)   Publish whichever pkg(s) exist for the version"
+      echo ""
+      echo "Options:"
+      echo "  --version=X.Y.Z  Override version (else read from package.json)"
+      echo "  --no-deploy      Update appcast.xml locally; skip the rwh deploy step"
+      echo "  --dry-run        Print steps without copying / signing / mutating"
+      exit 1 ;;
+  esac
+  i=$((i + 1))
+done
+
+# ── Resolve version ───────────────────────────────────────────────────────────
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(python3 -c 'import json; print(json.load(open("package.json"))["version"])' 2>/dev/null || true)"
+fi
+if [[ -z "$VERSION" ]]; then
+  echo "ERROR: could not determine version (try --version=X.Y.Z)" >&2
+  exit 1
+fi
+
+# ── Resolve modes ─────────────────────────────────────────────────────────────
+SIGNED_BROWSER_PKG="$RELEASE_DIR/Interceptor-Browser-${VERSION}.pkg"
+SIGNED_FULL_PKG="$RELEASE_DIR/Interceptor-Full-${VERSION}.pkg"
+
+PUBLISH_BROWSER=0
+PUBLISH_FULL=0
+case "$MODE_FLAG" in
+  browser-only) PUBLISH_BROWSER=1 ;;
+  full)         PUBLISH_FULL=1 ;;
+  "")
+    # Auto-detect from disk. Publish whichever pkg(s) exist for this version.
+    [[ -f "$SIGNED_BROWSER_PKG" ]] && PUBLISH_BROWSER=1
+    [[ -f "$SIGNED_FULL_PKG"    ]] && PUBLISH_FULL=1
+    if (( PUBLISH_BROWSER + PUBLISH_FULL == 0 )); then
+      echo "ERROR: no .pkg found for version $VERSION in $RELEASE_DIR" >&2
+      echo "       Expected one or both of:" >&2
+      echo "         $SIGNED_BROWSER_PKG" >&2
+      echo "         $SIGNED_FULL_PKG" >&2
+      echo "       Run scripts/release.sh first." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+if (( PUBLISH_BROWSER )) && [[ ! -f "$SIGNED_BROWSER_PKG" ]]; then
+  echo "ERROR: $SIGNED_BROWSER_PKG not found." >&2
+  echo "       Run: bash scripts/release.sh --browser-only" >&2
+  exit 1
+fi
+if (( PUBLISH_FULL )) && [[ ! -f "$SIGNED_FULL_PKG" ]]; then
+  echo "ERROR: $SIGNED_FULL_PKG not found." >&2
+  echo "       Run: bash scripts/release.sh --full" >&2
+  exit 1
+fi
+
+# Modes summary
+MODES_SUMMARY=()
+(( PUBLISH_BROWSER )) && MODES_SUMMARY+=("browser-only")
+(( PUBLISH_FULL    )) && MODES_SUMMARY+=("full")
+
+echo "==> Publishing v$VERSION to Sparkle (${MODES_SUMMARY[*]})"
+if (( DRY_RUN )); then
+  echo "==> DRY RUN — appcast.xml not mutated; no files copied."
+fi
+
+# ── Step 1: Verify notarization on the .pkg(s) before publishing ──────────────
+# Cheap sanity check: a notarization-stripped or bit-rotted pkg shouldn't reach
+# the appcast. spctl confirms the stapled notarization is still valid.
+echo "==> Step 1: Verifying notarization"
+if (( DRY_RUN )); then
+  (( PUBLISH_BROWSER )) && echo "    DRY: spctl --assess --type install $SIGNED_BROWSER_PKG"
+  (( PUBLISH_FULL    )) && echo "    DRY: spctl --assess --type install $SIGNED_FULL_PKG"
+else
+  for pkg in $( (( PUBLISH_BROWSER )) && echo "$SIGNED_BROWSER_PKG"; (( PUBLISH_FULL )) && echo "$SIGNED_FULL_PKG"); do
+    if ! spctl --assess --type install "$pkg" 2>/dev/null; then
+      echo "ERROR: $pkg failed spctl assessment. Re-notarize or re-staple before publishing." >&2
+      exit 1
+    fi
+    if ! xcrun stapler validate "$pkg" >/dev/null 2>&1; then
+      echo "ERROR: $pkg failed stapler validate. Re-staple before publishing." >&2
+      exit 1
+    fi
+  done
+fi
+
+# ── Step 2: Ensure Sparkle tools are cached ───────────────────────────────────
+echo "==> Step 2: Verifying Sparkle $SPARKLE_VERSION tools"
+if (( DRY_RUN )); then
+  echo "    DRY: ensure $SPARKLE_TOOLS_DIR/bin/sign_update exists"
+else
+  if [ ! -x "$SPARKLE_TOOLS_DIR/bin/sign_update" ]; then
+    echo "    Caching Sparkle $SPARKLE_VERSION tools in $SPARKLE_TOOLS_DIR"
+    mkdir -p "$SPARKLE_TOOLS_DIR"
+    curl -sSL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+      -o "$SPARKLE_TOOLS_DIR/sparkle.tar.xz"
+    tar xf "$SPARKLE_TOOLS_DIR/sparkle.tar.xz" -C "$SPARKLE_TOOLS_DIR"
+    rm -f "$SPARKLE_TOOLS_DIR/sparkle.tar.xz"
+  fi
+fi
+
+# ── Step 3: Validate host dir ─────────────────────────────────────────────────
+echo "==> Step 3: Validating Sparkle host dir"
+if [ ! -d "$SPARKLE_HOST_DIR" ]; then
+  echo "ERROR: Sparkle host dir missing at $SPARKLE_HOST_DIR" >&2
+  echo "       Set INTERCEPTOR_SPARKLE_HOST_DIR or check out the" >&2
+  echo "       Interceptor-Updates-Sparkle project there." >&2
+  exit 1
+fi
+HOST_PUBLIC="$SPARKLE_HOST_DIR/public"
+if (( ! DRY_RUN )); then
+  mkdir -p "$HOST_PUBLIC"
+fi
+
+# ── Step 4: Per-mode publish ──────────────────────────────────────────────────
+# For each pkg: copy, sign_update, mutate appcast.xml. Uses inline Python to
+# rewrite appcast.xml so the operation is idempotent — re-publishing the same
+# (version, title) replaces the prior <item> instead of duplicating it.
+publish_to_sparkle() {
+  local mode="$1" signed_pkg="$2" pkg_basename min_sys_ver title sig_line
+  pkg_basename="$(basename "$signed_pkg")"
+  case "$mode" in
+    browser-only) min_sys_ver="11.0";  title="Interceptor (Browser-Only) ${VERSION}" ;;
+    full)         min_sys_ver="14.0";  title="Interceptor (Full) ${VERSION}" ;;
+  esac
+
+  if (( DRY_RUN )); then
+    echo "    DRY: cp $signed_pkg → $HOST_PUBLIC/$pkg_basename"
+    echo "    DRY: sign_update + append appcast item ($mode, minSysVer $min_sys_ver, title \"$title\")"
+    return 0
+  fi
+
+  echo "    Copying $signed_pkg → $HOST_PUBLIC/$pkg_basename"
+  cp "$signed_pkg" "$HOST_PUBLIC/$pkg_basename"
+
+  echo "    Running sign_update on $pkg_basename"
+  sig_line="$("$SPARKLE_TOOLS_DIR/bin/sign_update" "$HOST_PUBLIC/$pkg_basename" 2>&1 | tail -1)"
+  echo "    $sig_line"
+
+  echo "    Updating appcast.xml entry for $title"
+  HOST_APPCAST="$HOST_PUBLIC/appcast.xml" \
+  PKG_VERSION="$VERSION" \
+  PKG_URL="${DOWNLOAD_URL_PREFIX}${pkg_basename}" \
+  PKG_SIG_LINE="$sig_line" \
+  PKG_TITLE="$title" \
+  PKG_MIN_SYS_VER="$min_sys_ver" \
+  PKG_MODE="$mode" \
+  python3 - <<'PY'
+import os, re, sys
+from datetime import datetime, timezone
+from xml.etree import ElementTree as ET
+
+ET.register_namespace("sparkle", "http://www.andymatuschak.org/xml-namespaces/sparkle")
+SP = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+
+path = os.environ["HOST_APPCAST"]
+version = os.environ["PKG_VERSION"]
+url = os.environ["PKG_URL"]
+sig_line = os.environ["PKG_SIG_LINE"].strip()
+title = os.environ["PKG_TITLE"]
+min_sys_ver = os.environ["PKG_MIN_SYS_VER"]
+mode = os.environ["PKG_MODE"]
+
+# sign_update output line looks like:
+#   sparkle:edSignature="..." length="..."
+m = re.search(r'sparkle:edSignature="([^"]+)"\s+length="([0-9]+)"', sig_line)
+if not m:
+    print(f"ERROR: could not parse sign_update output: {sig_line}", file=sys.stderr)
+    sys.exit(1)
+ed_sig, length = m.group(1), m.group(2)
+
+if os.path.exists(path):
+    tree = ET.parse(path)
+    root = tree.getroot()
+    channel = root.find("channel")
+else:
+    root = ET.Element("rss", {
+        "version": "2.0",
+        "xmlns:sparkle": "http://www.andymatuschak.org/xml-namespaces/sparkle",
+    })
+    channel = ET.SubElement(root, "channel")
+    ET.SubElement(channel, "title").text = "Interceptor"
+    ET.SubElement(channel, "link").text = "https://github.com/Hacker-Valley-Media/Interceptor"
+    ET.SubElement(channel, "description").text = "Sparkle update feed for Interceptor (Browser + Full)."
+    ET.SubElement(channel, "language").text = "en"
+    tree = ET.ElementTree(root)
+
+# Drop any prior <item> for this version+mode (idempotency). We tag mode in
+# the title so collisions across modes are visible, and use sparkle:channel
+# to make per-mode updaters filterable.
+for item in list(channel.findall("item")):
+    sv = item.find(f"{SP}shortVersionString")
+    t = item.find("title")
+    if sv is not None and sv.text == version and t is not None and t.text == title:
+        channel.remove(item)
+
+item = ET.Element("item")
+ET.SubElement(item, "title").text = title
+ET.SubElement(item, "pubDate").text = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
+ET.SubElement(item, f"{SP}version").text = version
+ET.SubElement(item, f"{SP}shortVersionString").text = version
+ET.SubElement(item, f"{SP}minimumSystemVersion").text = min_sys_ver
+ET.SubElement(item, f"{SP}installationType").text = "package"
+ET.SubElement(item, f"{SP}channel").text = mode
+ET.SubElement(item, "enclosure", {
+    "url": url,
+    f"{SP}edSignature": ed_sig,
+    "length": length,
+    "type": "application/octet-stream",
+})
+
+# Insert at top so newest is first.
+insert_at = list(channel).index(channel.findall("language")[-1]) + 1 if channel.find("language") is not None else 0
+channel.insert(insert_at, item)
+
+ET.indent(tree, space="    ")
+tree.write(path, encoding="utf-8", xml_declaration=True)
+print(f"    appcast.xml updated for {title}")
+PY
+}
+
+echo "==> Step 4: Per-mode publish"
+(( PUBLISH_BROWSER )) && publish_to_sparkle "browser-only" "$SIGNED_BROWSER_PKG"
+(( PUBLISH_FULL    )) && publish_to_sparkle "full"         "$SIGNED_FULL_PKG"
+
+# ── Step 5: Deploy host (optional) ────────────────────────────────────────────
+echo "==> Step 5: Deploying update host"
+if (( ! DEPLOY )); then
+  echo "    --no-deploy passed; appcast.xml updated locally, deploy skipped."
+  echo "    To deploy manually, push $HOST_PUBLIC/ to your update host."
+elif (( DRY_RUN )); then
+  echo "    DRY: rwh up --service interceptor-updates --detach (if rwh on PATH)"
+elif command -v rwh >/dev/null 2>&1; then
+  echo "    Running: rwh up --service interceptor-updates --detach"
+  (cd "$SPARKLE_HOST_DIR" && rwh up --service interceptor-updates --detach 2>&1 | tail -5) || \
+    echo "    WARN: rwh up exited non-zero — appcast may not be live" >&2
+else
+  echo "    WARN: rwh CLI not on PATH — push $HOST_PUBLIC manually to deploy." >&2
+fi
+
+echo "================================================================"
+echo "Sparkle publish complete:"
+echo "  feed:   ${DOWNLOAD_URL_PREFIX}appcast.xml"
+(( PUBLISH_BROWSER )) && echo "  browser: ${DOWNLOAD_URL_PREFIX}Interceptor-Browser-${VERSION}.pkg"
+(( PUBLISH_FULL    )) && echo "  full:    ${DOWNLOAD_URL_PREFIX}Interceptor-Full-${VERSION}.pkg"
+if (( DRY_RUN )); then
+  echo ""
+  echo "DRY-RUN complete — no changes made."
+fi
+echo "================================================================"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -566,40 +566,25 @@ if [[ "$DRY_RUN" != "1" ]]; then
   rm -f "$UNSIGNED_BROWSER_PKG" "$UNSIGNED_FULL_PKG"
 fi
 
-# ── Step 13: Publish Sparkle appcast ──────────────────────────────────────────
-# For each pkg built, copy into the Sparkle host's public/ dir, run sign_update
-# to get the EdDSA signature, and emit one appcast item per pkg. Sparkle's
-# generate_appcast doesn't support .pkg updates per its docs; we mutate
-# appcast.xml ourselves via inline Python.
-echo "==> Step 13: Publishing Sparkle appcast"
+# ── Step 13: Publish Sparkle appcast — REMOVED ────────────────────────────────
+# Sparkle publish is intentionally NOT part of release.sh anymore. Auto-pushing
+# the appcast inside the same script that produced the .pkg meant a fresh build
+# went straight into the auto-update pipeline with no human-in-the-loop test
+# gate. Run `bash scripts/publish-sparkle.sh` AFTER testing the .pkg locally,
+# only when you're sure the build is good.
+echo "==> Step 13: Sparkle publish — SKIPPED (run separately after testing)"
+echo "    Test the .pkg locally, then publish with:"
+echo "        bash scripts/publish-sparkle.sh"
+echo "    See scripts/publish-sparkle.sh --help for flags."
 
-if [[ "$DRY_RUN" == "1" ]]; then
-  for mode in "${MODES[@]}"; do
-    case "$mode" in
-      browser-only) echo "    DRY: copy $SIGNED_BROWSER_PKG → \$SPARKLE_HOST_DIR/public/, sign_update, append appcast item (browser-only, minSysVer 11.0)" ;;
-      full)         echo "    DRY: copy $SIGNED_FULL_PKG → \$SPARKLE_HOST_DIR/public/, sign_update, append appcast item (full, minSysVer 14.0)" ;;
-    esac
-  done
-  echo "    DRY: rwh up --service interceptor-updates --detach (if rwh on PATH)"
-else
-  # Cache Sparkle's CLI tools (sign_update) on first use.
-  if [ ! -x "$SPARKLE_TOOLS_DIR/bin/sign_update" ]; then
-    echo "    Caching Sparkle $SPARKLE_VERSION tools in $SPARKLE_TOOLS_DIR"
-    mkdir -p "$SPARKLE_TOOLS_DIR"
-    curl -sSL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
-      -o "$SPARKLE_TOOLS_DIR/sparkle.tar.xz"
-    tar xf "$SPARKLE_TOOLS_DIR/sparkle.tar.xz" -C "$SPARKLE_TOOLS_DIR"
-    rm -f "$SPARKLE_TOOLS_DIR/sparkle.tar.xz"
-  fi
-
+# Below is the old Step 13 publish function, kept dormant so the script doesn't
+# need to redefine SIGNED_*_PKG etc. The whole `if false` block is deliberately
+# dead — Sparkle publish lives in scripts/publish-sparkle.sh now.
+if false; then
   if [ ! -d "$SPARKLE_HOST_DIR" ]; then
-    echo "WARN: Sparkle host dir missing at $SPARKLE_HOST_DIR" >&2
-    echo "      Skipping appcast publish. Set INTERCEPTOR_SPARKLE_HOST_DIR" >&2
-    echo "      or check out the Interceptor-Updates-Sparkle project there." >&2
+    HOST_PUBLIC=""
   else
     HOST_PUBLIC="$SPARKLE_HOST_DIR/public"
-    mkdir -p "$HOST_PUBLIC"
-
     publish_to_sparkle() {
       local mode="$1" signed_pkg="$2" pkg_basename min_sys_ver title sig_line
       pkg_basename="$(basename "$signed_pkg")"
@@ -730,13 +715,13 @@ if [[ "$BUILD_FULL" == "1" ]]; then
   fi
 fi
 echo ""
-echo "Sparkle feed:  ${DOWNLOAD_URL_PREFIX}appcast.xml"
-if [[ "$BUILD_BROWSER" == "1" ]]; then
-  echo "Browser URL:   ${DOWNLOAD_URL_PREFIX}Interceptor-Browser-${VERSION}.pkg"
-fi
-if [[ "$BUILD_FULL" == "1" ]]; then
-  echo "Full URL:      ${DOWNLOAD_URL_PREFIX}Interceptor-Full-${VERSION}.pkg"
-fi
+echo "Next steps:"
+echo "  1. Test the .pkg(s) locally (open or installer)."
+echo "  2. When verified, push to the Sparkle update feed:"
+echo "       bash scripts/publish-sparkle.sh"
+echo ""
+echo "Once published, the appcast feed will be:"
+echo "       ${DOWNLOAD_URL_PREFIX}appcast.xml"
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "DRY-RUN complete."
 fi

--- a/test/bridge-recovery.test.ts
+++ b/test/bridge-recovery.test.ts
@@ -77,6 +77,39 @@ describe("bridge recovery layout", () => {
     expect(formatBridgeUnavailableError(layout)).toContain("interceptor status")
   })
 
+  test("pkg full install with plist NOT bootstrapped tells the user to bootstrap, not kickstart", () => {
+    const systemLaunchAgent = "/Library/LaunchAgents/com.interceptor.bridge.plist"
+    const applicationsBundle = "/Applications/interceptor-bridge.app"
+    const exists = existsFor([systemLaunchAgent, applicationsBundle])
+    const layout = getBridgeRecoveryLayout({
+      exists,
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    const error = formatBridgeUnavailableError(layout, { launchAgentLoaded: false })
+    expect(error).toContain("launchctl bootstrap")
+    expect(error).toContain(systemLaunchAgent)
+    expect(error).toContain("log out and back in")
+  })
+
+  test("pkg full install with plist already bootstrapped falls back to kickstart guidance", () => {
+    const systemLaunchAgent = "/Library/LaunchAgents/com.interceptor.bridge.plist"
+    const applicationsBundle = "/Applications/interceptor-bridge.app"
+    const exists = existsFor([systemLaunchAgent, applicationsBundle])
+    const layout = getBridgeRecoveryLayout({
+      exists,
+      home,
+      importMetaUrl: daemonImportMetaUrl,
+      uid,
+    })
+
+    const error = formatBridgeUnavailableError(layout, { launchAgentLoaded: true })
+    expect(error).not.toContain("launchctl bootstrap")
+    expect(error).toContain("kickstart")
+  })
+
   test("repo fallback uses the repo bundle before the bare binary", () => {
     const exists = existsFor([repoBundlePath, repoDistBinaryPath])
     const layout = getBridgeRecoveryLayout({

--- a/test/cli-meta-additions.test.ts
+++ b/test/cli-meta-additions.test.ts
@@ -80,7 +80,7 @@ describe("helpForCommand (#51)", () => {
     const help = helpForCommand("act")
     expect(help).toBeDefined()
     expect(help).toContain("interceptor act <ref>")
-    expect(help).toContain("--os")
+    expect(help).toContain("--trusted")
   })
 
   test("returns null for an unknown command", () => {

--- a/test/cli-meta-additions.test.ts
+++ b/test/cli-meta-additions.test.ts
@@ -123,6 +123,8 @@ describe("formatStatus (#49 + #52)", () => {
       bridgePid: null,
       bridgeSocket: null,
       launchAgentInstalled: false,
+      launchAgentPath: null,
+      launchAgentLoaded: false,
       ...over,
     }
   }

--- a/test/fixtures/linux-os-input-check.ts
+++ b/test/fixtures/linux-os-input-check.ts
@@ -1,0 +1,42 @@
+/**
+ * test/fixtures/linux-os-input-check.ts
+ *
+ * Fixture invoked by test/install-linux-container.test.ts inside a Linux Bun
+ * container (via `interceptor macos container run`). The CLI's --cmd flag
+ * splits on whitespace (cli/commands/macos.ts:893), so multi-word `bun -e`
+ * invocations are awkward to pass cleanly. Running this fixture as a single-
+ * argument script sidesteps the quoting problem.
+ *
+ * Assertions emitted on stdout (the test parses these markers):
+ *   - import-ok                                                — module loaded without throwing ERR_DLOPEN_FAILED
+ *   - osClick:{"success":false,"error":"act --os not …"}       — non-Darwin sentinel
+ *
+ * If either check fails the script exits non-zero with the error on stderr.
+ */
+
+export {}
+
+async function main() {
+  let mod: typeof import("../../daemon/os-input")
+  try {
+    mod = await import("../../daemon/os-input")
+  } catch (err) {
+    console.error("import-failed:", (err as Error).message)
+    process.exit(1)
+  }
+  console.log("import-ok")
+
+  const r = await mod.osClick(1, 1)
+  console.log("osClick:" + JSON.stringify(r))
+
+  if (r.success !== false) {
+    console.error("osClick should return success=false on non-Darwin")
+    process.exit(2)
+  }
+  if (typeof r.error !== "string" || !r.error.toLowerCase().includes("not supported")) {
+    console.error("osClick error string missing 'not supported': " + JSON.stringify(r))
+    process.exit(3)
+  }
+}
+
+main()

--- a/test/install-linux-container.test.ts
+++ b/test/install-linux-container.test.ts
@@ -1,0 +1,171 @@
+/**
+ * test/install-linux-container.test.ts
+ *
+ * Linux test harness via Apple's `container` runtime.
+ *
+ * macOS hosts can't natively exercise install.sh's Linux branches, but
+ * Apple's `container` (research/container/docs/technical-overview.md:24-27)
+ * runs Linux containers as lightweight VMs on Apple-Silicon Macs running
+ * macOS 26+. Interceptor wraps the runtime via the `container_run`
+ * domain (interceptor-bridge/Sources/Domains/ContainerDomain.swift) and
+ * the `interceptor macos container run` CLI surface (cli/commands/macos.ts).
+ *
+ * This file exercises the Linux dry-run path from a macOS host by mounting
+ * the repo into an Ubuntu container read-only and running install.sh inside
+ * it. The container has no network (--network none — Interceptor's default
+ * per ContainerDomain.swift, hermetic on macOS 15+) so no apt-get / no
+ * registry calls happen during the test.
+ *
+ * Gates:
+ *   - Skips on non-Darwin (the runtime is macOS-only).
+ *   - Skips when the `container` binary is absent (CI without macOS-26 +
+ *     Apple's tool installed).
+ *   - Skips when the `interceptor` binary isn't on $PATH (CI before the
+ *     dist build runs). Will use `bun run cli/index.ts` as fallback if
+ *     INTERCEPTOR_CLI is set to "bun".
+ */
+
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dir, "..")
+const IS_DARWIN = process.platform === "darwin"
+const UBUNTU_IMAGE = "docker.io/library/ubuntu:24.04"
+const BUN_IMAGE = "docker.io/oven/bun:1"
+
+/** True iff Apple's `container` binary is on $PATH and responds to --version. */
+function containerAvailable(): boolean {
+  if (!IS_DARWIN) return false
+  // Mirror ContainerDomain.swift's resolution order (Apple-Silicon Homebrew first).
+  const candidates = [
+    "/opt/homebrew/bin/container",
+    "/usr/local/bin/container",
+  ]
+  for (const path of candidates) {
+    const probe = spawnSync(path, ["--version"], { stdio: "ignore" })
+    if (probe.status === 0) return true
+  }
+  // Fallback: PATH lookup.
+  const which = spawnSync("which", ["container"], { stdio: "ignore" })
+  if (which.status !== 0) return false
+  const probe = spawnSync("container", ["--version"], { stdio: "ignore" })
+  return probe.status === 0
+}
+
+/**
+ * Resolve how to invoke the interceptor CLI. Returns the argv array.
+ *
+ * Prefers `interceptor` on $PATH; falls back to `bun run cli/index.ts` when
+ * the dist binary isn't built yet (common in CI before `bash scripts/build.sh`).
+ * Returns null if neither is available.
+ */
+function interceptorArgv(): string[] | null {
+  // Try the built binary first.
+  if (spawnSync("which", ["interceptor"], { stdio: "ignore" }).status === 0) {
+    return ["interceptor"]
+  }
+  // Fall back to `bun run cli/index.ts`.
+  if (spawnSync("which", ["bun"], { stdio: "ignore" }).status === 0) {
+    return ["bun", "run", resolve(REPO_ROOT, "cli/index.ts")]
+  }
+  return null
+}
+
+const SHOULD_RUN = containerAvailable() && interceptorArgv() !== null
+
+/**
+ * Run `interceptor macos container run` with the given image+command. Returns
+ * the parsed wire response from the bridge — { exitCode, stdout, stderr,
+ * durationMs, ... } per ContainerDomain.swift:196-204.
+ */
+function containerRun(image: string, cmd: string, extraArgs: string[] = []): {
+  ok: boolean
+  payload: Record<string, unknown>
+  raw: string
+  stderr: string
+} {
+  const argv = interceptorArgv()!
+  const result = spawnSync(
+    argv[0],
+    [
+      ...argv.slice(1),
+      "macos", "container", "run", image,
+      "--volume", `${REPO_ROOT}:/work:ro`,
+      "--cmd", cmd,
+      "--timeout", "120000",
+      ...extraArgs,
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+  )
+  let payload: Record<string, unknown> = {}
+  try {
+    // The CLI prints structured JSON for the container_run domain.
+    payload = JSON.parse(result.stdout ?? "{}")
+  } catch {
+    // Fall through; payload stays empty and tests assert against raw output.
+  }
+  return {
+    ok: result.status === 0,
+    payload,
+    raw: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+describe.skipIf(!SHOULD_RUN)("install.sh — Linux dry-run via Apple container", () => {
+  // Bare Ubuntu container has no Chrome / Brave installed; --skip-extension
+  // short-circuits the load_extension step so the test only validates the
+  // platform-routing + NM-symlink generation paths (the cross-platform delta
+  // PR-83 introduced).
+  test("--browser-only --chrome --skip-extension --dry-run prints Linux NM dir", () => {
+    const r = containerRun(UBUNTU_IMAGE,
+      "bash /work/scripts/install.sh --browser-only --chrome --skip-extension --dry-run")
+    expect(r.ok).toBe(true)
+    expect(r.payload.exitCode).toBe(0)
+    const stdout = String(r.payload.stdout ?? "")
+    expect(stdout).toContain(".config/google-chrome/NativeMessagingHosts")
+    // macOS NM dir convention must NOT leak when running under uname -s = Linux.
+    expect(stdout).not.toContain("Library/Application Support")
+  })
+
+  test("--browser-only --brave --skip-extension --dry-run prints Linux Brave NM dir", () => {
+    const r = containerRun(UBUNTU_IMAGE,
+      "bash /work/scripts/install.sh --browser-only --brave --skip-extension --dry-run")
+    expect(r.ok).toBe(true)
+    expect(r.payload.exitCode).toBe(0)
+    const stdout = String(r.payload.stdout ?? "")
+    expect(stdout).toContain(".config/BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    expect(stdout).not.toContain("Library/Application Support")
+  })
+
+  test("--full --chrome is rejected on Linux with the documented error", () => {
+    const r = containerRun(UBUNTU_IMAGE,
+      "bash /work/scripts/install.sh --full --chrome --dry-run")
+    // Container exits non-zero, but the run itself succeeded — we want a
+    // structured stderr from the script saying "--full mode is macOS only".
+    expect(r.ok).toBe(true)
+    expect(r.payload.exitCode).not.toBe(0)
+    const stderr = String(r.payload.stderr ?? "")
+    expect(stderr).toContain("--full mode is macOS only")
+  })
+
+  // the daemon-crash regression. test/os-input-platform.test.ts
+  // covers the macOS-host import path; this test covers the actual Linux
+  // import path by running the fixture inside a Linux Bun container. The
+  // fixture (test/fixtures/linux-os-input-check.ts) emits two markers:
+  // "import-ok" if the dlopen gate worked, "osClick:{success:false,...}" if
+  // the platform-guard sentinel is returned.
+  test("daemon/os-input.ts imports cleanly on Linux + os* return UNSUPPORTED (PR-83 regression)", () => {
+    const r = containerRun(BUN_IMAGE,
+      "bun /work/test/fixtures/linux-os-input-check.ts")
+    expect(r.ok).toBe(true)
+    expect(r.payload.exitCode).toBe(0)
+    const stdout = String(r.payload.stdout ?? "")
+    const stderr = String(r.payload.stderr ?? "")
+    expect(stdout).toContain("import-ok")
+    expect(stdout).toContain('"success":false')
+    expect(stdout).toContain("not supported")
+    expect(stderr).not.toContain("ERR_DLOPEN_FAILED")
+  })
+})

--- a/test/install-modes.test.ts
+++ b/test/install-modes.test.ts
@@ -14,6 +14,60 @@ import { resolve } from "node:path"
 const REPO_ROOT = resolve(import.meta.dir, "..")
 const INSTALL_SCRIPT = resolve(REPO_ROOT, "scripts/install.sh")
 
+/** True on macOS; flips test expectations from `~/Library/...` paths to `~/.config/...`. */
+const IS_DARWIN = process.platform === "darwin"
+
+/**
+ * Platform-specific NM-dir substring the dry-run output should contain for Chrome.
+ *
+ * macOS: `~/Library/Application Support/Google/Chrome/NativeMessagingHosts`
+ * Linux: `~/.config/google-chrome/NativeMessagingHosts`
+ */
+const CHROME_NM_SUBSTR = IS_DARWIN ? "Google/Chrome/NativeMessagingHosts" : "google-chrome/NativeMessagingHosts"
+
+/**
+ * Platform-specific NM-dir substring the dry-run output should contain for Brave.
+ *
+ * macOS: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts`
+ * Linux: `~/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts`
+ */
+const BRAVE_NM_SUBSTR = IS_DARWIN
+  ? "BraveSoftware/Brave-Browser/NativeMessagingHosts"
+  : ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+
+/**
+ * Whether a browser binary/app is detectable on this platform.
+ *
+ * Mirrors the `browser_installed` helper in scripts/install.sh — looks for the
+ * `.app` bundle on macOS and any candidate binary on `$PATH` on Linux. Tests
+ * that need a specific browser to be auto-detected skip themselves when it's
+ * absent so CI without browsers installed stays green.
+ */
+function browserInstalled(target: "chrome" | "brave" | "edge" | "vivaldi"): boolean {
+  if (IS_DARWIN) {
+    const apps: Record<typeof target, string> = {
+      chrome: "/Applications/Google Chrome.app",
+      brave: "/Applications/Brave Browser.app",
+      edge: "/Applications/Microsoft Edge.app",
+      vivaldi: "/Applications/Vivaldi.app",
+    }
+    return spawnSync("test", ["-d", apps[target]]).status === 0
+  }
+  // Edge / Vivaldi on Linux are out of scope in this revision (a follow-up).
+  // Only chrome and brave have Linux install-detection.
+  if (target === "edge" || target === "vivaldi") return false
+  const candidates = target === "chrome"
+    ? ["google-chrome", "google-chrome-stable"]
+    : ["brave-browser"]
+  return candidates.some(b => spawnSync("command", ["-v", b], { shell: true }).status === 0)
+}
+
+/**
+ * Run scripts/install.sh in dry-run mode and capture stdout/stderr/exit status.
+ *
+ * Sets both `--dry-run` and `INSTALL_DRY_RUN=1` so the script never mutates
+ * the filesystem or installs native-messaging manifests during tests.
+ */
 function runInstallDryRun(args: string[]): { stdout: string; status: number; stderr: string } {
   const proc = spawnSync("bash", [INSTALL_SCRIPT, "--dry-run", ...args], {
     cwd: REPO_ROOT,
@@ -47,7 +101,7 @@ describe("install modes — dry-run", () => {
     expect(stdout).not.toContain("[bridge]")
   })
 
-  test("--full prints both browser steps and bridge steps", () => {
+  test.skipIf(!IS_DARWIN)("--full prints both browser steps and bridge steps", () => {
     const { stdout, status } = runInstallDryRun(["--full", "--chrome"])
     expect(status).toBe(0)
     expect(stdout).toContain("Mode: full")
@@ -93,29 +147,174 @@ describe("install modes — dry-run", () => {
   })
 })
 
+describe("install platform routing — dry-run", () => {
+  test("dry-run output matches the platform's NM dir convention", () => {
+    if (!browserInstalled("chrome") && !browserInstalled("brave")) return
+    const target = browserInstalled("chrome") ? "chrome" : "brave"
+    const { stdout, status } = runInstallDryRun(["--browser-only", `--${target}`])
+    expect(status).toBe(0)
+
+    if (IS_DARWIN) {
+      // macOS: ~/Library/Application Support/<vendor>/<product>/NativeMessagingHosts
+      expect(stdout).toContain("Library/Application Support")
+      expect(stdout).not.toContain(".config/")
+    } else {
+      // Linux: ~/.config/<product>/NativeMessagingHosts
+      expect(stdout).toContain(".config/")
+      expect(stdout).not.toContain("Library/Application Support")
+    }
+  })
+
+  test.skipIf(IS_DARWIN)("--full mode is rejected on non-Darwin platforms", () => {
+    const { stderr, status } = runInstallDryRun(["--full", "--chrome"])
+    expect(status).not.toBe(0)
+    expect(stderr).toContain("--full mode is macOS only")
+  })
+})
+
 describe("install browser selection — dry-run", () => {
-  test("--chrome installs only the Chrome native-messaging path", () => {
+  test.skipIf(!browserInstalled("chrome"))("--chrome installs only the Chrome native-messaging path", () => {
     const { stdout, status } = runInstallDryRun(["--browser-only", "--chrome"])
     expect(status).toBe(0)
     expect(stdout).toContain("Browser: chrome")
-    expect(stdout).toContain("Google/Chrome/NativeMessagingHosts")
-    expect(stdout).not.toContain("BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    expect(stdout).toContain(CHROME_NM_SUBSTR)
+    expect(stdout).not.toContain(BRAVE_NM_SUBSTR)
   })
 
-  test("--brave installs only the Brave native-messaging path", () => {
+  test.skipIf(!browserInstalled("brave"))("--brave installs only the Brave native-messaging path", () => {
     const { stdout, status } = runInstallDryRun(["--browser-only", "--brave"])
     expect(status).toBe(0)
     expect(stdout).toContain("Browser: brave")
-    expect(stdout).toContain("BraveSoftware/Brave-Browser/NativeMessagingHosts")
-    expect(stdout).not.toContain("Google/Chrome/NativeMessagingHosts")
+    expect(stdout).toContain(BRAVE_NM_SUBSTR)
+    expect(stdout).not.toContain(CHROME_NM_SUBSTR)
   })
 
-  test("non-interactive default (no --chrome/--brave) falls back to chrome with notice", () => {
+  test("non-interactive default (no --chrome/--brave) auto-selects an installed browser", () => {
     const { stdout, status } = runInstallDryRun(["--browser-only"])
     expect(status).toBe(0)
-    expect(stdout).toContain("defaulting to 'chrome' (non-interactive)")
-    expect(stdout).toContain("Browser: chrome")
-    expect(stdout).toContain("Google/Chrome/NativeMessagingHosts")
-    expect(stdout).not.toContain("BraveSoftware/Brave-Browser/NativeMessagingHosts")
+    // Two valid auto-select paths:
+    //   1. Both browsers installed → script prints "defaulting to 'chrome' (non-interactive)"
+    //   2. Only one installed     → script prints "Browser: <X> (only supported browser found)"
+    const hasBoth = browserInstalled("chrome") && browserInstalled("brave")
+    if (hasBoth) {
+      expect(stdout).toContain("defaulting to 'chrome' (non-interactive)")
+      expect(stdout).toContain("Browser: chrome")
+      expect(stdout).toContain(CHROME_NM_SUBSTR)
+      expect(stdout).not.toContain(BRAVE_NM_SUBSTR)
+    } else if (browserInstalled("chrome")) {
+      expect(stdout).toContain("only supported browser found")
+      expect(stdout).toContain("Browser: chrome")
+      expect(stdout).toContain(CHROME_NM_SUBSTR)
+    } else if (browserInstalled("brave")) {
+      expect(stdout).toContain("only supported browser found")
+      expect(stdout).toContain("Browser: brave")
+      expect(stdout).toContain(BRAVE_NM_SUBSTR)
+    } else {
+      // No browser installed — script aborts before NM resolution. Documented exit path.
+      expect(status).not.toBe(0)
+    }
+  })
+})
+
+/**
+ * coverage for the Edge + Vivaldi vendors added by PR #75.
+ *
+ * Both browsers are macOS-only in this revision (Linux support deferred to a
+ * follow-up PRD per a follow-up). Each test is gated on Darwin so CI on Linux
+ * stays green, and on the `.app` bundle's presence so a maintainer Mac without
+ * Edge/Vivaldi installed also stays green.
+ *
+ * Evidence the paths come from:
+ *   - Edge macOS NM dir:    derived from chrome-extensions docs/extensions/
+ *                           develop/concepts/native-messaging.md:70 +
+ *                           Microsoft's published Edge User Data dir
+ *                           (~/Library/Application Support/Microsoft Edge).
+ *   - Vivaldi macOS NM dir: same rule + Vivaldi's User Data dir
+ *                           (~/Library/Application Support/Vivaldi).
+ *   - manifest `key` field at extension/manifest.json:9 pins the extension ID
+ *                           deterministically across Chromium vendors per
+ *                           manifest/key.md:10,18.
+ */
+describe("install browser selection — Edge + Vivaldi (Darwin)", () => {
+  test.skipIf(!IS_DARWIN || !browserInstalled("edge"))(
+    "--edge dry-run targets Microsoft Edge NM dir on macOS",
+    () => {
+      const { stdout, status } = runInstallDryRun(["--browser-only", "--edge"])
+      expect(status).toBe(0)
+      expect(stdout).toContain("Browser: edge")
+      expect(stdout).toContain("Library/Application Support/Microsoft Edge/NativeMessagingHosts")
+      // Chrome and Brave paths must NOT leak into Edge output.
+      expect(stdout).not.toContain("Google/Chrome/NativeMessagingHosts")
+      expect(stdout).not.toContain("Brave-Browser/NativeMessagingHosts")
+    }
+  )
+
+  test.skipIf(!IS_DARWIN || !browserInstalled("vivaldi"))(
+    "--vivaldi dry-run targets Vivaldi NM dir on macOS",
+    () => {
+      const { stdout, status } = runInstallDryRun(["--browser-only", "--vivaldi"])
+      expect(status).toBe(0)
+      expect(stdout).toContain("Browser: vivaldi")
+      expect(stdout).toContain("Library/Application Support/Vivaldi/NativeMessagingHosts")
+      expect(stdout).not.toContain("Google/Chrome/NativeMessagingHosts")
+      expect(stdout).not.toContain("Brave-Browser/NativeMessagingHosts")
+    }
+  )
+
+  // --edge / --vivaldi must be ACCEPTED as flags even when the corresponding
+  // .app isn't installed (the user gets the NM-symlink step; the dry-run
+  // prints what WOULD have been done). The flag-parser regression here is
+  // important: PR #75 added these flags but kept install detection optional.
+  test.skipIf(!IS_DARWIN)("--edge flag is accepted (no install detection required)", () => {
+    const { stdout, status } = runInstallDryRun(["--browser-only", "--edge"])
+    expect(status).toBe(0)
+    expect(stdout).toContain("Browser: edge")
+  })
+
+  test.skipIf(!IS_DARWIN)("--vivaldi flag is accepted (no install detection required)", () => {
+    const { stdout, status } = runInstallDryRun(["--browser-only", "--vivaldi"])
+    expect(status).toBe(0)
+    expect(stdout).toContain("Browser: vivaldi")
+  })
+})
+
+/**
+ * branded-Chromium `--load-extension` flow assertion.
+ *
+ * Chrome and Edge both ignore --load-extension in their branded desktop
+ * builds; the script must surface the developer-flow remediation rather
+ * than launch a no-op. Tested under --dry-run so we don't actually launch
+ * a browser.
+ *
+ * NB: the "branded build ignores --load-extension" remediation block
+ * lives inside `load_extension()` past the DRY_RUN early-return, so the
+ * dry-run path doesn't currently exercise this branch. We instead grep
+ * the script source for the exact remediation message — a cheap and
+ * deterministic regression assertion that catches accidental removal
+ * of the Edge case.
+ */
+describe("install branded-Chromium messaging — static checks", () => {
+  test("install.sh prints branded-build remediation for Chrome AND Edge", () => {
+    const src = require("node:fs").readFileSync(INSTALL_SCRIPT, "utf8")
+    // Single block; both vendors should be handled together.
+    expect(src).toContain('target" == "chrome" || "$target" == "edge"')
+    expect(src).toContain("ignores --load-extension in branded desktop builds")
+    // Developer flow URL substitution must be present for Edge.
+    expect(src).toMatch(/SCHEMA="edge"/)
+  })
+})
+
+/**
+ * install.ps1 carries the Edge native-messaging registry key.
+ *
+ * We can't run PowerShell from macOS CI, but a static grep on the .ps1
+ * source catches accidental removal of the Edge key. Path shape per
+ * native-messaging.md:64 (vendor-substituted: Google → Microsoft, Chrome → Edge).
+ */
+describe("install.ps1 — Edge registry key", () => {
+  test("install.ps1 contains the Edge NativeMessagingHosts registry key", () => {
+    const psScript = resolve(REPO_ROOT, "scripts/install.ps1")
+    const src = require("node:fs").readFileSync(psScript, "utf8")
+    expect(src).toMatch(/HKCU:\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\com\.interceptor\.host/)
   })
 })

--- a/test/os-input-platform.test.ts
+++ b/test/os-input-platform.test.ts
@@ -1,0 +1,80 @@
+/**
+ * test/os-input-platform.test.ts
+ *
+ * Regression test for the daemon's macOS FFI being gated to Darwin only.
+ *
+ * The daemon imports os-input (CoreGraphics-backed `act --os` implementation)
+ * at startup. Before the platform guard, the module's top-level `dlopen` of
+ * /System/Library/Frameworks/CoreGraphics.framework/CoreGraphics threw
+ * ERR_DLOPEN_FAILED on Linux at module-load time, crashing the daemon before
+ * NM handshake. The fix gates the dlopen on process.platform === "darwin"
+ * and short-circuits each exported os* function with an unsupported error
+ * on non-Darwin.
+ *
+ * These tests assert two contracts on non-Darwin:
+ *   1. `import("./daemon/os-input")` succeeds without throwing
+ *   2. Each exported os* function returns { success: false } with a
+ *      platform-mention error string instead of attempting CG operations
+ */
+
+import { describe, expect, test } from "bun:test"
+import { resolve } from "node:path"
+
+const REPO_ROOT = resolve(import.meta.dir, "..")
+const IS_DARWIN = process.platform === "darwin"
+
+describe("os-input — non-Darwin platform guard", () => {
+  test("module imports without throwing on non-Darwin", async () => {
+    // Importing the module is the regression check. Before the fix this threw
+    // ERR_DLOPEN_FAILED on Linux. We don't await the actions, just module load.
+    let threw: unknown = null
+    try {
+      await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    } catch (e) {
+      threw = e
+    }
+    expect(threw).toBeNull()
+  })
+
+  test.skipIf(IS_DARWIN)("osClick returns unsupported on non-Darwin", async () => {
+    const mod = await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    const result = await mod.osClick(0, 0)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/macOS only|not supported/)
+  })
+
+  test.skipIf(IS_DARWIN)("osKey returns unsupported on non-Darwin", async () => {
+    const mod = await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    const result = await mod.osKey("a")
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/macOS only|not supported/)
+  })
+
+  test.skipIf(IS_DARWIN)("osType returns unsupported on non-Darwin", async () => {
+    const mod = await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    const result = await mod.osType("hello")
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/macOS only|not supported/)
+  })
+
+  test.skipIf(IS_DARWIN)("osMove returns unsupported on non-Darwin", async () => {
+    const mod = await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    const result = await mod.osMove([{ x: 0, y: 0 }, { x: 1, y: 1 }])
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/macOS only|not supported/)
+  })
+
+  test("pure helpers (generateBezierPath, translateCoords) work on every platform", async () => {
+    const mod = await import(resolve(REPO_ROOT, "daemon/os-input.ts"))
+    // generateBezierPath is just math; it must not depend on the platform guard.
+    const path = mod.generateBezierPath(0, 0, 100, 100, 5)
+    expect(path).toBeArray()
+    expect(path.length).toBe(6) // steps=5 → 6 points (inclusive)
+    expect(path[0]).toEqual({ x: 0, y: 0 })
+    expect(path[path.length - 1]).toEqual({ x: 100, y: 100 })
+
+    // translateCoords is also pure arithmetic.
+    const coords = mod.translateCoords(50, 50, { left: 10, top: 20, width: 800, height: 600 })
+    expect(coords).toEqual({ screenX: 60, screenY: 158 }) // 20 + 88 (chromeUiHeight) + 50
+  })
+})

--- a/test/release-modes.test.ts
+++ b/test/release-modes.test.ts
@@ -16,6 +16,22 @@ const REPO_ROOT = resolve(import.meta.dir, "..")
 const RELEASE_SCRIPT = resolve(REPO_ROOT, "scripts/release.sh")
 const TEST_VERSION = "0.0.0-test"
 
+/**
+ * True on macOS. The whole describe block below is gated behind this.
+ *
+ * scripts/release.sh exercises the macOS-only release pipeline: codesign,
+ * productbuild, xcrun notarytool/stapler, /Volumes/ disk images, .pkg signing.
+ * None of this is meaningful on Linux. The dry-run still emits the script
+ * commands, but the assertions are written against macOS-specific paths and
+ * would be misleading if they ran on Linux.
+ */
+const IS_DARWIN = process.platform === "darwin"
+
+/**
+ * Run scripts/release.sh in dry-run mode at a fixed test version and capture
+ * stdout/stderr/exit status. Sets `INTERCEPTOR_DRY_RUN=1` so the script never
+ * shells out to codesign/notarytool or produces real .pkg artifacts.
+ */
 function runReleaseDryRun(args: string[]): {
   stdout: string
   stderr: string
@@ -38,7 +54,7 @@ function runReleaseDryRun(args: string[]): {
   }
 }
 
-describe("release modes — dry-run", () => {
+describe.skipIf(!IS_DARWIN)("release modes — dry-run", () => {
   test("--browser-only emits Browser pkg and zero bridge artifacts", () => {
     const { stdout, status } = runReleaseDryRun(["--browser-only"])
     expect(status).toBe(0)

--- a/test/release-modes.test.ts
+++ b/test/release-modes.test.ts
@@ -205,14 +205,11 @@ describe.skipIf(!IS_DARWIN)("release modes — dry-run", () => {
     expect(both).not.toMatch(/append appcast item/)
   })
 
-  test("Browser pkg stages the browser-surface skills only", () => {
+  test("Browser pkg stages the browser-surface skill only", () => {
     const { stdout, status } = runReleaseDryRun(["--browser-only"])
     expect(status).toBe(0)
 
-    // Browser daemon staging must include the two browser-surface skills.
-    expect(stdout).toContain(
-      ".agents/skills/interceptor /Volumes",
-    )
+    // Browser daemon staging must include the browser-surface skill.
     expect(stdout).toContain(
       ".agents/skills/interceptor-browser /Volumes",
     )
@@ -220,13 +217,10 @@ describe.skipIf(!IS_DARWIN)("release modes — dry-run", () => {
     expect(stdout).not.toContain(".agents/skills/interceptor-macos")
   })
 
-  test("Full pkg stages all three skills (browser two + macOS one)", () => {
+  test("Full pkg stages both the browser-surface and macOS skills", () => {
     const { stdout, status } = runReleaseDryRun(["--full"])
     expect(status).toBe(0)
 
-    expect(stdout).toContain(
-      ".agents/skills/interceptor /Volumes",
-    )
     expect(stdout).toContain(
       ".agents/skills/interceptor-browser /Volumes",
     )

--- a/test/release-modes.test.ts
+++ b/test/release-modes.test.ts
@@ -143,11 +143,11 @@ describe.skipIf(!IS_DARWIN)("release modes — dry-run", () => {
     expect(stdout).toContain("Interceptor-Daemon-Browser.pkg")
     expect(stdout).toContain("Interceptor-Daemon-Full.pkg")
 
-    // Step 13 must publish both pkgs to Sparkle.
-    expect(stdout).toMatch(
-      /append appcast item \(browser-only, minSysVer 11\.0\)/,
-    )
-    expect(stdout).toMatch(/append appcast item \(full, minSysVer 14\.0\)/)
+    // Step 13 must defer to the standalone publish script and surface the
+    // command in the operator-facing output. release.sh stops at notarization
+    // + stapling so the maintainer can test the .pkg before pushing to Sparkle.
+    expect(stdout).toContain("Sparkle publish — SKIPPED")
+    expect(stdout).toContain("bash scripts/publish-sparkle.sh")
   })
 
   test("--browser-only and --full are mutually exclusive", () => {
@@ -195,14 +195,14 @@ describe.skipIf(!IS_DARWIN)("release modes — dry-run", () => {
     expect(fullOut).not.toContain("scripts/release/postinstall-browser ")
   })
 
-  test("Sparkle appcast emits one item per built pkg with mode-tagged channel", () => {
+  test("Sparkle publish is decoupled — release.sh skips Step 13 and points at the standalone script", () => {
     const both = runReleaseDryRun([]).stdout
-    // Two distinct DRY appcast lines, one per mode, each carrying the
-    // mode label and minSysVer that distribution-browser.xml / .xml encode.
-    expect(both).toMatch(
-      /append appcast item \(browser-only, minSysVer 11\.0\)/,
-    )
-    expect(both).toMatch(/append appcast item \(full, minSysVer 14\.0\)/)
+    // release.sh no longer auto-publishes to Sparkle; that step lives in
+    // scripts/publish-sparkle.sh so the maintainer can test the .pkg
+    // locally before broadcasting an auto-update.
+    expect(both).toContain("Sparkle publish — SKIPPED")
+    expect(both).toContain("bash scripts/publish-sparkle.sh")
+    expect(both).not.toMatch(/append appcast item/)
   })
 
   test("Browser pkg stages the browser-surface skills only", () => {

--- a/test/status-renderer-hint.test.ts
+++ b/test/status-renderer-hint.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test"
+import { computeBridgeHint } from "../cli/lib/status-renderer"
+
+describe("computeBridgeHint", () => {
+  test("bridge alive — no hint", () => {
+    const hint = computeBridgeHint({
+      bridge: true,
+      mode: "full",
+      launchAgentInstalled: true,
+      launchAgentLoaded: true,
+      launchAgentPath: "/Library/LaunchAgents/com.interceptor.bridge.plist",
+    })
+    expect(hint).toEqual([])
+  })
+
+  test("plist on disk but NOT bootstrapped — emits launchctl bootstrap hint (the bug this fix targets)", () => {
+    const plistPath = "/Library/LaunchAgents/com.interceptor.bridge.plist"
+    const hint = computeBridgeHint({
+      bridge: false,
+      mode: "full",
+      launchAgentInstalled: true,
+      launchAgentLoaded: false,
+      launchAgentPath: plistPath,
+    })
+    const joined = hint.join("\n")
+    expect(joined).toContain("launchctl bootstrap")
+    expect(joined).toContain(plistPath)
+    expect(joined).toContain("NOT bootstrapped")
+    expect(joined).toContain("log out and back in")
+  })
+
+  test("plist on disk, bootstrapped, bridge dead — emits kickstart hint (existing behavior)", () => {
+    const hint = computeBridgeHint({
+      bridge: false,
+      mode: "full",
+      launchAgentInstalled: true,
+      launchAgentLoaded: true,
+      launchAgentPath: "/Library/LaunchAgents/com.interceptor.bridge.plist",
+    })
+    const joined = hint.join("\n")
+    expect(joined).toContain("kickstart")
+    expect(joined).not.toContain("launchctl bootstrap")
+  })
+
+  test("user-scoped plist path is reflected in the bootstrap hint", () => {
+    const userPlist = "/Users/tester/Library/LaunchAgents/com.interceptor.bridge.plist"
+    const hint = computeBridgeHint({
+      bridge: false,
+      mode: "full",
+      launchAgentInstalled: true,
+      launchAgentLoaded: false,
+      launchAgentPath: userPlist,
+    })
+    expect(hint.join("\n")).toContain(userPlist)
+  })
+
+  test("mode=unknown — bridge alive but no plist on disk — surfaces upgrade-to-full guidance", () => {
+    const hint = computeBridgeHint({
+      bridge: true,
+      mode: "unknown",
+      launchAgentInstalled: false,
+      launchAgentLoaded: false,
+      launchAgentPath: null,
+    })
+    // bridge=true short-circuits, so unknown-mode message only fires when bridge is dead.
+    expect(hint).toEqual([])
+
+    const hintDead = computeBridgeHint({
+      bridge: false,
+      mode: "unknown",
+      launchAgentInstalled: false,
+      launchAgentLoaded: false,
+      launchAgentPath: null,
+    })
+    expect(hintDead.join("\n")).toContain("interceptor upgrade --full")
+  })
+
+  test("falls back to /Library/LaunchAgents path when plist path is somehow null", () => {
+    // Defensive case — shouldn't normally happen since launchAgentInstalled
+    // implies launchAgentPath is set, but the formatter should still produce
+    // a usable hint rather than printing 'null' to the user.
+    const hint = computeBridgeHint({
+      bridge: false,
+      mode: "full",
+      launchAgentInstalled: true,
+      launchAgentLoaded: false,
+      launchAgentPath: null,
+    })
+    expect(hint.join("\n")).toContain("/Library/LaunchAgents/com.interceptor.bridge.plist")
+    expect(hint.join("\n")).not.toContain("null")
+  })
+})


### PR DESCRIPTION
## Summary

Lands two community contributions plus three bridge / release-pipeline improvements that accumulated since v0.13.3.

**Community contributions:**
- **Microsoft Edge + Vivaldi installer support** — adds `--edge` / `--vivaldi` flags to `scripts/install.sh`, native-messaging dir routing for both vendors on macOS, the Edge registry key on Windows in `scripts/install.ps1`, and the developer-flow remediation for both Chrome and Edge (which ignore `--load-extension` in branded desktop builds). Contributed by @klausagnoletti — originally [#75](https://github.com/Hacker-Valley-Media/Interceptor/pull/75).
- **Linux browser-only support** — installer now handles `uname -s = Linux` for Chrome and Brave (`~/.config/google-chrome/NativeMessagingHosts` and `~/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts`), and the daemon's CoreGraphics `dlopen` is gated behind `process.platform === "darwin"` so `daemon/os-input.ts` imports cleanly on Linux instead of throwing `ERR_DLOPEN_FAILED` at module load. Contributed by @atabisz — originally [#83](https://github.com/Hacker-Valley-Media/Interceptor/pull/83).

**Macros bonus fixes (from the same Linux work, split for revertibility):**
- **`kCGEventSourceStateHIDSystemState` for daemon-sourced CG events.** Apple's `CGEventSourceStateID` docs explicitly recommend HID state for "a daemon or a user space device driver interpreting hardware state and generating events" — exactly what `interceptor-daemon` is. Side effect: HID-sourced events flip `event.isTrusted=true` on Chromium; the prior `CombinedSessionState` made `--trusted` clicks land on the page but fail every `isTrusted` gate.
- **UTF-16-length-aware `osType`.** `CGEventKeyboardSetUnicodeString`'s `stringLength` is in `UniChar` (UTF-16 code units), not code points. The previous `length=1` dropped the trailing surrogate for any astral-plane code point (emoji, math symbols, etc.) and produced mojibake.

**Bridge resilience:**
- Distinguish **"bridge needs `bootstrap`"** from **"bridge needs `kickstart`"**. When the pkg postinstall's `launchctl bootstrap` call fails silently, the plist ends up on disk in `/Library/LaunchAgents/com.interceptor.bridge.plist` but is never registered into `gui/$(id -u)`. The old kickstart guidance produces `Could not find service ... in domain` — useless. The new probe runs `launchctl print gui/<uid>/com.interceptor.bridge` and surfaces the right command sequence based on the actual state.

**Release pipeline:**
- **`scripts/release.sh` no longer auto-pushes to Sparkle.** The publish step is now a separate `scripts/publish-sparkle.sh` script. Workflow is build → test → publish (only if tested OK), instead of "build, sign, notarize, and immediately broadcast to every auto-update user." The standalone publish script re-verifies `spctl --assess` and `xcrun stapler validate` on each .pkg before mutating the appcast.

**Bench:**
- Head-to-head bench config bumped from `gpt-5.2` → `gpt-5.4`.

## Test coverage

- 173 pass / 6 skip / 0 fail across `bun test` (28 test files, 533 expect() calls).
- `bun run typecheck` clean on all three tsconfigs (host, extension, root).
- `test/install-linux-container.test.ts` (new) — runs install.sh inside a real Ubuntu 24.04 guest spun up via Apple's `container` runtime on the macOS host. Auto-skips when `container` isn't available; passes 4/4 when it is. Pins the Linux NM-dir routing and the daemon-crash regression at the real Linux import path.
- `test/install-modes.test.ts` (extended) — Edge + Vivaldi dry-run cases plus a static check that `install.ps1` carries the Edge registry key.
- `test/os-input-platform.test.ts` (new) — non-Darwin module-import regression.
- `test/bridge-recovery.test.ts` (extended) — bootstrap-vs-kickstart guidance.
- `test/status-renderer-hint.test.ts` (new) — pure-function unit tests for the bridge hint logic.

## Verification on macOS

- `interceptor open https://google.com` + `interceptor screenshot --pixel --save` on the signed/notarized v0.13.4 .pkg produced a working a11y tree + screenshot with the signed-in profile visible.
- `bash scripts/install.sh --full --chrome --dry-run` output is byte-identical to `main`'s pre-PR output after ROOT normalization — zero lines differ on Darwin.

## Verification on Linux (via Apple `container` on the macOS host)

- Ubuntu 24.04 guest: `apt-get install chromium`, `bun build --compile` of daemon + CLI, `bash scripts/install.sh --browser-only --chrome` → NM symlink installed at `~/.config/google-chrome/NativeMessagingHosts/com.interceptor.host.json`, daemon + extension + content-script ping all reachable inside the container.
- End-to-end: `interceptor open https://google.com` + `interceptor screenshot --pixel --save` inside the Linux guest returned a real Google homepage screenshot. Pipeline confirmed working on Linux.

## Out of scope (deferred)

- Edge + Vivaldi on Linux. Microsoft / Vivaldi User Data dirs on Linux vary across distros; install-detection needs separate work.
- Linux release pipeline (`.deb` / `.rpm` / Flatpak). Source install via `bash scripts/install.sh --browser-only` only.
- Wayland-specific quit/relaunch handling. X11 / XWayland verified.
- Sparkle publish. Explicitly **NOT** part of this PR's merge — operator runs `bash scripts/publish-sparkle.sh` after testing if/when they want to broadcast.

## Acknowledgments

`README.md`'s `## Credits` section now lists both community contributors. Co-authored-by trailers are preserved on the relevant commits.

Closes #75
Closes #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft Edge and Vivaldi browser support
  * Enhanced macOS bridge status diagnostics

* **Bug Fixes**
  * Fixed CoreGraphics handling on non-macOS platforms
  * Corrected Unicode text input encoding

* **Chores**
  * Version bumped to 0.13.4
  * Updated benchmark model configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->