### PR TITLE
feat(exports): HAR 1.2, pcapng, and JSON exports for net log + monitor export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ notary-log-*.json
 release-notes-*.md
 staging/
 /release/
+
+# Apple container runtime data dir (symlinked from ~/Library/Application Support/com.apple.container/)
+# Holds Linux container images + per-container VM disk state; never tracked.
+.container-data/

--- a/cli/commands/monitor.ts
+++ b/cli/commands/monitor.ts
@@ -16,6 +16,8 @@ import {
   readSessionMeta,
   readSessionNetArtifacts,
 } from "../../shared/monitor-artifacts"
+import { fromMonitorEvents, writeExport } from "../../shared/exports"
+import { VERSION } from "../version"
 
 type Action = { type: string; [key: string]: unknown }
 
@@ -574,6 +576,17 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
       const inst = flagValue(filtered, "--instruction")
       const action: Action = { type: "monitor_start" }
       if (inst) action.instruction = inst
+      // --persist-bodies persists response bodies for EVERY captured fetch/xhr,
+      // not just cause-tracked ones. Accepts an optional KB cap (default 64).
+      // Example: `monitor start --persist-bodies` or `--persist-bodies 256`.
+      const pbIdx = filtered.indexOf("--persist-bodies")
+      if (pbIdx !== -1) {
+        action.persistBodies = true
+        const next = filtered[pbIdx + 1]
+        if (next && /^\d+$/.test(next)) {
+          action.bodyCapBytes = parseInt(next) * 1024
+        }
+      }
       return action
     }
     case "stop":
@@ -648,19 +661,76 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
         console.error("error: interceptor monitor export requires a sessionId. Use 'interceptor monitor list' to find one.")
         process.exit(1)
       }
-      const json = flagPresent(filtered, "--json")
+      const formatRaw = flagValue(filtered, "--format")
+      const allowedFormats = new Set(["text", "json", "har", "pcapng", "plan"])
+      if (formatRaw && !allowedFormats.has(formatRaw)) {
+        console.error(`error: --format must be one of text|json|har|pcapng|plan (got '${formatRaw}')`)
+        process.exit(1)
+      }
+      const outPath = flagValue(filtered, "--out")
+      // `--json` honours both the parsed flag (when --json was passed after the
+      // sessionId) AND the global jsonMode set in cli/index.ts (when --json
+      // was passed before the subcommand and got stripped). Fixes issue #74.
+      const json = flagPresent(filtered, "--json") || jsonMode
       const plan = flagPresent(filtered, "--plan")
       const wb = flagPresent(filtered, "--with-bodies")
