### PR TITLE
feat(browser): background-first tab creation + --activate opt-in (v0.14.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,13 @@ Operating rules:
 - Prefer passive observation before invasive instrumentation. For network work, start with `inspect` or `net`, not CDP debugger attach.
 - Do not use `--any-tab` unless the user explicitly authorizes operating outside Interceptor's tracked tab group.
 
-## Background First (macOS)
+## Background First (Browser + macOS)
 
-The macOS surface is **background-first by contract.** Only two commands move focus: `interceptor macos app activate <app>` and `interceptor macos open <app> --activate`. Everything else stays invisible — `open` (without `--activate`), all input verbs (`click`, `type`, `keys`, `drag`, `scroll`), all reads, capture, AX, menu, intent dispatch, vision, and overlays. If you call any other command and the user's frontmost app changes, that is a bug — file it.
+The whole product is **background-first by contract.** Both surfaces share the same rule: routine work never moves the user's focus; focus changes only happen on explicitly named opt-in verbs.
+
+**Browser surface:** `interceptor open <url>` and `interceptor tab new <url>` create tabs in the background by default. The user's currently-active tab stays active. The only verbs that move the active tab or focused window are: `open --activate`, `tab new --activate`, `tab switch <id>`, and `window focus <id>`. The reuse path (`open --reuse`) preserves the reused tab's current focus state — call `open --reuse --activate` to also foreground it. Every other browser verb (`click`, `type`, `read`, `tree`, `text`, `inspect`, `screenshot`, `net`, `cookies`, `scroll`, etc.) operates on the target tab without disturbing the user's active tab.
+
+**macOS surface:** Only two commands move focus: `interceptor macos app activate <app>` and `interceptor macos open <app> --activate`. Everything else stays invisible — `open` (without `--activate`), all input verbs (`click`, `type`, `keys`, `drag`, `scroll`), all reads, capture, AX, menu, intent dispatch, vision, and overlays. If you call any other command and the user's frontmost app changes, that is a bug — file it.
 
 When the user names a specific app ("screenshot of Brave", "scroll Signal", "open a tab in Brave"), do the work without bringing it forward unless the task strictly requires focus. Never reach for `app activate`, never insert `activate` into AppleScript blocks, never `--mode display`-screenshot a backgrounded app's window. The bridge's CGS capture / AX read / Apple Events / `postToPid` scroll paths all work without focus change.
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ The legacy individual commands (`interceptor tab new`, `interceptor tree`, `inte
 
 **Interceptor Group** — Every `interceptor tab new` adds tabs to a cyan "interceptor" group. Commands only work on tabs in this group. Your personal tabs are never touched. Use `--any-tab` to override.
 
+**Focus Model (Background-First Contract)** — Interceptor never steals focus from the tab you're working in. `interceptor open <url>` and `interceptor tab new <url>` create their tabs in the **background** by default — the tab you had active stays active. Only four browser verbs intentionally move focus: `open --activate`, `tab new --activate`, `tab switch <id>`, and `window focus <id>`. The reuse path preserves the reused tab's existing focus state; add `--activate` to bring it forward. All other operations (`click`, `type`, `read`, `screenshot`, `net`, `scene`, `monitor`, etc.) work against the target tab without touching whichever tab you're looking at. This mirrors the macOS surface's same background-first contract — see `AGENTS.md` "Background First (Browser + macOS)" for the full inventory.
+
 **Passive Network** — All `fetch()` and `XMLHttpRequest` traffic on every page is captured automatically. No debugger, no infobanner. Query it with `interceptor net log`.
 
 **Scene Graph** — Profile-driven access to visual editors that don't render to the DOM normally: Canva, Google Docs, Google Slides. Enumerate objects by stable ID, click shapes, read full document text, navigate slide decks, render pages to PNG. `interceptor scene` — no CDP, no vision, no screenshots needed.
@@ -327,12 +329,14 @@ The legacy individual commands (`interceptor tab new`, `interceptor tree`, `inte
 These collapse multi-step patterns into single CLI invocations:
 
 ```bash
-interceptor open "https://example.com"        # Open URL, wait, return tree + text
+interceptor open "https://example.com"        # Open URL in a background tab (default), wait, return tree + text
+interceptor open "https://example.com" --activate     # Foreground the new tab (explicit opt-in)
 interceptor open "https://example.com" --tree-only   # Skip text
 interceptor open "https://example.com" --text-only   # Skip tree
 interceptor open "https://example.com" --full        # Full text (no 2000-char limit)
 interceptor open "https://example.com" --no-wait     # Don't wait for load
 interceptor open "https://example.com" --reuse        # Reuse the most recent Interceptor-group tab (long automation: avoids tab accumulation)
+interceptor open "https://example.com" --reuse --activate  # Reuse the tab and bring it to the foreground
 interceptor read                              # Tree + text for current page
 interceptor read e5                           # Tree + text for element subtree
 interceptor read --tree-only                  # Just tree

--- a/cli/commands/compound.ts
+++ b/cli/commands/compound.ts
@@ -125,9 +125,14 @@ export function buildReadTreeAction(opts: {
 export function buildTabCreateAction(
   filtered: string[],
   url: string
-): { type: "tab_create"; url: string; reuse?: boolean } {
-  const action: { type: "tab_create"; url: string; reuse?: boolean } = { type: "tab_create", url }
+): { type: "tab_create"; url: string; reuse?: boolean; active?: boolean } {
+  const action: { type: "tab_create"; url: string; reuse?: boolean; active?: boolean } = { type: "tab_create", url }
   if (filtered.includes("--reuse")) action.reuse = true
+  // --activate is the explicit opt-in for foregrounding the new tab.
+  // Default is background-first; the extension's tab_create handler reads
+  // `action.active === true` and only then passes `active: true` to
+  // chrome.tabs.create.
+  if (filtered.includes("--activate")) action.active = true
   return action
 }
 

--- a/cli/commands/tabs.ts
+++ b/cli/commands/tabs.ts
@@ -18,8 +18,12 @@ export async function parseTabsCommand(filtered: string[]): Promise<Action | nul
 
     case "tab":
       switch (filtered[1]) {
-        case "new":
-          return { type: "tab_create", url: filtered[2] }
+        case "new": {
+          // Background-first by default; --activate is the opt-in.
+          const action: Action = { type: "tab_create", url: filtered[2] }
+          if (filtered.includes("--activate")) action.active = true
+          return action
+        }
         case "close":
           return filtered[2]
             ? { type: "tab_close", tabId: parseInt(filtered[2]) }

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -27,13 +27,15 @@ Flags:
   --json                              Output as JSON
 
 Compound (agent-optimized):
-  interceptor open <url>                     Open URL, wait, return tree + text
+  interceptor open <url>                     Open URL in a background tab (default), wait, return tree + text
+  interceptor open <url> --activate          Foreground the new tab (explicit opt-in; background-first contract)
   interceptor open <url> --tree-only         Skip text, return only tree
   interceptor open <url> --text-only         Skip tree, return only text
   interceptor open <url> --full              Full text instead of 2000-char summary
   interceptor open <url> --timeout <ms>      Override wait-stable timeout (default 5000)
   interceptor open <url> --no-wait           Return immediately after tab creation
   interceptor open <url> --reuse             Navigate the most recent Interceptor-group tab instead of opening a new one (cleans up long automation runs)
+  interceptor open <url> --reuse --activate  Navigate the reused tab and bring it to the foreground
   interceptor read                           Tree + text for active tab
   interceptor read <ref>                     Tree + text for element subtree
   interceptor read --tree-only               Skip text
@@ -96,9 +98,10 @@ Navigation:
 
 Tabs:
   interceptor tabs                           List all tabs
-  interceptor tab new [url]                  Open new tab
+  interceptor tab new [url]                  Open new tab in background (default)
+  interceptor tab new [url] --activate       Open new tab and foreground it (explicit opt-in)
   interceptor tab close [id]                 Close tab
-  interceptor tab switch <id>                Switch to tab
+  interceptor tab switch <id>                Switch to tab (explicit focus move)
 
 Capture:
   interceptor screenshot                     Full-page DOM-render screenshot (default — works without focus)
@@ -228,8 +231,11 @@ Meta:
   interceptor help                           This help text
 
 Native (macOS Bridge — full install only):
-  Background-first by contract: only 'macos app activate' and 'macos open --activate'
-  move the user's frontmost window. Every other 'macos *' verb leaves focus alone.
+  Background-first by contract (mirrors the browser surface in 'Tabs' and 'open' above):
+  the only verbs that move the user's frontmost window or active tab are
+  'macos app activate', 'macos open --activate', 'open --activate',
+  'tab new --activate', 'tab switch <id>', and 'window focus <id>'.
+  Every other 'macos *' verb and every routine 'open'/'tab new' leaves focus alone.
 
   Compound (agent-optimized):
   interceptor macos open <app>               Tree + windows + app info (no foregrounding)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.14.0",
+  "version": "0.14.2",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -35,6 +35,41 @@ function mimeTypeForFormat(format: string): string {
   return "image/jpeg"
 }
 
+// Background-first contract: chrome.tabs.captureVisibleTab captures the
+// **active** tab in a window, ignoring the tabId we pass — so when the target
+// tab was opened with `active: false` (the new default), the strip loop would
+// capture whichever foreground tab the user is actually looking at instead.
+// Mitigation: briefly activate our target around the capture window, then
+// restore whichever tab was active when we started. The visible flash is the
+// price; silently capturing the user's foreground tab is the bug we cannot
+// ship. Caller is expected to wrap the entire captureVisibleTab block —
+// including the rate-limit gap between strips — so the prior-active tab is
+// only restored once the full sequence is done.
+export async function withCaptureVisibleTabFocus<T>(
+  tabId: number,
+  windowId: number,
+  fn: () => Promise<T>
+): Promise<T> {
+  const [priorActive] = await chrome.tabs.query({ active: true, windowId })
+  const targetAlreadyActive = priorActive?.id === tabId
+  if (!targetAlreadyActive) {
+    try {
+      await chrome.tabs.update(tabId, { active: true })
+    } catch {
+      // If activation fails (tab vanished, window state changed), let the
+      // caller's captureVisibleTab call surface the underlying error so the
+      // existing diagnostics path stays authoritative.
+    }
+  }
+  try {
+    return await fn()
+  } finally {
+    if (!targetAlreadyActive && typeof priorActive?.id === "number" && priorActive.id !== tabId) {
+      await chrome.tabs.update(priorActive.id, { active: true }).catch(() => undefined)
+    }
+  }
+}
+
 async function stitchStripsInWorker(
   strips: Array<{ dataUrl: string; y: number }>,
   totalWidth: number,
@@ -296,34 +331,47 @@ async function handlePixelScreenshot(
       }
     }
 
-    for (let i = 0; i < stripCount; i++) {
-      const scrollTo = i * viewportHeight
-      await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo })
-      await new Promise(r => setTimeout(r, 150))
-      let stripUrl: string
-      try {
-        stripUrl = await withCaptureTimeout(
-          `captureVisibleTab(strip ${i + 1}/${stripCount})`,
-          chrome.tabs.captureVisibleTab(fullTab.windowId, { format: captureFormat, quality })
-        )
-      } catch (err) {
-        await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
-        if (err instanceof CaptureTimeoutError) {
+    // captureVisibleTab targets the active tab in the window. Wrap the entire
+    // strip sequence in one focus borrow so we only flash once for a full-page
+    // capture — not once per strip — and the user's prior-active tab is
+    // restored after the final strip lands.
+    const stripCaptureOutcome = await withCaptureVisibleTabFocus(tabId, fullTab.windowId, async () => {
+      for (let i = 0; i < stripCount; i++) {
+        const scrollTo = i * viewportHeight
+        await sendToContentScript(tabId, { type: "scroll_absolute", y: scrollTo })
+        await new Promise(r => setTimeout(r, 150))
+        let stripUrl: string
+        try {
+          stripUrl = await withCaptureTimeout(
+            `captureVisibleTab(strip ${i + 1}/${stripCount})`,
+            chrome.tabs.captureVisibleTab(fullTab.windowId, { format: captureFormat, quality })
+          )
+        } catch (err) {
+          await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
+          if (err instanceof CaptureTimeoutError) {
+            return {
+              ok: false as const,
+              error: {
+                success: false,
+                error: `full-page screenshot failed: ${err.operation} timed out after ${err.timeoutMs}ms`,
+                data: { hint: VISIBILITY_HINT, layer: "captureVisibleTab", strip: i + 1, totalStrips: stripCount, timedOutAt: err.operation }
+              } as ActionResult
+            }
+          }
           return {
-            success: false,
-            error: `full-page screenshot failed: ${err.operation} timed out after ${err.timeoutMs}ms`,
-            data: { hint: VISIBILITY_HINT, layer: "captureVisibleTab", strip: i + 1, totalStrips: stripCount, timedOutAt: err.operation }
+            ok: false as const,
+            error: { success: false, error: `captureVisibleTab failed on strip ${i + 1}/${stripCount}: ${(err as Error).message}` } as ActionResult
           }
         }
-        return { success: false, error: `captureVisibleTab failed on strip ${i + 1}/${stripCount}: ${(err as Error).message}` }
+        strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) })
+        // Chrome rate-limits captureVisibleTab to MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND
+        // (default: 2/sec). 1100ms between strips clears the quota with margin.
+        if (i < stripCount - 1) await new Promise(r => setTimeout(r, 1100))
       }
-      strips.push({ dataUrl: stripUrl, y: Math.round(scrollTo * devicePixelRatio) })
-      // Chrome rate-limits captureVisibleTab to MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND
-      // (default: 2/sec). 1100ms between strips clears the quota with margin.
-      if (i < stripCount - 1) await new Promise(r => setTimeout(r, 1100))
-    }
-
-    await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
+      await sendToContentScript(tabId, { type: "scroll_absolute", y: origScrollY }).catch(() => undefined)
+      return { ok: true as const }
+    })
+    if (!stripCaptureOutcome.ok) return stripCaptureOutcome.error
 
     // Stitch inline in the SW using OffscreenCanvas — avoids the
     // SW ↔ offscreen-document IPC round-trip which silently drops
@@ -376,9 +424,13 @@ async function handlePixelScreenshot(
 
   let dataUrl: string
   try {
-    dataUrl = await withCaptureTimeout(
-      "captureVisibleTab",
-      chrome.tabs.captureVisibleTab(targetTab.windowId, { format: captureFormat, quality })
+    // Same borrow-and-restore as the strip path. One brief flash for a single
+    // capture is the cost of background-first defaults.
+    dataUrl = await withCaptureVisibleTabFocus(tabId, targetTab.windowId, () =>
+      withCaptureTimeout(
+        "captureVisibleTab",
+        chrome.tabs.captureVisibleTab(targetTab.windowId, { format: captureFormat, quality })
+      )
     )
   } catch (err) {
     if (err instanceof CaptureTimeoutError) {

--- a/extension/src/background/capabilities/tabs.ts
+++ b/extension/src/background/capabilities/tabs.ts
@@ -26,7 +26,18 @@ export async function handleTabActions(
             const candidate = sorted[0]
             if (candidate?.id !== undefined) {
               try {
-                const updated = await chrome.tabs.update(candidate.id, { url: targetUrl })
+                // Reuse path: preserve the candidate tab's current
+                // active/inactive state by default — navigating a background
+                // tab keeps it in the background, a foreground tab stays
+                // foreground. Only pass `active: true` when the caller
+                // explicitly asked for activation via `action.active`, so
+                // `interceptor open <url> --reuse --activate` foregrounds
+                // the reused tab on demand without disturbing the user's
+                // focus on every routine reuse call.
+                const reuseActivate = (action.active as boolean | undefined) === true
+                const updateProps: chrome.tabs.UpdateProperties = { url: targetUrl }
+                if (reuseActivate) updateProps.active = true
+                const updated = await chrome.tabs.update(candidate.id, updateProps)
                 await waitForTabLoad(candidate.id)
                 // Pin the reused tab as the auto-target for subsequent commands.
                 // Mirrors the new-tab path below: every successful tab_create
@@ -45,7 +56,13 @@ export async function handleTabActions(
           }
         }
       }
-      const newTab = await chrome.tabs.create({ url: targetUrl })
+      // Background-by-default: chrome.tabs.create defaults `active` to true,
+      // which steals focus from the user's current tab. Interceptor's surface
+      // contract is background-first (mirrors the macOS surface: `open
+      // --activate` is the explicit opt-in). Callers pass `action.active:
+      // true` only when the new tab is genuinely meant to be foregrounded.
+      const shouldActivate = (action.active as boolean | undefined) === true
+      const newTab = await chrome.tabs.create({ url: targetUrl, active: shouldActivate })
       if (newTab.id) {
         const groupId = await addTabToInterceptorGroup(newTab.id)
         // Pin the newly-created tab as the auto-target for subsequent commands

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -13,7 +13,7 @@ export type Action =
   | { type: "extract_html"; index?: number; ref?: string; frameId?: number }
   | { type: "evaluate"; code: string; world?: "MAIN" | "ISOLATED" }
   | { type: "screenshot"; format?: "png" | "jpeg" | "webp"; quality?: number; save?: boolean; clip?: { x: number; y: number; width: number; height: number }; element?: number; full?: boolean; target_max_long_edge?: number }
-  | { type: "tab_create"; url?: string; reuse?: boolean }
+  | { type: "tab_create"; url?: string; reuse?: boolean; active?: boolean }
   | { type: "tab_close"; tabId?: number }
   | { type: "tab_switch"; tabId: number }
   | { type: "tab_list" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.14.0",
+  "version": "0.14.2",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/test/canvas-bridge.test.ts
+++ b/test/canvas-bridge.test.ts
@@ -3,7 +3,7 @@
 import { beforeAll, describe, expect, test } from "bun:test"
 import { GlobalRegistrator } from "@happy-dom/global-registrator"
 
-GlobalRegistrator.register()
+try { GlobalRegistrator.register() } catch { /* already registered by an earlier test file */ }
 
 beforeAll(() => {
   ;(globalThis as any).chrome = {

--- a/test/screenshot-background-tab.test.ts
+++ b/test/screenshot-background-tab.test.ts
@@ -1,0 +1,145 @@
+/// <reference lib="dom" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+// captureVisibleTab focus borrow-and-restore.
+//
+// `chrome.tabs.captureVisibleTab` captures whichever tab is **active** in the
+// window, not the tabId you pass. Once `tab_create` defaults to `active:
+// false`, a naive screenshot would silently capture the user's foreground
+// tab. `withCaptureVisibleTabFocus` mitigates this: query the currently-active
+// tab in the window, activate our target, run the capture closure, then
+// restore the prior-active tab regardless of success or failure.
+//
+// These tests stub `globalThis.chrome.tabs` with a deterministic fake and
+// verify: (1) the prior-active tab is identified, (2) the target gets
+// activated when it wasn't already, (3) the closure runs with the target
+// active, (4) the prior-active tab is restored after success and after
+// failure, (5) when the target was already active no extra updates fire.
+
+type UpdateCall = { tabId: number; props: chrome.tabs.UpdateProperties }
+
+interface FakeTab {
+  id: number
+  active: boolean
+  windowId: number
+}
+
+let activations: UpdateCall[]
+let fakeTabs: FakeTab[]
+let originalChrome: unknown
+
+function installFakeChrome(tabs: FakeTab[]) {
+  fakeTabs = tabs
+  activations = []
+  originalChrome = (globalThis as { chrome?: unknown }).chrome
+  ;(globalThis as { chrome: unknown }).chrome = {
+    tabs: {
+      query: async (q: chrome.tabs.QueryInfo) => {
+        return fakeTabs.filter(t =>
+          (q.active === undefined || t.active === q.active) &&
+          (q.windowId === undefined || t.windowId === q.windowId)
+        )
+      },
+      update: async (tabId: number, props: chrome.tabs.UpdateProperties) => {
+        activations.push({ tabId, props })
+        if (props.active === true) {
+          for (const t of fakeTabs) {
+            if (t.windowId === fakeTabs.find(x => x.id === tabId)?.windowId) {
+              t.active = t.id === tabId
+            }
+          }
+        }
+        return fakeTabs.find(t => t.id === tabId)
+      }
+    }
+  }
+}
+
+function restoreChrome() {
+  ;(globalThis as { chrome?: unknown }).chrome = originalChrome
+}
+
+beforeEach(() => {
+  // Default scenario: window 1 has two tabs — 100 (active, user's foreground)
+  // and 200 (background, the Interceptor-managed target).
+  installFakeChrome([
+    { id: 100, active: true, windowId: 1 },
+    { id: 200, active: false, windowId: 1 }
+  ])
+})
+
+afterEach(() => {
+  restoreChrome()
+})
+
+describe("withCaptureVisibleTabFocus — borrow-and-restore", () => {
+  test("activates the background target then restores the prior-active tab on success", async () => {
+    const { withCaptureVisibleTabFocus } = await import("../extension/src/background/capabilities/screenshot")
+    let observedActiveDuringCapture: number | undefined
+    const result = await withCaptureVisibleTabFocus(200, 1, async () => {
+      observedActiveDuringCapture = fakeTabs.find(t => t.active && t.windowId === 1)?.id
+      return "capture-payload"
+    })
+    expect(result).toBe("capture-payload")
+    expect(observedActiveDuringCapture).toBe(200)
+    expect(activations).toEqual([
+      { tabId: 200, props: { active: true } },
+      { tabId: 100, props: { active: true } }
+    ])
+    // Final state: prior-active tab is active again.
+    expect(fakeTabs.find(t => t.id === 100)?.active).toBe(true)
+    expect(fakeTabs.find(t => t.id === 200)?.active).toBe(false)
+  })
+
+  test("restores the prior-active tab even when the closure throws", async () => {
+    const { withCaptureVisibleTabFocus } = await import("../extension/src/background/capabilities/screenshot")
+    await expect(
+      withCaptureVisibleTabFocus(200, 1, async () => {
+        throw new Error("capture failed")
+      })
+    ).rejects.toThrow("capture failed")
+    expect(activations).toEqual([
+      { tabId: 200, props: { active: true } },
+      { tabId: 100, props: { active: true } }
+    ])
+    expect(fakeTabs.find(t => t.id === 100)?.active).toBe(true)
+  })
+
+  test("no-op when the target tab was already active — closure still runs", async () => {
+    fakeTabs[0].active = false
+    fakeTabs[1].active = true
+    const { withCaptureVisibleTabFocus } = await import("../extension/src/background/capabilities/screenshot")
+    let ran = false
+    await withCaptureVisibleTabFocus(200, 1, async () => { ran = true })
+    expect(ran).toBe(true)
+    expect(activations).toEqual([])
+    expect(fakeTabs.find(t => t.id === 200)?.active).toBe(true)
+  })
+
+  test("ignores activation errors and surfaces capture-closure errors verbatim", async () => {
+    // Replace chrome.tabs.update with a thrower for the initial activate call,
+    // then succeed on the restore. The capture closure runs regardless.
+    let updateCalls = 0
+    const chromeUnderTest = (globalThis as { chrome: { tabs: { update: (id: number, props: chrome.tabs.UpdateProperties) => Promise<unknown> } } }).chrome
+    const originalUpdate = chromeUnderTest.tabs.update
+    chromeUnderTest.tabs.update = async (tabId: number, props: chrome.tabs.UpdateProperties) => {
+      updateCalls++
+      if (updateCalls === 1) throw new Error("tab vanished")
+      return originalUpdate(tabId, props)
+    }
+    const { withCaptureVisibleTabFocus } = await import("../extension/src/background/capabilities/screenshot")
+    const out = await withCaptureVisibleTabFocus(200, 1, async () => "captured-anyway")
+    expect(out).toBe("captured-anyway")
+    // Final restore call was issued even though the initial activate threw.
+    expect(updateCalls).toBe(2)
+  })
+
+  test("does not restore when prior-active tab is the same as the target (no spurious update)", async () => {
+    fakeTabs[0].active = false
+    fakeTabs[1].active = true   // target is already the active one
+    const { withCaptureVisibleTabFocus } = await import("../extension/src/background/capabilities/screenshot")
+    await withCaptureVisibleTabFocus(200, 1, async () => undefined)
+    expect(activations).toEqual([])
+  })
+})

--- a/test/tab-create-activate-flag.test.ts
+++ b/test/tab-create-activate-flag.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { buildTabCreateAction } from "../cli/commands/compound"
+import { parseTabsCommand } from "../cli/commands/tabs"
+
+// Explicit `--activate` opt-in.
+//
+// `--activate` is the only way for the CLI to ask for a foreground tab.
+// These tests pin: (1) presence of the flag → `active: true` on the action,
+// (2) combinations with `--reuse` (so `open --reuse --activate` foregrounds
+// the reused tab), (3) the matching `tab new` parser path, and (4) the
+// extension-handler activation gate — only literal `active === true`
+// causes `chrome.tabs.create({ active: true })`.
+
+describe("tab_create — --activate explicit opt-in", () => {
+  test("interceptor open <url> --activate sets active: true", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--activate"],
+      "https://example.com"
+    )
+    expect(action.active).toBe(true)
+  })
+
+  test("interceptor open <url> --reuse --activate combines both flags", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--reuse", "--activate"],
+      "https://example.com"
+    )
+    expect(action.reuse).toBe(true)
+    expect(action.active).toBe(true)
+  })
+
+  test("flag order does not matter", () => {
+    const a = buildTabCreateAction(
+      ["open", "--activate", "https://example.com"],
+      "https://example.com"
+    )
+    const b = buildTabCreateAction(
+      ["open", "https://example.com", "--activate"],
+      "https://example.com"
+    )
+    expect(a.active).toBe(true)
+    expect(b.active).toBe(true)
+  })
+
+  test("interceptor tab new <url> --activate sets active: true on tab_create", async () => {
+    const action = await parseTabsCommand(["tab", "new", "https://example.com", "--activate"])
+    expect(action).not.toBeNull()
+    expect(action).toMatchObject({
+      type: "tab_create",
+      url: "https://example.com",
+      active: true
+    })
+  })
+
+  test("extension activation gate is strict — only literal true activates", () => {
+    // Mirror the exact gate in extension/src/background/capabilities/tabs.ts:
+    //   const shouldActivate = (action.active as boolean | undefined) === true
+    expect(((true as unknown) as boolean | undefined) === true).toBe(true)
+    expect(((false as unknown) as boolean | undefined) === true).toBe(false)
+    expect((undefined as boolean | undefined) === true).toBe(false)
+    // Truthy-but-not-boolean values do not pass the gate — guards against
+    // a future caller writing `active: 1` and accidentally enabling activation.
+    expect(((1 as unknown) as boolean | undefined) === true).toBe(false)
+    expect((("true" as unknown) as boolean | undefined) === true).toBe(false)
+  })
+})

--- a/test/tab-create-active-default.test.ts
+++ b/test/tab-create-active-default.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { buildTabCreateAction } from "../cli/commands/compound"
+import { parseTabsCommand } from "../cli/commands/tabs"
+
+// Background-first contract for tab creation.
+//
+// These tests pin the **default** behavior: a plain `interceptor open <url>`
+// or `interceptor tab new <url>` must not carry `active: true` on the
+// `tab_create` action it builds. The extension handler reads
+// `action.active === true` as the activate signal, so the absence of the
+// field — or `active: false` — both route to a background tab via
+// `chrome.tabs.create({ active: false })`. The activate path is covered in
+// tab-create-activate-flag.test.ts.
+
+describe("tab_create — background-first default", () => {
+  test("interceptor open <url> omits active by default", () => {
+    const action = buildTabCreateAction(["open", "https://example.com"], "https://example.com")
+    expect(action).toEqual({ type: "tab_create", url: "https://example.com" })
+    expect("active" in action).toBe(false)
+  })
+
+  test("interceptor open <url> with unrelated flags still omits active", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--full", "--tree-only", "--timeout", "8000"],
+      "https://example.com"
+    )
+    expect(action.active).toBeUndefined()
+  })
+
+  test("interceptor open <url> --reuse keeps active undefined", () => {
+    const action = buildTabCreateAction(
+      ["open", "https://example.com", "--reuse"],
+      "https://example.com"
+    )
+    expect(action.reuse).toBe(true)
+    expect(action.active).toBeUndefined()
+  })
+
+  test("interceptor tab new <url> omits active by default", async () => {
+    const action = await parseTabsCommand(["tab", "new", "https://example.com"])
+    expect(action).not.toBeNull()
+    expect(action).toMatchObject({ type: "tab_create", url: "https://example.com" })
+    expect("active" in (action as Record<string, unknown>)).toBe(false)
+  })
+
+  test("extension handler treats undefined active as background (active=false)", () => {
+    // Mirror the exact gate in extension/src/background/capabilities/tabs.ts:
+    //   const shouldActivate = (action.active as boolean | undefined) === true
+    // Anything other than literal `true` must resolve to background.
+    const cases: Array<{ active?: unknown; expected: boolean }> = [
+      { expected: false },                       // undefined
+      { active: undefined, expected: false },
+      { active: false, expected: false },
+      { active: 0, expected: false },
+      { active: "true", expected: false },       // not boolean true — still background
+      { active: null, expected: false },
+      { active: true, expected: true }            // only literal true activates
+    ]
+    for (const c of cases) {
+      const shouldActivate = (c.active as boolean | undefined) === true
+      expect(shouldActivate).toBe(c.expected)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`interceptor open` and `interceptor tab new` now create tabs in the **background** by default. The user's currently-active tab keeps focus. Explicit `--activate` flag is the opt-in for cases where the caller genuinely wants the new tab foregrounded.

Brings the browser surface into alignment with the macOS surface's existing background-first contract.

## What changed

### Surface
- `chrome.tabs.create` now passes `active: (action.active === true)` — only literal `true` activates
- `--activate` flag wired through both `interceptor open` and `interceptor tab new`
- `--reuse` path preserves the reused tab's focus state; pair with `--activate` to bring it forward
- Help text in `cli/help.ts` documents the focus model across both surfaces:
  - **Browser**: `open --activate`, `tab new --activate`, `tab switch <id>`, `window focus <id>`
  - **macOS**: `macos app activate`, `macos open --activate`

### Screenshot interaction
`chrome.tabs.captureVisibleTab` captures whichever tab is *active* in the window, not the tabId you pass. With tabs now defaulting to background, a naïve screenshot would silently capture the user's foreground tab instead of the Interceptor target.

New `withCaptureVisibleTabFocus` helper wraps both capture sites: query the prior-active tab, activate the target, run the capture closure, restore the prior-active tab in the `finally` block. One brief flash per `--full` capture sequence (not per strip) and per single-shot capture. DOM-render and tabCapture paths are unaffected — they already worked on background tabs.

### Tests added
- `test/tab-create-active-default.test.ts` — 5 cases pinning default-background behavior
- `test/tab-create-activate-flag.test.ts` — 5 cases pinning `--activate` opt-in
- `test/screenshot-background-tab.test.ts` — 5 cases pinning borrow-and-restore semantics

### Adjacent fix
`test/canvas-bridge.test.ts` wrapped `GlobalRegistrator.register()` in try/catch matching the documented pattern from `markdown-extract.test.ts` and `read-tree-format.test.ts`. Resolves a pre-existing order-dependent flake where canvas-bridge would throw `Failed to register. Happy DOM has already been globally registered.` when another Happy DOM consumer test file ran first.

## Verification

| Gate | Result |
|---|---|
| `bun test` (full suite) | 249 pass, 0 fail, 6 skip across 37 test files |
| `bun run typecheck` | clean across host + extension + root tsconfigs |
| `bash scripts/build.sh` | extension + CLI + daemon + bridge rebuilt clean |
| Live: `open <url>` (no flag) | ✅ new tab `active: false`, prior-active tab keeps focus |
| Live: `open <url> --activate` | ✅ new tab `active: true` |
| Live: `open <url> --reuse` | ✅ tab reused, prior-active stays active |
| Live: `screenshot --pixel` on background tab | ✅ capture succeeds, prior-active tab restored |

## Version
Bumps to **v0.14.2** (last release was v0.14.0; v0.14.1 was a local-only iteration).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--activate` flag to foreground newly created tabs and windows
  * Implemented background-first tab creation by default

* **Bug Fixes**
  * Fixed screenshot capture to preserve the previously active tab during full-page captures

* **Documentation**
  * Clarified background-first focus model for tab and window operations
  * Updated help text with new activation options and behavior descriptions

* **Chores**
  * Version bumped to 0.14.2
  * Added test coverage for tab activation functionality and background-first defaults

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->