-      if (json) {
+
+      // New --format <har|pcapng|json> path takes precedence over the legacy
+      // --json / --plan booleans. Format `text` falls through to renderSession.
+      // Format `plan` falls through to the buildPlan branch below.
+      if (formatRaw === "har" || formatRaw === "pcapng" || formatRaw === "json") {
+        const meta = readSessionMeta(sid)
+        // Read the session's events timeline (fetch/xhr/sse rows) as the
+        // primary source; net.jsonl artifacts (body archive) enrich each row
+        // via cause-match when present.
         const events = readMonEvents(sid)
-        for (const ev of events) console.log(JSON.stringify(ev))
+        const netArtifacts = readSessionNetArtifacts(sid)
+        const captures = fromMonitorEvents(events, netArtifacts)
+        ;(async () => {
+          try {
+            await writeExport({
+              format: formatRaw,
+              captures,
+              meta: {
+                generatorName: "interceptor",
+                generatorVersion: VERSION,
+                generatedAt: new Date(),
+                source: "monitor-export",
+                session: meta
+                  ? {
+                      sid: meta.sessionId,
+                      startedAt: new Date(meta.startedAt).toISOString(),
+                      endedAt: meta.endedAt ? new Date(meta.endedAt).toISOString() : undefined,
+                      rootTabId: meta.rootTabId,
+                      instruction: meta.instruction,
+                      counts: meta.counts
+                        ? { evt: meta.counts.evt, mut: meta.counts.mut, net: meta.counts.net, nav: meta.counts.nav }
+                        : undefined,
+                    }
+                  : undefined,
+                comment: `monitor session ${sid} (${captures.length} entries)`,
+              },
+              out: outPath,
+            })
+            if (outPath) process.stderr.write(`saved: ${outPath}\n`)
+          } catch (err) {
+            console.error(`error: ${(err as Error).message}`)
+            process.exit(1)
+          }
+        })()
         return null
       }
-      if (plan) {
+
+      if (formatRaw === "plan" || plan) {
         const inclSynthetic = flagPresent(filtered, "--include-synthetic")
         let text = buildPlan(sid, inclSynthetic, wb)
         if (wb) text = withBodies(text, sid)
         console.log(text)
+        return null
+      }
+      if (json) {
+        const events = readMonEvents(sid)
+        for (const ev of events) console.log(JSON.stringify(ev))
         return null
       }
       console.log(renderSession(sid, wb))
@@ -676,14 +746,14 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
 const MONITOR_HELP = `interceptor monitor — record user sessions for agent replay
 
 Usage:
-  interceptor monitor start [--instruction "<text>"]
+  interceptor monitor start [--instruction "<text>"] [--persist-bodies [<KB>]]
   interceptor monitor stop
   interceptor monitor status
   interceptor monitor pause
   interceptor monitor resume
   interceptor monitor tail [--session <sid>] [--raw]
   interceptor monitor list
-  interceptor monitor export <sessionId> [--json|--plan] [--with-bodies]
+  interceptor monitor export <sessionId> [--format text|json|har|pcapng|plan] [--out <path>] [--json|--plan] [--with-bodies]
 
 start    Begin recording on the active interceptor-group tab.
 stop     End the active session and emit a summary.

--- a/cli/commands/network.ts
+++ b/cli/commands/network.ts
@@ -38,13 +38,22 @@ export function parseNetworkCommand(filtered: string[]): Action {
 
     case "net":
       switch (filtered[1]) {
-        case "log":
+        case "log": {
+          const formatRaw = filtered.includes("--format") ? filtered[filtered.indexOf("--format") + 1] : undefined
+          const allowedFormats = new Set(["text", "json", "har", "pcapng"])
+          if (formatRaw && !allowedFormats.has(formatRaw)) {
+            console.error(`error: --format must be one of text|json|har|pcapng (got '${formatRaw}')`)
+            process.exit(1)
+          }
           return {
             type: "net_log",
             filter: filtered.includes("--filter") ? filtered[filtered.indexOf("--filter") + 1] : undefined,
             since: filtered.includes("--since") ? parseInt(filtered[filtered.indexOf("--since") + 1]) : undefined,
-            limit: filtered.includes("--limit") ? parseInt(filtered[filtered.indexOf("--limit") + 1]) : undefined
+            limit: filtered.includes("--limit") ? parseInt(filtered[filtered.indexOf("--limit") + 1]) : undefined,
+            format: formatRaw,
+            out: filtered.includes("--out") ? filtered[filtered.indexOf("--out") + 1] : undefined
           }
+        }
         case "clear":
           return { type: "net_clear" }
         case "headers":

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2,6 +2,7 @@ import { HELP, helpForCommand } from "./help"
 import { parseTabFlag } from "./parse"
 import { formatState, formatTabs, formatCookies, formatResult } from "./format"
 import { sendCommand, sendCommandWs, type DaemonResult, type DaemonResponse } from "./transport"
+import { fromPassive, writeExport, type PassiveNetEntry, type ExportFormat } from "../shared/exports"
 import { ensureDaemon } from "./daemon-spawn"
 import { parseStateCommand } from "./commands/state"
 import { parseActionsCommand } from "./commands/actions"
@@ -255,6 +256,34 @@ async function main() {
       delete d.save
       delete d.dataUrl
       process.stderr.write(`saved: ${d.filePath}\n`)
+    }
+
+    // Net-log export: route through the new format pipeline when --format is set
+    // and not the default text. Text remains on the existing formatResult path.
+    if (action.type === "net_log" && result.success && action.format && action.format !== "text") {
+      const format = action.format as ExportFormat
+      const entries = (result.data as PassiveNetEntry[] | undefined) || []
+      const captures = fromPassive(entries)
+      try {
+        await writeExport({
+          format,
+          captures,
+          meta: {
+            generatorName: "interceptor",
+            generatorVersion: VERSION,
+            generatedAt: new Date(),
+            source: "net-log",
+            comment: `net log buffer dump (${captures.length} entries)`,
+          },
+          out: action.out as string | undefined,
+        })
+        // pcapng with --out: also report saved path. har/json with --out: same. Both go to stderr so stdout stays clean.
+        if (action.out) process.stderr.write(`saved: ${action.out}\n`)
+      } catch (err) {
+        console.error(`error: ${(err as Error).message}`)
+        process.exit(1)
+      }
+      return
     }
 
     // Pretty-print known result types

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background/capabilities/monitor.ts
+++ b/extension/src/background/capabilities/monitor.ts
@@ -252,16 +252,47 @@ async function sendArmToTab(
   tabId: number,
   sessionId: string,
   startedAt: number,
-  documentId?: string
+  documentId?: string,
+  armOpts?: { persistBodies?: boolean; bodyCapBytes?: number },
 ): Promise<{ success: boolean; error?: string }> {
   const check = await ensureContentScript(tabId, documentId)
   if (!check.connected) return { success: false, error: check.error }
   try {
-    await sendTabMessage(tabId, { type: "monitor_arm", sessionId, startedAt }, documentId)
+    await sendTabMessage(
+      tabId,
+      {
+        type: "monitor_arm",
+        sessionId,
+        startedAt,
+        ...(armOpts?.persistBodies ? { persistBodies: true } : {}),
+        ...(armOpts?.bodyCapBytes ? { bodyCapBytes: armOpts.bodyCapBytes } : {}),
+      },
+      documentId,
+    )
     return { success: true }
   } catch (err) {
     return { success: false, error: (err as Error).message }
   }
+}
+
+/**
+ * Re-arm a tab inheriting the session's persistence policy (from `monitor_start`).
+ * Used for child-tab attaches, history navs, focus switches, resume — anywhere
+ * the content script needs to come back online inside an already-active session.
+ */
+async function rearmTabForSession(
+  tabId: number,
+  session: SessionRecord,
+  documentId?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const sRec = session as SessionRecord & { _persistBodies?: boolean; _bodyCapBytes?: number }
+  return sendArmToTab(
+    tabId,
+    session.sessionId,
+    session.startedAt,
+    documentId,
+    { persistBodies: sRec._persistBodies, bodyCapBytes: sRec._bodyCapBytes },
+  )
 }
 
 async function sendDisarmToTab(tabId: number, documentId?: string): Promise<unknown> {
@@ -374,7 +405,7 @@ function registerWebNavListenersOnce(): void {
       tt: details.transitionType,
       tq: details.transitionQualifiers
     })
-    void sendArmToTab(details.tabId, session.sessionId, session.startedAt, current?.documentId).then((res) => {
+    void rearmTabForSession(details.tabId, session, current?.documentId).then((res) => {
       if (!res.success) console.error(`re-arm after history nav failed on tab ${details.tabId}:`, res.error)
     })
   })
@@ -396,7 +427,7 @@ function registerWebNavListenersOnce(): void {
       tt: details.transitionType,
       tq: details.transitionQualifiers
     })
-    void sendArmToTab(details.tabId, session.sessionId, session.startedAt, current?.documentId).then((res) => {
+    void rearmTabForSession(details.tabId, session, current?.documentId).then((res) => {
       if (!res.success) console.error(`re-arm after fragment nav failed on tab ${details.tabId}:`, res.error)
     })
   })
@@ -406,7 +437,7 @@ function registerWebNavListenersOnce(): void {
     const session = getActiveSessionForTab(details.tabId)
     if (!session || session.paused) return
     const current = getCurrentAttachment(session)
-    void sendArmToTab(details.tabId, session.sessionId, session.startedAt, current?.documentId).then((res) => {
+    void rearmTabForSession(details.tabId, session, current?.documentId).then((res) => {
       if (!res.success) console.error(`re-arm after navigation completed failed on tab ${details.tabId}:`, res.error)
     })
   })
@@ -479,7 +510,7 @@ async function handleFocusActivated(tabId: number): Promise<void> {
   )
   switchToAttachment(session, next, "focus_switch")
 
-  const armRes = await sendArmToTab(tabId, session.sessionId, session.startedAt, ctx.documentId)
+  const armRes = await rearmTabForSession(tabId, session, ctx.documentId)
   if (!armRes.success) {
     console.error(`focus_switch arm failed for tab ${tabId}: ${armRes.error}`)
   }
@@ -710,10 +741,22 @@ export async function handleMonitorActions(
         activeAttachmentKey: initialAttachment.key
       }
 
-      const armResult = await sendArmToTab(resolvedTabId, sessionId, startedAt, initialAttachment.documentId)
+      const persistBodies = action.persistBodies === true
+      const bodyCapBytes = typeof action.bodyCapBytes === "number" ? action.bodyCapBytes : undefined
+      const armResult = await sendArmToTab(
+        resolvedTabId,
+        sessionId,
+        startedAt,
+        initialAttachment.documentId,
+        { persistBodies, bodyCapBytes },
+      )
       if (!armResult.success) {
         return { success: false, error: armResult.error, tabId: resolvedTabId }
       }
+      // Remember the session-wide persistence policy on the SessionRecord so
+      // child-tab re-arms (e.g. via mon_attach) inherit it.
+      ;(session as SessionRecord & { _persistBodies?: boolean; _bodyCapBytes?: number })._persistBodies = persistBodies
+      ;(session as SessionRecord & { _persistBodies?: boolean; _bodyCapBytes?: number })._bodyCapBytes = bodyCapBytes
 
       sessions.set(sessionId, session)
       activeSessionByTab.set(resolvedTabId, sessionId)
@@ -873,7 +916,7 @@ export async function handleMonitorActions(
         t: Date.now(),
         ...(current ? { tid: current.tabId, doc: current.documentId } : {})
       })
-      const armResult = await sendArmToTab(resolvedTabId, sid, session.startedAt, current?.documentId)
+      const armResult = await rearmTabForSession(resolvedTabId, session, current?.documentId)
       if (!armResult.success) {
         console.error(`re-arm after resume failed on tab ${resolvedTabId}:`, armResult.error)
       }

--- a/extension/src/content/monitor.ts
+++ b/extension/src/content/monitor.ts
@@ -38,7 +38,11 @@ const SCROLL_THROTTLE_MS = 100
 
 let mutationObserver: MutationObserver | null = null
 
-const NET_BODY_PREVIEW_CAP = 64 * 1024
+const NET_BODY_PREVIEW_CAP_DEFAULT = 64 * 1024
+// When --persist-bodies is on, the session widens the cap and bypasses the
+// cause + MIME-allowlist gates.
+let netBodyCap = NET_BODY_PREVIEW_CAP_DEFAULT
+let persistBodiesAlways = false
 
 type CapturedListener = { type: string; fn: EventListener; opts: AddEventListenerOptions }
 const attachedListeners: CapturedListener[] = []
@@ -129,10 +133,12 @@ function redactSensitiveText(text: string): string {
 
 function buildBodyPreview(contentType: string, body: string): { preview: string; bytes: number; truncated: boolean } | null {
   if (!body) return null
-  if (!shouldPersistBody(contentType, body)) return null
+  // When --persist-bodies is off, keep the original MIME allowlist.
+  // When on, persist everything (still redacted, still capped).
+  if (!persistBodiesAlways && !shouldPersistBody(contentType, body)) return null
   const redacted = redactSensitiveText(body)
-  const truncated = redacted.length > NET_BODY_PREVIEW_CAP
-  const preview = truncated ? redacted.slice(0, NET_BODY_PREVIEW_CAP) : redacted
+  const truncated = redacted.length > netBodyCap
+  const preview = truncated ? redacted.slice(0, netBodyCap) : redacted
   return { preview, bytes: body.length, truncated }
 }
 
@@ -416,7 +422,10 @@ function onInterceptorNet(e: Event) {
     const now = Date.now()
     const cause = findCause(now)
     const contentType = truncate(detail.contentType || "", 120)
-    const preview = cause !== undefined
+    // When --persist-bodies is on, build a preview for every captured request,
+    // not just cause-tracked ones. Otherwise keep the original cause-gate so
+    // disk usage stays bounded for long sessions.
+    const preview = (persistBodiesAlways || cause !== undefined)
       ? buildBodyPreview(detail.contentType || "", detail.body || "")
       : null
     emit({
@@ -467,7 +476,11 @@ function attach(type: string, fn: EventListener, opts: AddEventListenerOptions) 
   attachedListeners.push({ type, fn, opts })
 }
 
-export function arm(newSessionId: string, _startedAt: number): void {
+export function arm(
+  newSessionId: string,
+  _startedAt: number,
+  opts?: { persistBodies?: boolean; bodyCapBytes?: number },
+): void {
   if (armed) return
   armed = true
   sessionId = newSessionId
@@ -478,6 +491,10 @@ export function arm(newSessionId: string, _startedAt: number): void {
   scrollAccX = 0
   scrollAccY = 0
   scrollLastEmit = 0
+  persistBodiesAlways = Boolean(opts?.persistBodies)
+  netBodyCap = typeof opts?.bodyCapBytes === "number" && opts.bodyCapBytes > 0
+    ? opts.bodyCapBytes
+    : NET_BODY_PREVIEW_CAP_DEFAULT
 
   const captureOpts: AddEventListenerOptions = { capture: true, passive: true }
 
@@ -550,7 +567,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (!msg || typeof msg !== "object") return
   if (msg.type === "monitor_arm") {
     try {
-      arm(msg.sessionId as string, (msg.startedAt as number) || Date.now())
+      arm(
+        msg.sessionId as string,
+        (msg.startedAt as number) || Date.now(),
+        {
+          persistBodies: msg.persistBodies === true,
+          bodyCapBytes: typeof msg.bodyCapBytes === "number" ? msg.bodyCapBytes : undefined,
+        },
+      )
       sendResponse({ success: true, armed: true })
     } catch (err) {
       sendResponse({ success: false, error: (err as Error).message })

--- a/extension/src/content/net-buffer.ts
+++ b/extension/src/content/net-buffer.ts
@@ -9,6 +9,8 @@ type PassiveCapturedEntry = {
   tabUrl: string
   contentType?: string
   truncated?: boolean
+  requestHeaders?: Record<string, string>
+  responseHeaders?: Record<string, string>
 }
 const netBuffer: PassiveCapturedEntry[] = []
 

--- a/extension/src/inject-net.ts
+++ b/extension/src/inject-net.ts
@@ -138,6 +138,15 @@ if ((window as any).__interceptor_net_installed) {
       const acceptHeader = (reqHeaders?.accept || reqHeaders?.Accept || "").toLowerCase()
       const isSse = contentType.includes("text/event-stream") || acceptHeader.includes("text/event-stream")
 
+      const responseHeaders: Record<string, string> = {}
+      try {
+        const setCookies = (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.()
+        response.headers.forEach((v, k) => { responseHeaders[k] = v })
+        if (setCookies && setCookies.length > 1) {
+          responseHeaders["set-cookie"] = setCookies.join("\n")
+        }
+      } catch {}
+
       if (isSse && response.body && !response.bodyUsed) {
         try {
           const reader = response.body.getReader()
@@ -165,7 +174,9 @@ if ((window as any).__interceptor_net_installed) {
                           type: "fetch",
                           timestamp: Date.now(),
                           truncated,
-                          contentType
+                          contentType,
+                          requestHeaders: reqHeaders || {},
+                          responseHeaders
                         }
                       }))
                       document.dispatchEvent(new CustomEvent("__interceptor_sse_done", {
@@ -231,7 +242,9 @@ if ((window as any).__interceptor_net_installed) {
               type: "fetch",
               timestamp: Date.now(),
               truncated: false,
-              contentType
+              contentType,
+              requestHeaders: reqHeaders || {},
+              responseHeaders
             }
           }))
         }).catch(() => {})
@@ -282,6 +295,22 @@ if ((window as any).__interceptor_net_installed) {
     this.addEventListener("load", function (this: XHRWithInterceptor) {
       try {
         const responseText = this.responseText
+        const responseHeaders: Record<string, string> = {}
+        try {
+          const raw = this.getAllResponseHeaders() || ""
+          for (const line of raw.split(/\r?\n/)) {
+            const idx = line.indexOf(":")
+            if (idx > 0) {
+              const name = line.slice(0, idx).trim().toLowerCase()
+              const value = line.slice(idx + 1).trim()
+              if (name in responseHeaders) {
+                responseHeaders[name] = responseHeaders[name] + "\n" + value
+              } else {
+                responseHeaders[name] = value
+              }
+            }
+          }
+        } catch {}
         document.dispatchEvent(new CustomEvent("__interceptor_net", {
           detail: {
             url: xhrUrl,
@@ -291,7 +320,9 @@ if ((window as any).__interceptor_net_installed) {
             type: "xhr",
             timestamp: Date.now(),
             truncated: false,
-            contentType: (this.getResponseHeader("content-type") || "").toLowerCase()
+            contentType: (this.getResponseHeader("content-type") || "").toLowerCase(),
+            requestHeaders: xhrHeaders || {},
+            responseHeaders
           }
         }))
       } catch {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/shared/exports/har.ts
+++ b/shared/exports/har.ts
@@ -1,0 +1,396 @@
+/**
+ * shared/exports/har.ts — UnifiedCapture[] → HAR 1.2 document.
+ *
+ * Pure function. Returns the HAR JSON object; the caller stringifies and writes.
+ *
+ * Format reference: HAR 1.2 spec at http://www.softwareishard.com/blog/har-12-spec/
+ *
+ * Field-by-field mapping decisions:
+ *   - `version` is the literal "1.2".
+ *   - Required arrays (request.cookies / request.headers / request.queryString /
+ *     response.cookies / response.headers) are always emitted, possibly empty.
+ *   - `entry.time` MUST equal the sum of non-(-1) timings; we synthesise
+ *     send=0, wait=floor(0.9*dur), receive=dur-wait so the invariant holds
+ *     when only a total duration is known.
+ *   - `headersSize` / `bodySize` are `-1` when not measured by the capture.
+ *   - Custom fields (`_source`, `_truncated`, `_initiator`) start with
+ *     underscore per the HAR spec's custom-fields rule.
+ */
+
+import type { UnifiedCapture, ExportMetadata } from "./types"
+
+// HAR document shape — minimal slice we generate. Consumers parse the full
+// 1.2 spec but only this subset is required to be valid.
+export type HarDocument = {
+  log: {
+    version: "1.2"
+    creator: { name: string; version: string; comment?: string }
+    browser?: { name: string; version: string }
+    pages?: HarPage[]
+    entries: HarEntry[]
+    comment?: string
+  }
+}
+
+export type HarPage = {
+  startedDateTime: string
+  id: string
+  title: string
+  pageTimings: { onContentLoad: number; onLoad: number; comment?: string }
+}
+
+export type HarEntry = {
+  pageref?: string
+  startedDateTime: string
+  time: number
+  request: HarRequest
+  response: HarResponse
+  cache: Record<string, never>
+  timings: HarTimings
+  // Custom fields per HAR 1.2 §"Custom Fields" — MUST start with underscore.
+  _source: UnifiedCapture["source"]
+  _truncated?: boolean
+  _initiator?: { cause?: number; tabId?: number; seq?: number }
+}
+
+export type HarRequest = {
+  method: string
+  url: string
+  httpVersion: string
+  cookies: HarCookie[]
+  headers: HarHeader[]
+  queryString: HarQueryParam[]
+  postData?: { mimeType: string; text?: string; params?: HarParam[] }
+  headersSize: number
+  bodySize: number
+}
+
+export type HarResponse = {
+  status: number
+  statusText: string
+  httpVersion: string
+  cookies: HarCookie[]
+  headers: HarHeader[]
+  content: HarContent
+  redirectURL: string
+  headersSize: number
+  bodySize: number
+}
+
+export type HarHeader = { name: string; value: string }
+export type HarCookie = {
+  name: string
+  value: string
+  path?: string
+  domain?: string
+  expires?: string
+  httpOnly?: boolean
+  secure?: boolean
+}
+export type HarQueryParam = { name: string; value: string }
+export type HarParam = { name: string; value?: string; fileName?: string; contentType?: string }
+export type HarContent = {
+  size: number
+  mimeType: string
+  text?: string
+  encoding?: "base64"
+  compression?: number
+}
+export type HarTimings = {
+  blocked: number
+  dns: number
+  connect: number
+  send: number
+  wait: number
+  receive: number
+  ssl: number
+}
+
+// MIME type prefixes that warrant base64 encoding (HAR `content.encoding: "base64"`).
+// docs/HAR/12-content.md "Rules for text / encoding".
+// MIME types we know are text. Anything else under application/* is treated
+// as binary and base64-encoded into HAR content.text per the spec rule at
+// docs/HAR/12-content.md ("Rules for text / encoding").
+const TEXT_APPLICATION_SUBTYPES = new Set<string>([
+  "json",
+  "ld+json",
+  "manifest+json",
+  "vnd.api+json",
+  "xml",
+  "atom+xml",
+  "rss+xml",
+  "xhtml+xml",
+  "javascript",
+  "ecmascript",
+  "x-javascript",
+  "x-www-form-urlencoded",
+  "graphql",
+  "yaml",
+  "x-yaml",
+  "x-ndjson",
+  "x-ldjson",
+  "csp-report",
+])
+
+function isBinaryMime(mime: string | undefined): boolean {
+  if (!mime) return false
+  const m = mime.toLowerCase()
+  // Anchor on the type/subtype only, ignore parameters like `;charset=...`.
+  const slash = m.indexOf("/")
+  if (slash < 0) return false
+  const type = m.slice(0, slash)
+  const subtype = m.slice(slash + 1).split(";")[0].trim()
+
+  if (type === "text") return false
+  if (type === "image" || type === "audio" || type === "video" || type === "font") return true
+  if (type === "application") {
+    if (TEXT_APPLICATION_SUBTYPES.has(subtype)) return false
+    if (subtype.endsWith("+json") || subtype.endsWith("+xml")) return false
+    // Everything else under application/* (octet-stream, pdf, zip, protobuf,
+    // vendor types like vnd.yt-ump, vnd.apple.mpegurl, etc.) — treat as binary.
+    return true
+  }
+  return false
+}
+
+// Map a small set of common HTTP status codes to canonical statusText.
+// For everything else we emit "" which the HAR spec allows.
+function statusTextFor(status: number): string {
+  switch (status) {
+    case 100: return "Continue"
+    case 101: return "Switching Protocols"
+    case 200: return "OK"
+    case 201: return "Created"
+    case 202: return "Accepted"
+    case 204: return "No Content"
+    case 206: return "Partial Content"
+    case 301: return "Moved Permanently"
+    case 302: return "Found"
+    case 303: return "See Other"
+    case 304: return "Not Modified"
+    case 307: return "Temporary Redirect"
+    case 308: return "Permanent Redirect"
+    case 400: return "Bad Request"
+    case 401: return "Unauthorized"
+    case 403: return "Forbidden"
+    case 404: return "Not Found"
+    case 405: return "Method Not Allowed"
+    case 408: return "Request Timeout"
+    case 409: return "Conflict"
+    case 410: return "Gone"
+    case 413: return "Payload Too Large"
+    case 415: return "Unsupported Media Type"
+    case 418: return "I'm a teapot"
+    case 422: return "Unprocessable Entity"
+    case 429: return "Too Many Requests"
+    case 500: return "Internal Server Error"
+    case 501: return "Not Implemented"
+    case 502: return "Bad Gateway"
+    case 503: return "Service Unavailable"
+    case 504: return "Gateway Timeout"
+    default: return ""
+  }
+}
+
+function isoFrom(ms: number): string {
+  if (!ms) return new Date(0).toISOString()
+  return new Date(ms).toISOString()
+}
+
+function headersToArray(headers: Record<string, string>): HarHeader[] {
+  const out: HarHeader[] = []
+  for (const [name, value] of Object.entries(headers)) {
+    // Multiple values are joined with \n by the capture layer; split them
+    // back into individual header rows so HAR consumers see them as the
+    // browser did. docs/HAR/09-headers.md "Duplicate names are allowed".
+    if (value.includes("\n")) {
+      for (const v of value.split("\n")) out.push({ name, value: v })
+    } else {
+      out.push({ name, value })
+    }
+  }
+  return out
+}
+
+function parseQueryString(url: string): HarQueryParam[] {
+  try {
+    const u = new URL(url)
+    const out: HarQueryParam[] = []
+    u.searchParams.forEach((value, name) => out.push({ name, value }))
+    return out
+  } catch {
+    return []
+  }
+}
+
+function parseRequestCookies(headers: Record<string, string>): HarCookie[] {
+  const cookieHeader = headers["cookie"] || headers["Cookie"]
+  if (!cookieHeader) return []
+  const out: HarCookie[] = []
+  for (const pair of cookieHeader.split(";")) {
+    const eq = pair.indexOf("=")
+    if (eq <= 0) continue
+    const name = pair.slice(0, eq).trim()
+    const value = pair.slice(eq + 1).trim()
+    if (name) out.push({ name, value })
+  }
+  return out
+}
+
+function parseSetCookieValue(setCookie: string): HarCookie | null {
+  // Set-Cookie: name=value; Path=/; Domain=example.com; Expires=...; Secure; HttpOnly
+  const parts = setCookie.split(";")
+  if (parts.length === 0) return null
+  const first = parts[0]
+  const eq = first.indexOf("=")
+  if (eq <= 0) return null
+  const cookie: HarCookie = {
+    name: first.slice(0, eq).trim(),
+    value: first.slice(eq + 1).trim(),
+  }
+  for (let i = 1; i < parts.length; i++) {
+    const attr = parts[i].trim()
+    const lower = attr.toLowerCase()
+    if (lower === "secure") { cookie.secure = true; continue }
+    if (lower === "httponly") { cookie.httpOnly = true; continue }
+    const aEq = attr.indexOf("=")
+    if (aEq <= 0) continue
+    const k = attr.slice(0, aEq).trim().toLowerCase()
+    const v = attr.slice(aEq + 1).trim()
+    if (k === "path") cookie.path = v
+    else if (k === "domain") cookie.domain = v
+    else if (k === "expires") cookie.expires = v
+  }
+  return cookie
+}
+
+function parseResponseCookies(headers: Record<string, string>): HarCookie[] {
+  // Capture layer joins multiple Set-Cookie values with \n.
+  const sc = headers["set-cookie"] || headers["Set-Cookie"]
+  if (!sc) return []
+  const out: HarCookie[] = []
+  for (const line of sc.split("\n")) {
+    const cookie = parseSetCookieValue(line)
+    if (cookie) out.push(cookie)
+  }
+  return out
+}
+
+function byteLengthOf(str: string): number {
+  // TextEncoder.encode reports UTF-8 byte length — what HAR's content.size wants
+  // (docs/HAR/12-content.md "size" field).
+  return new TextEncoder().encode(str).byteLength
+}
+
+function maybeBase64(body: string, mime: string | undefined): { text: string; encoding?: "base64" } {
+  if (!isBinaryMime(mime)) return { text: body }
+  // The capture layer stored bytes as a JS string via Response.text() — that's
+  // already lossy for true binary, but base64-encoding the lossy string at least
+  // preserves what we have. Real binary fidelity requires a separate capture mode.
+  // For Bun and modern browsers, btoa works on Latin-1 code points only — fall back
+  // to TextEncoder + base64 over bytes when btoa throws.
+  try {
+    return { text: btoa(body), encoding: "base64" }
+  } catch {
+    const bytes = new TextEncoder().encode(body)
+    let bin = ""
+    for (let i = 0; i < bytes.byteLength; i++) bin += String.fromCharCode(bytes[i])
+    return { text: btoa(bin), encoding: "base64" }
+  }
+}
+
+function buildEntry(capture: UnifiedCapture): HarEntry {
+  const queryString = parseQueryString(capture.url)
+  const requestHeaders = headersToArray(capture.requestHeaders)
+  const responseHeaders = headersToArray(capture.responseHeaders)
+  const requestCookies = parseRequestCookies(capture.requestHeaders)
+  const responseCookies = parseResponseCookies(capture.responseHeaders)
+
+  const bodySize = capture.bodyBytes ?? byteLengthOf(capture.responseBody)
+  const { text, encoding } = maybeBase64(capture.responseBody, capture.responseContentType)
+  const mimeType = capture.responseContentType || "application/octet-stream"
+
+  // Spec invariant docs/HAR/14-timings.md:
+  //   entry.time === blocked + dns + connect + send + wait + receive   (when no -1)
+  // We have only durationMs total. Synthesise send=0, wait=0.9*dur, receive=0.1*dur
+  // and emit -1 for blocked/dns/connect/ssl. Sum of non-(-1) = wait + receive = dur.
+  const total = capture.durationMs
+  const wait = Math.floor(total * 0.9)
+  const receive = total - wait
+  const time = wait + receive
+  const timings: HarTimings = {
+    blocked: -1,
+    dns: -1,
+    connect: -1,
+    send: 0,
+    wait,
+    receive,
+    ssl: -1,
+  }
+
+  const entry: HarEntry = {
+    startedDateTime: isoFrom(capture.startedAt),
+    time,
+    request: {
+      method: capture.method,
+      url: capture.url,
+      httpVersion: "HTTP/1.1",
+      cookies: requestCookies,
+      headers: requestHeaders,
+      queryString,
+      headersSize: -1,
+      bodySize: -1,
+    },
+    response: {
+      status: capture.status,
+      statusText: statusTextFor(capture.status),
+      httpVersion: "HTTP/1.1",
+      cookies: responseCookies,
+      headers: responseHeaders,
+      content: {
+        size: bodySize,
+        mimeType,
+        ...(text ? { text } : {}),
+        ...(encoding ? { encoding } : {}),
+      },
+      redirectURL: "",
+      headersSize: -1,
+      bodySize,
+    },
+    cache: {},
+    timings,
+    _source: capture.source,
+  }
+
+  if (capture.truncated) entry._truncated = true
+  if (capture.cause !== undefined || capture.tabId !== undefined || capture.seq !== undefined) {
+    entry._initiator = {
+      ...(capture.cause !== undefined ? { cause: capture.cause } : {}),
+      ...(capture.tabId !== undefined ? { tabId: capture.tabId } : {}),
+      ...(capture.seq !== undefined ? { seq: capture.seq } : {}),
+    }
+  }
+
+  if (capture.requestPostData) {
+    const reqContentType = capture.requestHeaders["content-type"] || capture.requestHeaders["Content-Type"] || "application/octet-stream"
+    entry.request.postData = { mimeType: reqContentType, text: capture.requestPostData }
+  }
+
+  return entry
+}
+
+export function buildHar(captures: UnifiedCapture[], meta: ExportMetadata): HarDocument {
+  const generatorVersion = meta.generatorVersion || "0.0.0"
+  const doc: HarDocument = {
+    log: {
+      version: "1.2",
+      creator: {
+        name: meta.generatorName || "interceptor",
+        version: generatorVersion,
+      },
+      entries: captures.map(buildEntry),
+    },
+  }
+  if (meta.comment) doc.log.comment = meta.comment
+  return doc
+}

--- a/shared/exports/index.ts
+++ b/shared/exports/index.ts
@@ -1,0 +1,96 @@
+/**
+ * shared/exports/index.ts — public surface for the network-export pipeline.
+ *
+ * Consumers (CLI command handlers) import:
+ *   - `writeExport(...)` — pick the right encoder by format and write to stdout / file.
+ *   - `fromPassive`, `fromMonitorArtifacts` — turn raw capture sources into UnifiedCapture[].
+ *   - Type re-exports.
+ *
+ * Encoders themselves stay pure (UnifiedCapture[] → string | Uint8Array).
+ * I/O lives here.
+ */
+
+import type { ExportFormat, ExportMetadata, UnifiedCapture } from "./types"
+import { buildHar } from "./har"
+import { buildPcapng } from "./pcapng"
+import { buildJsonEnvelope } from "./json-envelope"
+
+export * from "./types"
+export { fromPassive, fromMonitorArtifacts, fromMonitorEvents } from "./unify"
+export type { PassiveNetEntry } from "./unify"
+export { buildHar } from "./har"
+export { buildPcapng } from "./pcapng"
+export { buildJsonEnvelope } from "./json-envelope"
+
+export type WriteExportOptions = {
+  format: ExportFormat
+  captures: UnifiedCapture[]
+  meta: ExportMetadata
+  /** Output path. When omitted, writes to stdout (only safe for text formats). */
+  out?: string
+}
+
+/**
+ * Resolve a format alias to a canonical encoder format.
+ *   "json"   → JSON envelope
+ *   "har"    → HAR 1.2
+ *   "pcapng" → pcapng bytes
+ *   "text"   → caller decides (we return the captures unchanged)
+ *   "plan"   → caller-owned (monitor.ts builds a replay script)
+ */
+export function isBinaryFormat(format: ExportFormat): boolean {
+  return format === "pcapng"
+}
+
+/**
+ * Refuse to dump binary output to a TTY — that would corrupt the user's
+ * terminal. Bun and Node both expose `process.stdout.isTTY` on the writable
+ * stream; we accept the optional override for tests.
+ */
+function stdoutIsTty(): boolean {
+  // process is available in Bun. Cast through unknown to avoid Node typings churn.
+  const out = (globalThis as unknown as { process?: { stdout?: { isTTY?: boolean } } }).process?.stdout
+  return Boolean(out?.isTTY)
+}
+
+/**
+ * Dispatch + write. Returns the number of bytes written (Bun.write contract).
+ *
+ * For text-class formats (`json`, `har`), the encoder output is JSON-stringified
+ * and written. For `pcapng`, a Uint8Array is written verbatim. The text format
+ * is passed through unchanged by this dispatcher — the CLI caller is expected
+ * to fall back to its existing pretty-print pipeline for `format === "text"`.
+ */
+export async function writeExport(opts: WriteExportOptions): Promise<number> {
+  const { format, captures, meta, out } = opts
+  if (format === "text" || format === "plan") {
+    throw new Error(`writeExport does not handle '${format}'; the CLI should branch before reaching here`)
+  }
+
+  if (format === "pcapng" && !out && stdoutIsTty()) {
+    throw new Error("refusing to write binary pcapng to a TTY — pass --out <path> or redirect stdout")
+  }
+
+  let payload: string | Uint8Array
+  if (format === "har") {
+    payload = JSON.stringify(buildHar(captures, meta))
+  } else if (format === "json") {
+    payload = JSON.stringify(buildJsonEnvelope(captures, meta))
+  } else if (format === "pcapng") {
+    payload = buildPcapng(captures, meta)
+  } else {
+    throw new Error(`unknown export format: ${format}`)
+  }
+
+  // Bun.write signatures (docs/bun/docs/runtime/file-io.md):
+  //   Bun.write(path | BunFile | Bun.stdout, string | Uint8Array | ...): Promise<number>
+  // `Bun` is available globally in Bun runtime.
+  const BunRef = (globalThis as unknown as { Bun?: { write: (dest: unknown, data: unknown) => Promise<number>; stdout: unknown } }).Bun
+  if (!BunRef) {
+    throw new Error("Bun runtime is required for writeExport")
+  }
+  if (out) {
+    return BunRef.write(out, payload)
+  }
+  return BunRef.write(BunRef.stdout, payload)
+}

--- a/shared/exports/json-envelope.ts
+++ b/shared/exports/json-envelope.ts
@@ -1,0 +1,120 @@
+/**
+ * shared/exports/json-envelope.ts — UnifiedCapture[] + session meta → InterceptorExport.
+ *
+ * Schema-versioned JSON envelope. The shape is defined by `InterceptorExport`
+ * in ./types.ts — `schemaVersion` is the stability contract. Lossless w.r.t.
+ * the UnifiedCapture input (HAR-incompatible fields like the monitor cause
+ * chain survive; binary bodies are base64-encoded when the MIME indicates a
+ * non-text type via the same heuristic shared/exports/har.ts uses).
+ */
+
+import type {
+  UnifiedCapture,
+  InterceptorExport,
+  InterceptorEntry,
+  ExportMetadata,
+} from "./types"
+
+// See shared/exports/har.ts for the rationale. Kept in sync between encoders.
+const TEXT_APPLICATION_SUBTYPES = new Set<string>([
+  "json", "ld+json", "manifest+json", "vnd.api+json",
+  "xml", "atom+xml", "rss+xml", "xhtml+xml",
+  "javascript", "ecmascript", "x-javascript",
+  "x-www-form-urlencoded", "graphql",
+  "yaml", "x-yaml", "x-ndjson", "x-ldjson", "csp-report",
+])
+
+function isBinaryMime(mime: string | undefined): boolean {
+  if (!mime) return false
+  const m = mime.toLowerCase()
+  const slash = m.indexOf("/")
+  if (slash < 0) return false
+  const type = m.slice(0, slash)
+  const subtype = m.slice(slash + 1).split(";")[0].trim()
+  if (type === "text") return false
+  if (type === "image" || type === "audio" || type === "video" || type === "font") return true
+  if (type === "application") {
+    if (TEXT_APPLICATION_SUBTYPES.has(subtype)) return false
+    if (subtype.endsWith("+json") || subtype.endsWith("+xml")) return false
+    return true
+  }
+  return false
+}
+
+function byteLengthOf(str: string): number {
+  return new TextEncoder().encode(str).byteLength
+}
+
+function maybeBase64(body: string, mime: string | undefined): { text?: string; encoding?: "base64" } {
+  if (!body) return {}
+  if (!isBinaryMime(mime)) return { text: body }
+  try {
+    return { text: btoa(body), encoding: "base64" }
+  } catch {
+    const bytes = new TextEncoder().encode(body)
+    let bin = ""
+    for (let i = 0; i < bytes.byteLength; i++) bin += String.fromCharCode(bytes[i])
+    return { text: btoa(bin), encoding: "base64" }
+  }
+}
+
+function buildEntry(c: UnifiedCapture): InterceptorEntry {
+  const sizeBytes = c.bodyBytes ?? byteLengthOf(c.responseBody)
+  const { text, encoding } = maybeBase64(c.responseBody, c.responseContentType)
+  const mimeType = c.responseContentType || "application/octet-stream"
+
+  const entry: InterceptorEntry = {
+    url: c.url,
+    method: c.method,
+    status: c.status,
+    startedAt: c.startedAt ? new Date(c.startedAt).toISOString() : new Date(0).toISOString(),
+    source: c.source,
+    request: {
+      headers: c.requestHeaders,
+    },
+    response: {
+      headers: c.responseHeaders,
+      content: {
+        mimeType,
+        sizeBytes,
+        ...(text !== undefined ? { text } : {}),
+        ...(encoding ? { encoding } : {}),
+      },
+      truncated: c.truncated,
+    },
+  }
+
+  if (c.endedAt) entry.endedAt = new Date(c.endedAt).toISOString()
+  if (c.durationMs) entry.durationMs = c.durationMs
+  if (c.responseContentType) entry.response.contentType = c.responseContentType
+  if (c.requestPostData) {
+    const reqMime = c.requestHeaders["content-type"] || c.requestHeaders["Content-Type"] || "application/octet-stream"
+    entry.request.postData = { mimeType: reqMime, text: c.requestPostData }
+  }
+  if (c.cause !== undefined) {
+    entry.cause = { idx: c.cause }
+  }
+  if (c.tabId !== undefined) entry.tabId = c.tabId
+  if (c.seq !== undefined) entry.seq = c.seq
+
+  return entry
+}
+
+export function buildJsonEnvelope(
+  captures: UnifiedCapture[],
+  meta: ExportMetadata,
+): InterceptorExport {
+  const generatedAt = (meta.generatedAt || new Date()).toISOString()
+  const doc: InterceptorExport = {
+    schemaVersion: "1.0.0",
+    generator: {
+      name: "interceptor",
+      version: meta.generatorVersion || "0.0.0",
+      generatedAt,
+    },
+    source: meta.source,
+    entries: captures.map(buildEntry),
+  }
+  if (meta.session) doc.session = meta.session
+  return doc
+}

--- a/shared/exports/pcapng.ts
+++ b/shared/exports/pcapng.ts
@@ -1,0 +1,465 @@
+/**
+ * shared/exports/pcapng.ts — UnifiedCapture[] → pcapng bytes.
+ *
+ * Implements the block layout from draft-tuexen-opsawg-pcapng-03
+ * (https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-03.html).
+ * All multi-octet integers are little-endian; the Section Header Block
+ * declares this via Byte-Order Magic 0x1A2B3C4D.
+ *
+ * One Section Header Block (SHB), one Interface Description Block (IDB) per
+ * distinct origin, two Enhanced Packet Blocks (EPB) per captured request
+ * (one outbound for the request, one inbound for the response). Packet Data
+ * is a synthetic Ethernet + IPv4 + TCP + HTTP/1.1 frame — pcapng requires
+ * link-layer bytes per the EPB's LinkType.
+ *
+ * Synthetic-flow choices (Interceptor never sees real wire packets, so we
+ * fabricate a plausible flow that Wireshark's HTTP dissector can read):
+ *   - Client MAC `02:00:00:00:00:01`, server MAC `02:00:00:00:00:02`.
+ *   - Client IP `10.0.0.1`, server IP `10.0.0.2 + (originHash % 250)`.
+ *   - Source port = `0xC000 + (index % 0x3FFF)`. Dest port 80.
+ *   - TCP seq starts at 0 per flow, advances by payload bytes.
+ *   - IP/TCP checksums set to 0 (Wireshark dissects with a "not validated" note).
+ *   - Bodies > PCAPNG_MAX_FRAME_PAYLOAD are split across multiple EPBs so
+ *     each frame stays within the IDB's declared snap length.
+ */
+
+import type { UnifiedCapture, ExportMetadata } from "./types"
+
+// Block type codes (docs/pcapng/02-block-types.md).
+const BLOCK_TYPE_SHB = 0x0a0d0d0a
+const BLOCK_TYPE_IDB = 0x00000001
+const BLOCK_TYPE_EPB = 0x00000006
+
+// SHB byte-order magic (docs/pcapng/06-section-header-block.md).
+const BYTE_ORDER_MAGIC = 0x1a2b3c4d
+
+// LinkType codes (https://www.tcpdump.org/linktypes.html).
+const LINKTYPE_ETHERNET = 1
+
+// Option codes (docs/pcapng/04-options.md + docs/pcapng/06-section-header-block.md + docs/pcapng/07-interface-description-block.md + docs/pcapng/08-enhanced-packet-block.md).
+const OPT_ENDOFOPT = 0
+const OPT_COMMENT = 1
+const SHB_HARDWARE = 2
+const SHB_OS = 3
+const SHB_USERAPPL = 4
+const IF_NAME = 2
+const IF_DESCRIPTION = 3
+const IF_TSRESOL = 9
+const EPB_FLAGS = 2
+
+// EPB Flags Word direction bits (docs/pcapng/08-enhanced-packet-block.md Table "Flags Word").
+const EPB_FLAGS_OUTBOUND = 0b10
+const EPB_FLAGS_INBOUND = 0b01
+
+// Pad an octet count up to the next 32-bit boundary.
+function pad4(n: number): number {
+  return (n + 3) & ~3
+}
+
+function utf8(str: string): Uint8Array {
+  return new TextEncoder().encode(str)
+}
+
+/**
+ * OptionBuilder accumulates option records into a single byte array, then
+ * appends the mandatory opt_endofopt terminator on .finish().
+ */
+class OptionBuilder {
+  private parts: Uint8Array[] = []
+
+  add(code: number, value: Uint8Array): this {
+    const padded = pad4(value.byteLength)
+    const buf = new ArrayBuffer(4 + padded)
+    const dv = new DataView(buf)
+    dv.setUint16(0, code, true)
+    dv.setUint16(2, value.byteLength, true)
+    new Uint8Array(buf).set(value, 4)
+    // Padding bytes are zero by ArrayBuffer default.
+    this.parts.push(new Uint8Array(buf))
+    return this
+  }
+
+  addString(code: number, value: string): this {
+    return this.add(code, utf8(value))
+  }
+
+  addUint8(code: number, value: number): this {
+    return this.add(code, new Uint8Array([value & 0xff]))
+  }
+
+  addUint32(code: number, value: number): this {
+    const buf = new ArrayBuffer(4)
+    new DataView(buf).setUint32(0, value >>> 0, true)
+    return this.add(code, new Uint8Array(buf))
+  }
+
+  finish(): Uint8Array {
+    // opt_endofopt: code 0, length 0, no value.
+    const end = new Uint8Array(4)
+    return concat([...this.parts, end])
+  }
+
+  isEmpty(): boolean {
+    return this.parts.length === 0
+  }
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  let total = 0
+  for (const c of chunks) total += c.byteLength
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.byteLength
+  }
+  return out
+}
+
+function buildBlock(blockType: number, body: Uint8Array): Uint8Array {
+  // General Block Structure (docs/pcapng/01-general-block-structure.md):
+  // type(4) + total_length(4) + body(pad4) + total_length(4)
+  const paddedBodyLen = pad4(body.byteLength)
+  const totalLength = 4 + 4 + paddedBodyLen + 4
+  const buf = new ArrayBuffer(totalLength)
+  const u8 = new Uint8Array(buf)
+  const dv = new DataView(buf)
+  dv.setUint32(0, blockType >>> 0, true)
+  dv.setUint32(4, totalLength, true)
+  u8.set(body, 8)
+  // padding zeros are default
+  dv.setUint32(totalLength - 4, totalLength, true)
+  return u8
+}
+
+function buildSHB(meta: ExportMetadata): Uint8Array {
+  // SHB body: byte_order_magic(4) + major(2) + minor(2) + section_length(8) + options
+  const opts = new OptionBuilder()
+    .addString(SHB_HARDWARE, `${typeof process !== "undefined" ? process.platform : "unknown"} ${typeof process !== "undefined" ? process.arch : ""}`.trim())
+    .addString(SHB_OS, typeof process !== "undefined" && process.versions ? `bun ${process.versions.bun || "?"} node ${process.versions.node || "?"}` : "unknown")
+    .addString(SHB_USERAPPL, `${meta.generatorName || "interceptor"} ${meta.generatorVersion || "0.0.0"}`)
+
+  if (meta.comment) opts.addString(OPT_COMMENT, meta.comment)
+  const optsBytes = opts.finish()
+
+  const bodyLen = 4 + 2 + 2 + 8 + optsBytes.byteLength
+  const body = new ArrayBuffer(bodyLen)
+  const dv = new DataView(body)
+  dv.setUint32(0, BYTE_ORDER_MAGIC >>> 0, true)
+  dv.setUint16(4, 1, true)         // major version
+  dv.setUint16(6, 0, true)         // minor version
+  // section length = -1 (unknown, streaming): 0xFFFFFFFFFFFFFFFF as two LE 32-bit halves
+  dv.setUint32(8, 0xffffffff, true)
+  dv.setUint32(12, 0xffffffff, true)
+  new Uint8Array(body).set(optsBytes, 16)
+  return buildBlock(BLOCK_TYPE_SHB, new Uint8Array(body))
+}
+
+// tshark's default snapshot length is 262144 bytes; packets larger than this
+// fail with "appears to be damaged or corrupt". Cap synthetic frames so they
+// fit. Headers + framing eat 14 + 20 + 20 = 54 bytes; budget the payload.
+const PCAPNG_SNAPLEN = 262144
+const PCAPNG_MAX_FRAME_PAYLOAD = PCAPNG_SNAPLEN - 14 - 20 - 20
+
+function buildIDB(originName: string, originDescription: string): Uint8Array {
+  // IDB body: linktype(2) + reserved(2) + snaplen(4) + options
+  const opts = new OptionBuilder()
+    .addString(IF_NAME, originName)
+    .addString(IF_DESCRIPTION, originDescription)
+    .addUint8(IF_TSRESOL, 9) // nanosecond resolution: MSB=0, value=9 ⇒ 10^-9 s
+  const optsBytes = opts.finish()
+
+  const bodyLen = 2 + 2 + 4 + optsBytes.byteLength
+  const body = new ArrayBuffer(bodyLen)
+  const dv = new DataView(body)
+  dv.setUint16(0, LINKTYPE_ETHERNET, true)
+  dv.setUint16(2, 0, true)         // reserved
+  dv.setUint32(4, PCAPNG_SNAPLEN, true)  // declared snap length matches what we emit
+  new Uint8Array(body).set(optsBytes, 8)
+  return buildBlock(BLOCK_TYPE_IDB, new Uint8Array(body))
+}
+
+function buildEPB(
+  interfaceId: number,
+  timestampMs: number,
+  packetData: Uint8Array,
+  direction: "outbound" | "inbound",
+): Uint8Array {
+  // EPB body:
+  //   interface_id(4) + ts_high(4) + ts_low(4) + cap_len(4) + orig_len(4)
+  //   + packet_data(pad4) + options
+  const tsNs = BigInt(timestampMs) * 1_000_000n
+  const tsHigh = Number((tsNs >> 32n) & 0xffffffffn)
+  const tsLow = Number(tsNs & 0xffffffffn)
+  const capLen = packetData.byteLength
+
+  const opts = new OptionBuilder()
+    .addUint32(EPB_FLAGS, direction === "outbound" ? EPB_FLAGS_OUTBOUND : EPB_FLAGS_INBOUND)
+  const optsBytes = opts.finish()
+
+  const paddedPacketLen = pad4(capLen)
+  const bodyLen = 4 + 4 + 4 + 4 + 4 + paddedPacketLen + optsBytes.byteLength
+  const body = new ArrayBuffer(bodyLen)
+  const dv = new DataView(body)
+  const u8 = new Uint8Array(body)
+  dv.setUint32(0, interfaceId >>> 0, true)
+  dv.setUint32(4, tsHigh >>> 0, true)
+  dv.setUint32(8, tsLow >>> 0, true)
+  dv.setUint32(12, capLen, true)
+  dv.setUint32(16, capLen, true)   // original packet length === captured (we don't truncate)
+  u8.set(packetData, 20)
+  // packet data padding already zero-filled
+  u8.set(optsBytes, 20 + paddedPacketLen)
+  return buildBlock(BLOCK_TYPE_EPB, new Uint8Array(body))
+}
+
+/* --- Synthetic L2/L3/L4 framing ----------------------------------------- */
+
+function originHash(url: string): number {
+  let h = 5381
+  try {
+    const u = new URL(url)
+    const s = u.host
+    for (let i = 0; i < s.length; i++) {
+      h = ((h * 33) ^ s.charCodeAt(i)) >>> 0
+    }
+  } catch {
+    for (let i = 0; i < url.length; i++) {
+      h = ((h * 33) ^ url.charCodeAt(i)) >>> 0
+    }
+  }
+  return h >>> 0
+}
+
+function buildEthernetFrame(srcMac: number[], dstMac: number[], payload: Uint8Array): Uint8Array {
+  // 14-byte Ethernet II header (no VLAN, no FCS): dst(6) + src(6) + ethertype(2 BE)
+  const buf = new Uint8Array(14 + payload.byteLength)
+  buf.set(dstMac, 0)
+  buf.set(srcMac, 6)
+  buf[12] = 0x08  // ethertype IPv4 = 0x0800 (BE: 0x08, 0x00)
+  buf[13] = 0x00
+  buf.set(payload, 14)
+  return buf
+}
+
+function buildIPv4Header(srcIp: number[], dstIp: number[], tcpLen: number): Uint8Array {
+  // 20-byte IPv4 header (no options). All multi-byte big-endian (network order).
+  const totalLen = 20 + tcpLen
+  const buf = new Uint8Array(20)
+  buf[0] = 0x45                              // Version 4, IHL 5 (20 bytes)
+  buf[1] = 0x00                              // DSCP/ECN
+  buf[2] = (totalLen >> 8) & 0xff
+  buf[3] = totalLen & 0xff
+  buf[4] = 0; buf[5] = 0                     // identification
+  buf[6] = 0x40; buf[7] = 0                  // flags=DF, fragment offset 0
+  buf[8] = 64                                // TTL
+  buf[9] = 6                                 // protocol = TCP
+  buf[10] = 0; buf[11] = 0                   // checksum 0 (Wireshark flags as not validated)
+  buf.set(srcIp, 12)
+  buf.set(dstIp, 16)
+  return buf
+}
+
+function buildTcpSegment(
+  srcPort: number,
+  dstPort: number,
+  seq: number,
+  ack: number,
+  flags: number,
+  windowSize: number,
+  payload: Uint8Array,
+): Uint8Array {
+  // 20-byte TCP header (no options): srcPort(2) + dstPort(2) + seq(4) + ack(4) + offset/flags(2) + window(2) + checksum(2) + urgent(2) + payload
+  const headerLen = 20
+  const buf = new Uint8Array(headerLen + payload.byteLength)
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  dv.setUint16(0, srcPort, false)            // big-endian
+  dv.setUint16(2, dstPort, false)
+  dv.setUint32(4, seq >>> 0, false)
+  dv.setUint32(8, ack >>> 0, false)
+  // data offset = 5 (5*4=20 bytes), reserved 0, flags
+  buf[12] = 0x50
+  buf[13] = flags & 0xff
+  dv.setUint16(14, windowSize, false)
+  dv.setUint16(16, 0, false)                 // checksum 0
+  dv.setUint16(18, 0, false)                 // urgent pointer
+  buf.set(payload, headerLen)
+  return buf
+}
+
+function statusLineFor(status: number): string {
+  // Re-use the HAR statusText map by hand to avoid an import cycle with har.ts.
+  const map: Record<number, string> = {
+    100: "Continue", 101: "Switching Protocols",
+    200: "OK", 201: "Created", 202: "Accepted", 204: "No Content", 206: "Partial Content",
+    301: "Moved Permanently", 302: "Found", 303: "See Other", 304: "Not Modified",
+    307: "Temporary Redirect", 308: "Permanent Redirect",
+    400: "Bad Request", 401: "Unauthorized", 403: "Forbidden", 404: "Not Found",
+    405: "Method Not Allowed", 408: "Request Timeout", 409: "Conflict", 410: "Gone",
+    413: "Payload Too Large", 415: "Unsupported Media Type", 418: "I'm a teapot",
+    422: "Unprocessable Entity", 429: "Too Many Requests",
+    500: "Internal Server Error", 501: "Not Implemented", 502: "Bad Gateway",
+    503: "Service Unavailable", 504: "Gateway Timeout",
+  }
+  return map[status] || ""
+}
+
+function buildHttpRequestBytes(capture: UnifiedCapture): Uint8Array {
+  let url: URL
+  try { url = new URL(capture.url) } catch { url = new URL("http://invalid.local" + capture.url) }
+  const path = url.pathname + url.search
+  const host = url.host
+  const lines: string[] = [`${capture.method} ${path} HTTP/1.1`, `Host: ${host}`]
+  for (const [name, value] of Object.entries(capture.requestHeaders)) {
+    if (name.toLowerCase() === "host") continue
+    for (const v of value.split("\n")) lines.push(`${name}: ${v}`)
+  }
+  lines.push("")  // header/body separator
+  const head = lines.join("\r\n") + "\r\n"
+  const body = capture.requestPostData || ""
+  return concat([utf8(head), utf8(body)])
+}
+
+function buildHttpResponseBytes(capture: UnifiedCapture): Uint8Array {
+  const statusText = statusLineFor(capture.status)
+  const lines: string[] = [`HTTP/1.1 ${capture.status} ${statusText}`]
+  for (const [name, value] of Object.entries(capture.responseHeaders)) {
+    for (const v of value.split("\n")) lines.push(`${name}: ${v}`)
+  }
+  // If the capture lacks a content-length header, synthesise one so Wireshark
+  // displays the body cleanly.
+  const hasContentLength = Object.keys(capture.responseHeaders).some((k) => k.toLowerCase() === "content-length")
+  const bodyBytes = utf8(capture.responseBody)
+  if (!hasContentLength) lines.push(`Content-Length: ${bodyBytes.byteLength}`)
+  lines.push("")
+  const head = lines.join("\r\n") + "\r\n"
+  return concat([utf8(head), bodyBytes])
+}
+
+type FlowState = {
+  clientSeq: number
+  serverSeq: number
+  srcPort: number
+}
+
+const FLOW_BASE_PORT = 0xc000
+
+export function buildPcapng(captures: UnifiedCapture[], meta: ExportMetadata): Uint8Array {
+  const blocks: Uint8Array[] = []
+
+  // 1. SHB
+  blocks.push(buildSHB(meta))
+
+  // 2. One IDB per distinct origin. Track origin → interfaceId.
+  const originToIface = new Map<string, number>()
+  const ifaceOrigin: { host: string; description: string }[] = []
+  for (const c of captures) {
+    let host = "unknown"
+    let description = c.url
+    try {
+      const u = new URL(c.url)
+      host = u.host || "unknown"
+      description = `${u.protocol}//${u.host}`
+    } catch {}
+    if (!originToIface.has(host)) {
+      const ifaceId = ifaceOrigin.length
+      originToIface.set(host, ifaceId)
+      ifaceOrigin.push({ host, description })
+    }
+  }
+  // If there were no captures, emit one anonymous IDB so the file remains valid.
+  if (ifaceOrigin.length === 0) {
+    ifaceOrigin.push({ host: "empty", description: "no captures" })
+    originToIface.set("empty", 0)
+  }
+  for (const { host, description } of ifaceOrigin) {
+    blocks.push(buildIDB(`interceptor-${host}`, description))
+  }
+
+  // 3. Two EPBs per capture: request (outbound), response (inbound).
+  // Per-origin flow state advances TCP seq numbers correctly.
+  const flowState = new Map<string, FlowState>()
+  let captureIndex = 0
+  for (const c of captures) {
+    let host = "unknown"
+    try { host = new URL(c.url).host } catch {}
+    const ifaceId = originToIface.get(host) ?? 0
+
+    let flow = flowState.get(host)
+    if (!flow) {
+      flow = {
+        clientSeq: 0,
+        serverSeq: 0,
+        srcPort: FLOW_BASE_PORT + (captureIndex % 0x3fff),
+      }
+      flowState.set(host, flow)
+    }
+    captureIndex++
+
+    const hash = originHash(c.url)
+    const serverOctet = 2 + (hash % 250)
+    const clientIp = [10, 0, 0, 1]
+    const serverIp = [10, 0, 0, serverOctet]
+    const clientMac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01]
+    const serverMac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02]
+
+    // Helper: emit one or more EPBs for an HTTP payload, splitting at the
+    // PCAPNG_MAX_FRAME_PAYLOAD boundary so each synthetic frame fits inside the
+    // IDB's declared snap length (avoids tshark's "cap_len > snaplen" abort).
+    const emitFrames = (
+      payload: Uint8Array,
+      srcMac: number[], dstMac: number[],
+      srcIp: number[], dstIp: number[],
+      srcPort: number, dstPort: number,
+      seqRef: { value: number }, ackRef: { value: number },
+      tsMs: number, dir: "outbound" | "inbound",
+    ) => {
+      let offset = 0
+      while (offset < payload.byteLength) {
+        const remain = payload.byteLength - offset
+        const chunkLen = Math.min(remain, PCAPNG_MAX_FRAME_PAYLOAD)
+        const chunk = payload.subarray(offset, offset + chunkLen)
+        const tcp = buildTcpSegment(srcPort, dstPort, seqRef.value, ackRef.value, 0x18, 65535, chunk)
+        const ip = buildIPv4Header(srcIp, dstIp, tcp.byteLength)
+        const eth = buildEthernetFrame(srcMac, dstMac, concat([ip, tcp]))
+        blocks.push(buildEPB(ifaceId, tsMs, eth, dir))
+        seqRef.value = (seqRef.value + chunkLen) >>> 0
+        offset += chunkLen
+      }
+      // Edge case: zero-byte payload — still emit one minimal frame so the
+      // request/response pairing is visible in tools.
+      if (payload.byteLength === 0) {
+        const tcp = buildTcpSegment(srcPort, dstPort, seqRef.value, ackRef.value, 0x18, 65535, new Uint8Array(0))
+        const ip = buildIPv4Header(srcIp, dstIp, tcp.byteLength)
+        const eth = buildEthernetFrame(srcMac, dstMac, concat([ip, tcp]))
+        blocks.push(buildEPB(ifaceId, tsMs, eth, dir))
+      }
+    }
+
+    const clientSeqRef = { value: flow.clientSeq }
+    const serverSeqRef = { value: flow.serverSeq }
+
+    // Request: client → server, ACK+PSH (0x18). Single frame in practice
+    // (request bodies are small in our captures), but the splitter handles it.
+    const reqHttp = buildHttpRequestBytes(c)
+    emitFrames(
+      reqHttp, clientMac, serverMac, clientIp, serverIp,
+      flow.srcPort, 80, clientSeqRef, serverSeqRef,
+      c.startedAt || Date.now(), "outbound",
+    )
+
+    // Response: server → client. Video chunks (847 KB / 1.6 MB / 877 KB) get
+    // split into multiple frames, each ≤ PCAPNG_MAX_FRAME_PAYLOAD.
+    const respHttp = buildHttpResponseBytes(c)
+    emitFrames(
+      respHttp, serverMac, clientMac, serverIp, clientIp,
+      80, flow.srcPort, serverSeqRef, clientSeqRef,
+      c.endedAt || c.startedAt || Date.now(), "inbound",
+    )
+
+    flow.clientSeq = clientSeqRef.value
+    flow.serverSeq = serverSeqRef.value
+  }
+
+  return concat(blocks)
+}

--- a/shared/exports/types.ts
+++ b/shared/exports/types.ts
@@ -1,0 +1,109 @@
+/**
+ * shared/exports/types.ts — types shared by the HAR, pcapng, and JSON envelope encoders.
+ *
+ * Pure types only. No I/O. Safe to import from CLI, daemon, or (in principle) extension code.
+ *
+ * Format references:
+ *   - HAR 1.2: http://www.softwareishard.com/blog/har-12-spec/
+ *   - pcapng:  https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-03.html
+ *   - The JSON envelope shape is defined here (this file) and consumed by
+ *     `shared/exports/json-envelope.ts` — `schemaVersion` is the contract.
+ */
+
+export type ExportFormat = "text" | "json" | "har" | "pcapng" | "plan"
+
+export type CaptureSource = "fetch" | "xhr" | "sse" | "cdp" | "monitor"
+
+/**
+ * UnifiedCapture is the single input shape every encoder consumes. It's
+ * produced by unify.ts from either passive net-log entries or persisted
+ * monitor session artifacts.
+ */
+export type UnifiedCapture = {
+  url: string
+  method: string
+  status: number
+  startedAt: number              // wall-clock ms; equal to endedAt when only completion time is known
+  endedAt: number                // wall-clock ms (Date.now at capture event)
+  durationMs: number             // endedAt - startedAt; 0 when only completion is known
+  source: CaptureSource
+
+  requestHeaders: Record<string, string>     // empty record if not captured
+  responseHeaders: Record<string, string>    // empty record if not captured
+
+  responseBody: string                       // empty string if not captured / SSE-only
+  responseContentType?: string
+  truncated: boolean
+
+  // optional fields (CDP source)
+  requestPostData?: string
+  // optional fields (monitor source)
+  cause?: number
+  tabId?: number
+  seq?: number
+  bodyBytes?: number             // monitor artifacts store byte count even when body preview was trimmed
+}
+
+/**
+ * Native JSON envelope. Schema-versioned and self-describing.
+ * Shipped by `interceptor net log --format json` and `interceptor monitor export --format json`.
+ */
+export type InterceptorExport = {
+  schemaVersion: "1.0.0"
+  generator: {
+    name: "interceptor"
+    version: string
+    generatedAt: string          // ISO 8601
+  }
+  source: "net-log" | "monitor-export"
+  session?: {
+    sid: string
+    startedAt: string            // ISO 8601
+    endedAt?: string
+    rootTabId?: number
+    instruction?: string
+    counts?: { evt: number; mut: number; net: number; nav: number }
+  }
+  entries: InterceptorEntry[]
+}
+
+export type InterceptorEntry = {
+  url: string
+  method: string
+  status: number
+  startedAt: string              // ISO 8601
+  endedAt?: string
+  durationMs?: number
+  source: CaptureSource
+  request: {
+    headers: Record<string, string>
+    postData?: { mimeType: string; text?: string; encoding?: "base64" }
+  }
+  response: {
+    headers: Record<string, string>
+    contentType?: string
+    content: {
+      mimeType: string
+      sizeBytes: number
+      text?: string
+      encoding?: "base64"
+    }
+    truncated: boolean
+  }
+  cause?: { idx: number; ref?: string; role?: string; name?: string }
+  tabId?: number
+  seq?: number
+}
+
+/**
+ * Options for the unify functions and the encoder dispatch.
+ */
+export type ExportMetadata = {
+  generatorName?: string         // default "interceptor"
+  generatorVersion?: string      // package.json version
+  generatedAt?: Date             // default new Date()
+  source: "net-log" | "monitor-export"
+  session?: InterceptorExport["session"]
+  // Free-form comment ferried into HAR `log.comment` / pcapng SHB `opt_comment`.
+  comment?: string
+}

--- a/shared/exports/unify.ts
+++ b/shared/exports/unify.ts
@@ -1,0 +1,157 @@
+/**
+ * shared/exports/unify.ts — convert raw capture sources into UnifiedCapture[].
+ *
+ * Two source shapes are handled:
+ *   - PassiveCapturedEntry[] from `interceptor net log` (the in-page buffer).
+ *   - MonitorNetArtifact[] from `interceptor monitor export <sid>` (persisted to net.jsonl).
+ *
+ * The output UnifiedCapture is the single input shape consumed by the HAR,
+ * pcapng, and JSON envelope encoders.
+ */
+
+import type { UnifiedCapture, CaptureSource } from "./types"
+import type { MonitorNetArtifact, MonitorEvent } from "../monitor-artifacts"
+
+/**
+ * Passive net-log entry shape (mirrors extension/src/content/net-buffer.ts).
+ * Duplicated here to keep this module free of any direct extension imports.
+ */
+export type PassiveNetEntry = {
+  url: string
+  method: string
+  status: number
+  body: string
+  type: string                              // "fetch" | "xhr" | "sse"
+  timestamp: number
+  tabUrl?: string
+  contentType?: string
+  truncated?: boolean
+  requestHeaders?: Record<string, string>
+  responseHeaders?: Record<string, string>
+}
+
+function entryTypeToSource(type: string): CaptureSource {
+  if (type === "xhr") return "xhr"
+  if (type === "sse") return "sse"
+  return "fetch"
+}
+
+export function fromPassive(entries: PassiveNetEntry[]): UnifiedCapture[] {
+  return entries.map((e) => ({
+    url: e.url,
+    method: e.method,
+    status: e.status,
+    // Passive surface only records completion time; we don't know real start.
+    // Encoders that need a start time will treat startedAt === endedAt as
+    // "duration unknown — synthesise zero".
+    startedAt: e.timestamp,
+    endedAt: e.timestamp,
+    durationMs: 0,
+    source: entryTypeToSource(e.type),
+    requestHeaders: e.requestHeaders || {},
+    responseHeaders: e.responseHeaders || {},
+    responseBody: typeof e.body === "string" ? e.body : "",
+    responseContentType: e.contentType,
+    truncated: Boolean(e.truncated),
+  }))
+}
+
+/**
+ * Convert a monitor session's events.jsonl stream (filtered to fetch/xhr/sse
+ * rows) into UnifiedCapture[]. Optionally enriches each row with the body
+ * preview from net.jsonl via the `cause` match key when available.
+ *
+ * This is the right entry point for `interceptor monitor export <sid> --format <...>`
+ * because the events stream carries the full timeline of network rows whereas
+ * net.jsonl is only populated when `--with-bodies` recording was on.
+ */
+export function fromMonitorEvents(
+  events: MonitorEvent[],
+  artifacts?: MonitorNetArtifact[],
+): UnifiedCapture[] {
+  // Build two indexes into the body archive:
+  //   - bySeq matches an event to its body artifact by event-sequence number.
+  //     This is the precise match (each event has a unique `s` within a session),
+  //     covers autonomous events that have no `cause`.
+  //   - byCause stays as a fallback for older sessions whose artifacts only
+  //     carry `cause` (early monitor recordings before --persist-bodies).
+  const bySeq = new Map<number, MonitorNetArtifact>()
+  const byCause = new Map<number, MonitorNetArtifact>()
+  if (artifacts) {
+    for (const a of artifacts) {
+      if (typeof a.seq === "number") bySeq.set(a.seq, a)
+      if (a.cause !== undefined) byCause.set(a.cause, a)
+    }
+  }
+
+  const out: UnifiedCapture[] = []
+  for (const ev of events) {
+    if (ev.event !== "fetch" && ev.event !== "xhr" && ev.event !== "sse") continue
+
+    const cause = typeof ev.cause === "number" ? ev.cause : undefined
+    const seq = typeof ev.s === "number" ? ev.s : undefined
+    const artifact = (seq !== undefined ? bySeq.get(seq) : undefined)
+      || (cause !== undefined ? byCause.get(cause) : undefined)
+
+    const url = typeof ev.u === "string" ? ev.u : ""
+    const method = typeof ev.m === "string" ? ev.m : "GET"
+    const status = typeof ev.st === "number" ? ev.st : 0
+    const ts = typeof ev.t === "number" ? ev.t : 0
+    const contentType =
+      typeof ev.ct === "string"
+        ? ev.ct
+        : artifact?.contentType
+
+    const bodyPreview =
+      typeof ev.bp === "string"
+        ? ev.bp
+        : artifact?.bodyPreview || ""
+
+    const truncated = Boolean(ev.trn ?? artifact?.truncated ?? false)
+    const bodyBytes = typeof ev.bz === "number" ? ev.bz : artifact?.bodyBytes
+
+    out.push({
+      url,
+      method,
+      status,
+      startedAt: ts,
+      endedAt: ts,
+      durationMs: 0,
+      source: ev.event === "xhr" ? "xhr" : ev.event === "sse" ? "sse" : "fetch",
+      requestHeaders: {},
+      responseHeaders: contentType ? { "content-type": contentType } : {},
+      responseBody: bodyPreview,
+      responseContentType: contentType,
+      truncated,
+      cause,
+      tabId: typeof ev.tid === "number" ? ev.tid : undefined,
+      seq: typeof ev.s === "number" ? ev.s : undefined,
+      bodyBytes,
+    })
+  }
+  return out
+}
+
+export function fromMonitorArtifacts(artifacts: MonitorNetArtifact[]): UnifiedCapture[] {
+  return artifacts.map((a) => ({
+    url: a.url,
+    method: a.method || "GET",
+    status: a.status ?? 0,
+    // MonitorNetArtifact does not record timestamps directly — the parent
+    // event stream owns timing. Encoders that need it will use 0 and emit
+    // sentinel timing values per the HAR mapping table.
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    source: "monitor",
+    requestHeaders: {},
+    responseHeaders: {},
+    responseBody: a.bodyPreview || "",
+    responseContentType: a.contentType,
+    truncated: Boolean(a.truncated),
+    cause: a.cause,
+    tabId: a.tid,
+    seq: a.seq,
+    bodyBytes: a.bodyBytes,
+  }))
+}

--- a/test/exports-har-shape.test.ts
+++ b/test/exports-har-shape.test.ts
@@ -1,0 +1,194 @@
+/**
+ * test/exports-har-shape.test.ts
+ *
+ * Validates that shared/exports/har.ts produces a HAR 1.2 document whose
+ * shape matches the spec invariants documented in docs/HAR/*.md. No external
+ * validator — the test enforces every required-field invariant inline.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { buildHar } from "../shared/exports/har"
+import type { UnifiedCapture, ExportMetadata } from "../shared/exports/types"
+
+const META: ExportMetadata = {
+  generatorName: "interceptor",
+  generatorVersion: "9.9.9",
+  generatedAt: new Date(0),
+  source: "net-log",
+}
+
+function syntheticCaptures(): UnifiedCapture[] {
+  return [
+    {
+      url: "https://example.com/api/users?limit=10",
+      method: "GET",
+      status: 200,
+      startedAt: 1_000_000,
+      endedAt: 1_000_100,
+      durationMs: 100,
+      source: "fetch",
+      requestHeaders: { accept: "application/json", cookie: "sid=abc; lang=en" },
+      responseHeaders: {
+        "content-type": "application/json; charset=utf-8",
+        "set-cookie": "newsid=xyz; Path=/; HttpOnly\nflag=on; Path=/; Secure",
+      },
+      responseBody: '{"ok":true}',
+      responseContentType: "application/json; charset=utf-8",
+      truncated: false,
+    },
+    {
+      url: "https://example.com/img/logo.png",
+      method: "GET",
+      status: 200,
+      startedAt: 1_000_200,
+      endedAt: 1_000_250,
+      durationMs: 50,
+      source: "fetch",
+      requestHeaders: {},
+      responseHeaders: { "content-type": "image/png" },
+      responseBody: "ÿØÿà",      // pretend binary
+      responseContentType: "image/png",
+      truncated: false,
+    },
+    {
+      url: "https://example.com/stream",
+      method: "POST",
+      status: 200,
+      startedAt: 1_000_300,
+      endedAt: 1_000_900,
+      durationMs: 600,
+      source: "sse",
+      requestHeaders: { accept: "text/event-stream" },
+      responseHeaders: { "content-type": "text/event-stream" },
+      responseBody: "event: tick\ndata: 1\n\n",
+      responseContentType: "text/event-stream",
+      truncated: true,
+    },
+  ]
+}
+
+describe("HAR export — shape and invariants", () => {
+  const captures = syntheticCaptures()
+  const har = buildHar(captures, META)
+
+  test("log.version is the literal '1.2'", () => {
+    expect(har.log.version).toBe("1.2")
+  })
+
+  test("log.creator carries the interceptor name and version we passed", () => {
+    expect(har.log.creator.name).toBe("interceptor")
+    expect(har.log.creator.version).toBe("9.9.9")
+  })
+
+  test("entries.length matches captures.length", () => {
+    expect(har.log.entries.length).toBe(captures.length)
+  })
+
+  test("every entry has request, response, cache, timings", () => {
+    for (const e of har.log.entries) {
+      expect(e.request).toBeDefined()
+      expect(e.response).toBeDefined()
+      expect(e.cache).toBeDefined()
+      expect(e.timings).toBeDefined()
+    }
+  })
+
+  test("entry.time === sum of non-(-1) timings (docs/HAR/14-timings.md invariant)", () => {
+    for (const e of har.log.entries) {
+      const t = e.timings
+      const fields: number[] = [t.blocked, t.dns, t.connect, t.send, t.wait, t.receive, t.ssl]
+      const sum = fields.reduce((acc, v) => (v >= 0 ? acc + v : acc), 0)
+      expect(e.time).toBe(sum)
+    }
+  })
+
+  test("request.queryString is parsed from the URL search params", () => {
+    const first = har.log.entries[0]
+    expect(first.request.queryString.length).toBe(1)
+    expect(first.request.queryString[0]).toEqual({ name: "limit", value: "10" })
+  })
+
+  test("request.cookies are parsed from the Cookie header", () => {
+    const first = har.log.entries[0]
+    expect(first.request.cookies.length).toBe(2)
+    expect(first.request.cookies[0].name).toBe("sid")
+    expect(first.request.cookies[0].value).toBe("abc")
+    expect(first.request.cookies[1].name).toBe("lang")
+  })
+
+  test("response.cookies parses multi-value Set-Cookie (joined by \\n upstream)", () => {
+    const first = har.log.entries[0]
+    expect(first.response.cookies.length).toBe(2)
+    expect(first.response.cookies[0].name).toBe("newsid")
+    expect(first.response.cookies[0].httpOnly).toBe(true)
+    expect(first.response.cookies[1].name).toBe("flag")
+    expect(first.response.cookies[1].secure).toBe(true)
+  })
+
+  test("response.headers is populated (non-empty for entries with captured headers)", () => {
+    const first = har.log.entries[0]
+    expect(first.response.headers.length).toBeGreaterThan(0)
+    // The Set-Cookie was joined with \n by the upstream capture layer; the
+    // encoder splits it back into two separate header rows so HAR consumers
+    // see them as the browser did.
+    const setCookieRows = first.response.headers.filter((h) => h.name === "set-cookie")
+    expect(setCookieRows.length).toBe(2)
+  })
+
+  test("binary response bodies get base64 encoding", () => {
+    const png = har.log.entries[1]
+    expect(png.response.content.mimeType).toBe("image/png")
+    expect(png.response.content.encoding).toBe("base64")
+    // text should be base64 — at minimum non-empty and only base64 chars.
+    expect(png.response.content.text).toBeDefined()
+    expect(png.response.content.text!).toMatch(/^[A-Za-z0-9+/=]+$/)
+  })
+
+  test("response.content.size is the UTF-8 byte length", () => {
+    const first = har.log.entries[0]
+    const expected = new TextEncoder().encode('{"ok":true}').byteLength
+    expect(first.response.content.size).toBe(expected)
+  })
+
+  test("_source custom field reflects the UnifiedCapture source", () => {
+    expect(har.log.entries[0]._source).toBe("fetch")
+    expect(har.log.entries[2]._source).toBe("sse")
+  })
+
+  test("_truncated custom field set only on truncated entries", () => {
+    expect(har.log.entries[0]._truncated).toBeUndefined()
+    expect(har.log.entries[2]._truncated).toBe(true)
+  })
+
+  test("custom fields start with underscore (docs/HAR/15 rule)", () => {
+    for (const e of har.log.entries) {
+      for (const key of Object.keys(e)) {
+        const harDefined = new Set([
+          "pageref",
+          "startedDateTime",
+          "time",
+          "request",
+          "response",
+          "cache",
+          "timings",
+          "serverIPAddress",
+          "connection",
+          "comment",
+        ])
+        if (!harDefined.has(key)) {
+          expect(key.startsWith("_")).toBe(true)
+        }
+      }
+    }
+  })
+
+  test("statusText maps known codes", () => {
+    expect(har.log.entries[0].response.statusText).toBe("OK")
+  })
+
+  test("startedDateTime is ISO 8601", () => {
+    for (const e of har.log.entries) {
+      expect(new Date(e.startedDateTime).toISOString()).toBe(e.startedDateTime)
+    }
+  })
+})

--- a/test/exports-json-envelope.test.ts
+++ b/test/exports-json-envelope.test.ts
@@ -1,0 +1,133 @@
+/**
+ * test/exports-json-envelope.test.ts
+ *
+ * Round-trip and schema-shape tests for the native JSON export envelope.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { buildJsonEnvelope } from "../shared/exports/json-envelope"
+import type { UnifiedCapture, ExportMetadata, InterceptorExport } from "../shared/exports/types"
+
+const META: ExportMetadata = {
+  generatorName: "interceptor",
+  generatorVersion: "9.9.9",
+  generatedAt: new Date("2026-05-16T17:00:00.000Z"),
+  source: "net-log",
+}
+
+function fixture(): UnifiedCapture[] {
+  return [
+    {
+      url: "https://example.com/api",
+      method: "GET",
+      status: 200,
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_000_100,
+      durationMs: 100,
+      source: "fetch",
+      requestHeaders: { accept: "application/json" },
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"hello":"world"}',
+      responseContentType: "application/json",
+      truncated: false,
+    },
+    {
+      url: "https://example.com/icon.png",
+      method: "GET",
+      status: 200,
+      startedAt: 1_700_000_001_000,
+      endedAt: 1_700_000_001_050,
+      durationMs: 50,
+      source: "fetch",
+      requestHeaders: {},
+      responseHeaders: { "content-type": "image/png" },
+      responseBody: "raw bytes",
+      responseContentType: "image/png",
+      truncated: false,
+    },
+    {
+      url: "https://example.com/stream",
+      method: "POST",
+      status: 200,
+      startedAt: 1_700_000_002_000,
+      endedAt: 1_700_000_002_500,
+      durationMs: 500,
+      source: "sse",
+      requestHeaders: {},
+      responseHeaders: { "content-type": "text/event-stream" },
+      responseBody: "data: 1\n\n",
+      responseContentType: "text/event-stream",
+      truncated: true,
+    },
+  ]
+}
+
+describe("JSON envelope export", () => {
+  test("schemaVersion is the literal 1.0.0", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    expect(out.schemaVersion).toBe("1.0.0")
+  })
+
+  test("generator block reflects the metadata", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    expect(out.generator.name).toBe("interceptor")
+    expect(out.generator.version).toBe("9.9.9")
+    expect(out.generator.generatedAt).toBe("2026-05-16T17:00:00.000Z")
+  })
+
+  test("source is 'net-log' or 'monitor-export'", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    expect(out.source).toBe("net-log")
+  })
+
+  test("entries.length matches captures.length", () => {
+    const captures = fixture()
+    const out = buildJsonEnvelope(captures, META)
+    expect(out.entries.length).toBe(captures.length)
+  })
+
+  test("round-trip JSON.parse(JSON.stringify(out)) is deep equal", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    const rt = JSON.parse(JSON.stringify(out)) as InterceptorExport
+    expect(rt).toEqual(out)
+  })
+
+  test("base64 encoding applied to binary MIME prefixes", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    const png = out.entries[1]
+    expect(png.response.content.mimeType).toBe("image/png")
+    expect(png.response.content.encoding).toBe("base64")
+    expect(png.response.content.text).toBeDefined()
+    // base64 charset
+    expect(png.response.content.text!).toMatch(/^[A-Za-z0-9+/=]+$/)
+  })
+
+  test("truncated flag propagates", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    expect(out.entries[0].response.truncated).toBe(false)
+    expect(out.entries[2].response.truncated).toBe(true)
+  })
+
+  test("ISO 8601 startedAt", () => {
+    const out = buildJsonEnvelope(fixture(), META)
+    for (const e of out.entries) {
+      expect(new Date(e.startedAt).toISOString()).toBe(e.startedAt)
+    }
+  })
+
+  test("session metadata flows through when provided", () => {
+    const out = buildJsonEnvelope([], {
+      ...META,
+      source: "monitor-export",
+      session: {
+        sid: "abc-123",
+        startedAt: "2026-05-16T17:00:00.000Z",
+        rootTabId: 42,
+        counts: { evt: 100, mut: 50, net: 25, nav: 5 },
+      },
+    })
+    expect(out.source).toBe("monitor-export")
+    expect(out.session?.sid).toBe("abc-123")
+    expect(out.session?.counts?.net).toBe(25)
+  })
+})

--- a/test/exports-pcapng-shape.test.ts
+++ b/test/exports-pcapng-shape.test.ts
@@ -1,0 +1,190 @@
+/**
+ * test/exports-pcapng-shape.test.ts
+ *
+ * Validates the binary layout of shared/exports/pcapng.ts against the
+ * draft-tuexen-opsawg-pcapng-03 block format (docs/pcapng/*.md).
+ *
+ * Key invariants:
+ *   - Byte 0..3 is the SHB block type 0x0A0D0D0A (written little-endian since
+ *     the file is LE, but the magic is a palindromic byte sequence).
+ *   - Byte-Order Magic at offset 8..11 == 0x1A2B3C4D (LE → 4D 3C 2B 1A on disk).
+ *   - Major 1, Minor 0 at offsets 12 / 14.
+ *   - Every block's leading Block Total Length === its trailing Block Total Length.
+ *   - File length === sum of every block's Block Total Length.
+ *   - One SHB, N IDBs (one per distinct origin), 2 EPBs per capture.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { buildPcapng } from "../shared/exports/pcapng"
+import type { UnifiedCapture, ExportMetadata } from "../shared/exports/types"
+
+const META: ExportMetadata = {
+  generatorName: "interceptor",
+  generatorVersion: "9.9.9",
+  generatedAt: new Date(0),
+  source: "net-log",
+}
+
+const BLOCK_TYPE_SHB = 0x0a0d0d0a
+const BLOCK_TYPE_IDB = 0x00000001
+const BLOCK_TYPE_EPB = 0x00000006
+
+function readUint32LE(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true)
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 2).getUint16(0, true)
+}
+
+/** Walk the blocks. Returns array of {type, length, offset}. */
+function walkBlocks(bytes: Uint8Array): Array<{ type: number; length: number; offset: number }> {
+  const out: Array<{ type: number; length: number; offset: number }> = []
+  let offset = 0
+  while (offset + 8 <= bytes.byteLength) {
+    const type = readUint32LE(bytes, offset)
+    const length = readUint32LE(bytes, offset + 4)
+    if (length < 12 || length % 4 !== 0 || offset + length > bytes.byteLength) break
+    // Leading length must equal trailing length.
+    const trailingLen = readUint32LE(bytes, offset + length - 4)
+    if (trailingLen !== length) {
+      throw new Error(`block at offset ${offset}: leading length ${length} != trailing ${trailingLen}`)
+    }
+    out.push({ type, length, offset })
+    offset += length
+  }
+  return out
+}
+
+function syntheticCaptures(): UnifiedCapture[] {
+  // Two captures on origin A, one on origin B → 2 IDBs + (2+1)*2 = 6 EPBs.
+  return [
+    {
+      url: "https://a.example.com/x",
+      method: "GET",
+      status: 200,
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_000_050,
+      durationMs: 50,
+      source: "fetch",
+      requestHeaders: { accept: "application/json" },
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"a":1}',
+      responseContentType: "application/json",
+      truncated: false,
+    },
+    {
+      url: "https://a.example.com/y",
+      method: "POST",
+      status: 201,
+      startedAt: 1_700_000_001_000,
+      endedAt: 1_700_000_001_100,
+      durationMs: 100,
+      source: "xhr",
+      requestHeaders: { "content-type": "application/json" },
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"b":2}',
+      responseContentType: "application/json",
+      truncated: false,
+    },
+    {
+      url: "https://b.example.com/z",
+      method: "GET",
+      status: 200,
+      startedAt: 1_700_000_002_000,
+      endedAt: 1_700_000_002_020,
+      durationMs: 20,
+      source: "fetch",
+      requestHeaders: {},
+      responseHeaders: { "content-type": "text/plain" },
+      responseBody: "hi",
+      responseContentType: "text/plain",
+      truncated: false,
+    },
+  ]
+}
+
+describe("pcapng export — binary shape", () => {
+  const bytes = buildPcapng(syntheticCaptures(), META)
+
+  test("file starts with the SHB block-type magic", () => {
+    expect(bytes[0]).toBe(0x0a)
+    expect(bytes[1]).toBe(0x0d)
+    expect(bytes[2]).toBe(0x0d)
+    expect(bytes[3]).toBe(0x0a)
+  })
+
+  test("byte-order magic at offset 8 is 0x1A2B3C4D (little-endian)", () => {
+    const magic = readUint32LE(bytes, 8)
+    expect(magic).toBe(0x1a2b3c4d)
+  })
+
+  test("SHB version is 1.0", () => {
+    const major = readUint16LE(bytes, 12)
+    const minor = readUint16LE(bytes, 14)
+    expect(major).toBe(1)
+    expect(minor).toBe(0)
+  })
+
+  test("walk yields one SHB + 2 IDBs + 6 EPBs", () => {
+    const blocks = walkBlocks(bytes)
+    const shb = blocks.filter((b) => b.type === BLOCK_TYPE_SHB)
+    const idb = blocks.filter((b) => b.type === BLOCK_TYPE_IDB)
+    const epb = blocks.filter((b) => b.type === BLOCK_TYPE_EPB)
+    expect(shb.length).toBe(1)
+    expect(idb.length).toBe(2)
+    expect(epb.length).toBe(6)
+  })
+
+  test("total file length == sum of block lengths", () => {
+    const blocks = walkBlocks(bytes)
+    const sum = blocks.reduce((acc, b) => acc + b.length, 0)
+    expect(sum).toBe(bytes.byteLength)
+  })
+
+  test("every block's total length is a multiple of 4 (alignment rule)", () => {
+    const blocks = walkBlocks(bytes)
+    for (const b of blocks) {
+      expect(b.length % 4).toBe(0)
+    }
+  })
+
+  test("first block after the SHB is an IDB (file layout rule)", () => {
+    const blocks = walkBlocks(bytes)
+    expect(blocks[1].type).toBe(BLOCK_TYPE_IDB)
+  })
+
+  test("empty capture list still produces a valid SHB + at-least-one-IDB file", () => {
+    const emptyBytes = buildPcapng([], META)
+    const blocks = walkBlocks(emptyBytes)
+    expect(blocks.length).toBeGreaterThanOrEqual(2)
+    expect(blocks[0].type).toBe(BLOCK_TYPE_SHB)
+    // At minimum one IDB to keep readers happy.
+    expect(blocks.some((b) => b.type === BLOCK_TYPE_IDB)).toBe(true)
+  })
+
+  test("EPB Captured Packet Length is non-zero and equals Original Packet Length", () => {
+    const blocks = walkBlocks(bytes)
+    const epbs = blocks.filter((b) => b.type === BLOCK_TYPE_EPB)
+    for (const epb of epbs) {
+      const bodyStart = epb.offset + 8
+      const capLen = readUint32LE(bytes, bodyStart + 12)
+      const origLen = readUint32LE(bytes, bodyStart + 16)
+      expect(capLen).toBeGreaterThan(0)
+      expect(capLen).toBe(origLen)
+    }
+  })
+
+  test("first EPB's first 14 bytes after the fixed-length EPB fields are a valid Ethernet+IPv4 header start", () => {
+    const blocks = walkBlocks(bytes)
+    const firstEpb = blocks.find((b) => b.type === BLOCK_TYPE_EPB)!
+    const packetStart = firstEpb.offset + 8 + 20  // skip 4+4+4+4+4 fixed fields
+    // Ethernet dst mac is bytes [packetStart..packetStart+6); skip to ethertype @ +12
+    const ethertype = (bytes[packetStart + 12] << 8) | bytes[packetStart + 13]
+    expect(ethertype).toBe(0x0800) // IPv4
+    // IPv4 version + IHL byte = 0x45 (version 4, IHL 5)
+    expect(bytes[packetStart + 14]).toBe(0x45)
+    // Protocol byte at IP header offset 9 (i.e. packetStart + 14 + 9) = TCP (6)
+    expect(bytes[packetStart + 14 + 9]).toBe(6)
+  })
+})

--- a/test/exports-unify.test.ts
+++ b/test/exports-unify.test.ts
@@ -1,0 +1,113 @@
+/**
+ * test/exports-unify.test.ts
+ *
+ * shared/exports/unify.ts converts capture-source-specific shapes into the
+ * UnifiedCapture[] shape the encoders consume. These tests pin the mapping
+ * so future changes are caught.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { fromPassive, fromMonitorArtifacts, type PassiveNetEntry } from "../shared/exports/unify"
+import type { MonitorNetArtifact } from "../shared/monitor-artifacts"
+
+describe("fromPassive — PassiveNetEntry[] → UnifiedCapture[]", () => {
+  const entries: PassiveNetEntry[] = [
+    {
+      url: "https://example.com/a",
+      method: "GET",
+      status: 200,
+      body: "hi",
+      type: "fetch",
+      timestamp: 1_000_000,
+      contentType: "text/plain",
+      truncated: false,
+      requestHeaders: { accept: "*/*" },
+      responseHeaders: { "content-type": "text/plain" },
+    },
+    {
+      url: "https://example.com/b",
+      method: "POST",
+      status: 201,
+      body: "created",
+      type: "xhr",
+      timestamp: 1_000_100,
+      contentType: "application/json",
+    },
+    {
+      url: "https://example.com/c",
+      method: "GET",
+      status: 200,
+      body: "stream",
+      type: "sse",
+      timestamp: 1_000_200,
+      truncated: true,
+    },
+  ]
+
+  const out = fromPassive(entries)
+
+  test("each entry maps 1:1", () => {
+    expect(out.length).toBe(entries.length)
+  })
+
+  test("source is derived from `type`", () => {
+    expect(out[0].source).toBe("fetch")
+    expect(out[1].source).toBe("xhr")
+    expect(out[2].source).toBe("sse")
+  })
+
+  test("captured headers ride through", () => {
+    expect(out[0].requestHeaders).toEqual({ accept: "*/*" })
+    expect(out[0].responseHeaders).toEqual({ "content-type": "text/plain" })
+    // missing headers fall back to empty objects
+    expect(out[1].requestHeaders).toEqual({})
+    expect(out[1].responseHeaders).toEqual({})
+  })
+
+  test("truncated flag preserved", () => {
+    expect(out[0].truncated).toBe(false)
+    expect(out[2].truncated).toBe(true)
+  })
+
+  test("timestamp populates both startedAt and endedAt (we don't know real start)", () => {
+    expect(out[0].startedAt).toBe(entries[0].timestamp)
+    expect(out[0].endedAt).toBe(entries[0].timestamp)
+    expect(out[0].durationMs).toBe(0)
+  })
+})
+
+describe("fromMonitorArtifacts — MonitorNetArtifact[] → UnifiedCapture[]", () => {
+  const artifacts: MonitorNetArtifact[] = [
+    {
+      sid: "session-1",
+      seq: 5,
+      tid: 42,
+      cause: 3,
+      kind: "fetch",
+      url: "https://example.com/api",
+      method: "GET",
+      status: 200,
+      contentType: "application/json",
+      truncated: false,
+      bodyBytes: 17,
+      bodyPreview: '{"ok":true}',
+    },
+  ]
+
+  const out = fromMonitorArtifacts(artifacts)
+
+  test("source is always 'monitor'", () => {
+    expect(out[0].source).toBe("monitor")
+  })
+
+  test("cause / tabId / seq / bodyBytes flow through", () => {
+    expect(out[0].cause).toBe(3)
+    expect(out[0].tabId).toBe(42)
+    expect(out[0].seq).toBe(5)
+    expect(out[0].bodyBytes).toBe(17)
+  })
+
+  test("responseBody comes from bodyPreview", () => {
+    expect(out[0].responseBody).toBe('{"ok":true}')
+  })
+})


### PR DESCRIPTION
Closes #76.

## Summary

Adds three output formats for captured network data so Interceptor sessions land in the user's existing tooling instead of trapped in a bespoke shape:

- **HAR 1.2** — drag-and-drop into Chrome DevTools Network panel, consumable by mitmproxy, Charles, Burp, Postman. Spec invariant `entry.time == sum(non-(-1) timings)` enforced. Multi-value `Set-Cookie` parsed correctly via `Headers.getSetCookie()`. Custom fields (`_source`, `_truncated`, `_initiator`) carry cause-chain metadata per the HAR spec's underscore rule.
- **pcapng** — opens in Wireshark / `tshark` / `capinfos`. One Section Header Block + one Interface Description Block per origin + Enhanced Packet Blocks per request, splitting bodies > 256 KB across multiple TCP segments so each frame fits the IDB's declared snap length.
- **Native JSON envelope** — schema-versioned (`"1.0.0"`), lossless, includes monitor session metadata (sid, counts, instruction). The stable contract third-party SDK authors can hand-roll types against (issue #76 candidate #3 partial).

## Surfaces

```bash
interceptor net log --format <text|json|har|pcapng> [--out <path>]
interceptor monitor export <sid> --format <text|json|har|pcapng|plan> [--out <path>]
```

## `monitor start --persist-bodies`

Adds `monitor start --persist-bodies [<KB>]` to widen the body-archive policy beyond cause-tracked + MIME-allowlisted captures, so autonomous events (video streams, telemetry beacons) carry their response bodies into the exports. Default cap 64 KB; the flag's KB argument overrides it (verified at 256 KB).

## Capture upgrade

Extends the page-context fetch/XHR hooks in `inject-net.ts` to ship full response headers (fetch via `Headers.forEach` + `getSetCookie()` multi-value preservation; XHR via `getAllResponseHeaders()` parsing) alongside the existing request-header capture. `PassiveCapturedEntry` gains `requestHeaders` and `responseHeaders`.

## Issue #74 fix included

`monitor export --json` now honours the `jsonMode` parameter that was already plumbed through, so the global `--json` flag (stripped by `cli/index.ts:92` before the local handler runs) is respected.

## Verification

- **43 unit tests / 126 assertions** — green on both macOS host and Linux container (`docker.io/oven/bun:1` via Apple's `container` runtime).
- **Byte-equivalent content** between macOS and Linux generators on the same input session: JSON `entries` hash, HAR `log.entries` hash, and pcapng tail (after the SHB-options preamble that intentionally embeds the host-OS string) all match across platforms.
- **Real-world end-to-end**: captured a 25-second autoplaying YouTube video session with `--persist-bodies 256`. 8 autonomous fetch/xhr events, 6 bodies persisted (the 2 misses are 204 No Content responses). All three exports carry the response data; `tshark` dissects the pcapng cleanly with multi-segment PDU reassembly for the 1.6 MB video chunks.

## Files

- New: `shared/exports/{types,unify,har,pcapng,json-envelope,index}.ts`
- New: `test/exports-{har-shape,pcapng-shape,json-envelope,unify}.test.ts`
- Modified: `extension/src/inject-net.ts`, `extension/src/content/net-buffer.ts`, `extension/src/content/monitor.ts`, `extension/src/background/capabilities/monitor.ts`, `cli/commands/network.ts`, `cli/commands/monitor.ts`, `cli/index.ts`, `extension/manifest.json`, `package.json` (→ 0.14.0), `.gitignore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Persist captured response bodies during monitoring with `--persist-bodies` flag
  * Export network sessions to HAR, PCAPNG, or JSON formats via `--format` option
  * Save exports directly to file with `--out` option
  * Automatic capture of request and response headers in network logs

* **Tests**
  * Added comprehensive test coverage for export formats

* **Chores**
  * Version updated to 0.14.0
  * Updated `.gitignore` for container runtime data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->