### PR TITLE
ci(windows): Inno Setup installer + GitHub Actions release workflow

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,49 +1,59 @@
 name: Windows Installer
 
 # Builds the Interceptor Windows browser-surface installer (.exe via Inno
-# Setup) on every v* tag push and on manual dispatch. On tag push, the
-# installer is attached to a GitHub Release for the same tag.
+# Setup) on MANUAL dispatch only, then uploads it to the GitHub Release for
+# the version you pass. There is intentionally NO automatic trigger: cutting
+# a release is a deliberate, human-initiated step (matching the macOS .pkg /
+# Sparkle flow, which keeps a human test gate before publishing).
 #
-# Code signing: the .exe is currently unsigned, which means Windows
-# SmartScreen will show a "Windows protected your PC" warning the first
-# time a user runs it. To add signing later, acquire a Code Signing
-# certificate, store the .pfx + password as repo secrets WINDOWS_PFX
-# (base64) and WINDOWS_PFX_PASSWORD, and add a signtool step after the
-# ISCC.exe step below.
+# The build uses the ref you dispatch against (default: the branch you run
+# from), so:
+#   * Attach an installer to an EXISTING release WITHOUT bumping the version:
+#       gh workflow run windows-installer.yml --ref main -f version_override=0.16.2
+#     -> builds current main, stamps 0.16.2, uploads the .exe to the v0.16.2 Release.
+#   * Build a real future release from its tag (once that tag carries this file):
+#       gh workflow run windows-installer.yml --ref v0.17.0 -f version_override=0.17.0
+# The target GitHub Release (v<version>) must already exist; `gh release upload`
+# fails otherwise, which is the intended guard (create the Release first).
+#
+# Code signing: the .exe is currently unsigned, so Windows SmartScreen shows a
+# "Windows protected your PC" warning on first run. To add signing later,
+# acquire a Code Signing certificate, store the .pfx + password as repo secrets
+# WINDOWS_PFX (base64) and WINDOWS_PFX_PASSWORD, and add a signtool step AFTER
+# the ISCC.exe step. Scope those secrets to that step's env: only (never job-wide).
+#
+# Third-party actions are pinned to a full commit SHA (not a mutable tag) to
+# defend against the tag-repointing supply-chain class (CVE-2025-30066, etc.).
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version_override:
-        description: 'Override version (else read from package.json)'
+        description: 'Version to stamp + Release to upload to (X.Y.Z). Defaults to package.json.'
         required: false
         default: ''
-
-permissions:
-  contents: write
 
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write          # needed only to upload the .exe to the Release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:
           bun-version: latest
 
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          VERSION_OVERRIDE: ${{ inputs.version_override }}   # via env: — no inline ${{}} in run
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          elif [[ -n "${{ inputs.version_override }}" ]]; then
-            VERSION="${{ inputs.version_override }}"
+          if [[ -n "$VERSION_OVERRIDE" ]]; then
+            VERSION="$VERSION_OVERRIDE"
           else
             VERSION=$(grep '"version"' package.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
           fi
@@ -66,16 +76,17 @@ jobs:
           "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=${{ steps.version.outputs.version }} scripts\installer\interceptor.iss
 
       - name: Upload installer as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: Interceptor-${{ steps.version.outputs.version }}-windows-x64
           path: dist/release/Interceptor-${{ steps.version.outputs.version }}-windows-x64.exe
           if-no-files-found: error
 
-      - name: Attach installer to GitHub Release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/release/Interceptor-${{ steps.version.outputs.version }}-windows-x64.exe
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+      - name: Upload installer to the GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "v${{ steps.version.outputs.version }}" \
+            "dist/release/Interceptor-${{ steps.version.outputs.version }}-windows-x64.exe" \
+            --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,81 @@
+name: Windows Installer
+
+# Builds the Interceptor Windows browser-surface installer (.exe via Inno
+# Setup) on every v* tag push and on manual dispatch. On tag push, the
+# installer is attached to a GitHub Release for the same tag.
+#
+# Code signing: the .exe is currently unsigned, which means Windows
+# SmartScreen will show a "Windows protected your PC" warning the first
+# time a user runs it. To add signing later, acquire a Code Signing
+# certificate, store the .pfx + password as repo secrets WINDOWS_PFX
+# (base64) and WINDOWS_PFX_PASSWORD, and add a signtool step after the
+# ISCC.exe step below.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: 'Override version (else read from package.json)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${{ inputs.version_override }}" ]]; then
+            VERSION="${{ inputs.version_override }}"
+          else
+            VERSION=$(grep '"version"' package.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        shell: bash
+
+      - name: Build Windows binaries + extension
+        run: bash scripts/build.sh --target=windows
+        shell: bash
+
+      # Inno Setup ships preinstalled on windows-latest under
+      # C:\Program Files (x86)\Inno Setup 6\ISCC.exe.
+      - name: Compile installer
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=${{ steps.version.outputs.version }} scripts\installer\interceptor.iss
+
+      - name: Upload installer as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Interceptor-${{ steps.version.outputs.version }}-windows-x64
+          path: dist/release/Interceptor-${{ steps.version.outputs.version }}-windows-x64.exe
+          if-no-files-found: error
+
+      - name: Attach installer to GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/release/Interceptor-${{ steps.version.outputs.version }}-windows-x64.exe
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/scripts/installer/interceptor.iss
+++ b/scripts/installer/interceptor.iss
@@ -1,0 +1,154 @@
+; Inno Setup script for the Interceptor Windows browser surface.
+;
+; Per-user install. No admin / UAC by default — Chromium scopes native
+; messaging hosts per-user (HKCU), so a per-machine install would gain
+; nothing. PrivilegesRequiredOverridesAllowed=dialog still lets a power
+; user opt into a per-machine install at the elevation prompt.
+;
+; In-place upgrade: the AppId GUID is stable across versions. Running
+; this installer when a previous version is present silently removes
+; the old install (including any locked interceptor-daemon.exe via
+; Restart Manager) before laying down the new files.
+;
+; Compile from the repo root with:
+;   ISCC.exe /DAppVersion=0.14.2 scripts\installer\interceptor.iss
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0-dev"
+#endif
+
+#define AppId "{B7F4D8A1-3E22-4B91-A6E4-9C2D5F8A1234}"
+
+[Setup]
+AppId={{#AppId}}
+AppName=Interceptor
+AppVersion={#AppVersion}
+AppPublisher=Hacker Valley Media
+AppPublisherURL=https://github.com/Hacker-Valley-Media/Interceptor
+AppSupportURL=https://github.com/Hacker-Valley-Media/Interceptor/issues
+AppUpdatesURL=https://github.com/Hacker-Valley-Media/Interceptor/releases
+DefaultDirName={localappdata}\Programs\Interceptor
+DefaultGroupName=Interceptor
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputDir=..\..\dist\release
+OutputBaseFilename=Interceptor-{#AppVersion}-windows-x64
+Compression=lzma2/ultra64
+SolidCompression=yes
+WizardStyle=modern
+ChangesEnvironment=yes
+CloseApplications=yes
+RestartApplications=no
+UninstallDisplayIcon={app}\interceptor.exe
+UninstallDisplayName=Interceptor {#AppVersion}
+InfoAfterFile=post-install.txt
+
+[Tasks]
+Name: addtopath; Description: "Add Interceptor to your user PATH"; GroupDescription: "Additional integrations:"
+
+[Files]
+Source: "..\..\dist\interceptor.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\..\daemon\interceptor-daemon.exe"; DestDir: "{app}\daemon"; Flags: ignoreversion
+Source: "..\..\extension\dist\*"; DestDir: "{app}\extension"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Registry]
+; Native messaging host registration. Points each Chromium-family browser
+; at the JSON manifest we render in CurStepChanged(ssPostInstall) — the
+; manifest has to carry the absolute path to interceptor-daemon.exe, which
+; we only know at install time.
+Root: HKCU; Subkey: "Software\Google\Chrome\NativeMessagingHosts\com.interceptor.host"; ValueType: string; ValueName: ""; ValueData: "{app}\com.interceptor.host.json"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.interceptor.host"; ValueType: string; ValueName: ""; ValueData: "{app}\com.interceptor.host.json"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Microsoft\Edge\NativeMessagingHosts\com.interceptor.host"; ValueType: string; ValueName: ""; ValueData: "{app}\com.interceptor.host.json"; Flags: uninsdeletekey
+
+[UninstallDelete]
+Type: files; Name: "{app}\com.interceptor.host.json"
+
+[Code]
+const
+  EnvironmentKey = 'Environment';
+
+procedure RenderNativeMessagingManifest();
+var
+  Manifest, DaemonPath: string;
+begin
+  DaemonPath := ExpandConstant('{app}\daemon\interceptor-daemon.exe');
+  StringChangeEx(DaemonPath, '\', '\\', True);
+  Manifest :=
+    '{' + #13#10 +
+    '  "name": "com.interceptor.host",' + #13#10 +
+    '  "description": "Interceptor daemon bridge",' + #13#10 +
+    '  "path": "' + DaemonPath + '",' + #13#10 +
+    '  "type": "stdio",' + #13#10 +
+    '  "allowed_origins": [' + #13#10 +
+    '    "chrome-extension://hkjbaciefhhgekldhncknbjkofbpenng/",' + #13#10 +
+    '    "chrome-extension://clcflogdlhfnlibdiahigikhpnlmhnpl/",' + #13#10 +
+    '    "chrome-extension://icbmachoifbaiepkgmkdmiomnhmbgigi/"' + #13#10 +
+    '  ]' + #13#10 +
+    '}' + #13#10;
+  SaveStringToFile(ExpandConstant('{app}\com.interceptor.host.json'), Manifest, False);
+end;
+
+function GetUserPath(): string;
+var
+  Existing: string;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, EnvironmentKey, 'Path', Existing) then
+    Existing := '';
+  Result := Existing;
+end;
+
+function PathContains(Hay, Needle: string): Boolean;
+begin
+  Hay := ';' + Lowercase(Hay) + ';';
+  Needle := ';' + Lowercase(Needle) + ';';
+  Result := Pos(Needle, Hay) > 0;
+end;
+
+procedure AddToUserPath();
+var
+  Existing, AppDir: string;
+begin
+  AppDir := ExpandConstant('{app}');
+  Existing := GetUserPath();
+  if PathContains(Existing, AppDir) then
+    Exit;
+  if (Length(Existing) > 0) and (Existing[Length(Existing)] <> ';') then
+    Existing := Existing + ';';
+  Existing := Existing + AppDir;
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvironmentKey, 'Path', Existing);
+end;
+
+procedure RemoveFromUserPath();
+var
+  Existing, AppDir, Working: string;
+begin
+  AppDir := ExpandConstant('{app}');
+  Existing := GetUserPath();
+  if Length(Existing) = 0 then Exit;
+  Working := ';' + Existing + ';';
+  StringChangeEx(Working, ';' + AppDir + ';', ';', True);
+  if (Length(Working) > 0) and (Working[1] = ';') then
+    Working := Copy(Working, 2, Length(Working));
+  if (Length(Working) > 0) and (Working[Length(Working)] = ';') then
+    Working := Copy(Working, 1, Length(Working) - 1);
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, EnvironmentKey, 'Path', Working);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    RenderNativeMessagingManifest();
+    if WizardIsTaskSelected('addtopath') then
+      AddToUserPath();
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+    RemoveFromUserPath();
+end;

--- a/scripts/installer/post-install.txt
+++ b/scripts/installer/post-install.txt
@@ -1,0 +1,27 @@
+Interceptor is installed. Two manual steps remain before the browser surface
+will respond:
+
+1. Enable Developer mode in your target Chromium-family browser.
+   - Brave: open  brave://extensions/   and toggle Developer mode (top-right).
+   - Chrome: open chrome://extensions/  and toggle Developer mode (top-right).
+   - Edge:   open edge://extensions/    and toggle Developer mode (left side).
+   Without Developer mode the browser silently ignores unpacked extensions.
+
+2. Load the Interceptor extension as an unpacked extension.
+   - On the same extensions page, click "Load unpacked".
+   - Select the folder:   <install-dir>\extension
+     (Default: %LOCALAPPDATA%\Programs\Interceptor\extension)
+   - The Interceptor extension card should appear and be enabled.
+
+Once both steps are done, open a fresh terminal and run:
+
+    interceptor status
+    interceptor open https://example.com
+
+If "interceptor" is not recognised in your terminal, close and reopen it so
+Windows picks up the updated user PATH. Or call the executable directly:
+
+    "%LOCALAPPDATA%\Programs\Interceptor\interceptor.exe" status
+
+The macOS-only commands (interceptor macos *) are not available on Windows.
+The Windows-native UIA / Win32 surface is reserved but not yet shipped.


### PR DESCRIPTION
## What

Adds a Windows installer for end users so they don't have to build from source. On any `v*` tag push (and on manual dispatch), GitHub Actions builds the Windows binaries + extension via the existing `scripts/build.sh --target=windows`, compiles an Inno Setup installer, and attaches the `.exe` to a GitHub Release.

This is the Windows analog of the existing macOS `.pkg` flow — give a non-developer a single double-clickable file, no `bun install` / `scripts/build.sh` / `scripts/install.ps1` chain required.

## Files

- `.github/workflows/windows-installer.yml` — runs on `v*` tag push + `workflow_dispatch`. `windows-latest` ships Inno Setup 6 preinstalled, so no extra setup is needed.
- `scripts/installer/interceptor.iss` — Inno Setup script.
- `scripts/installer/post-install.txt` — final installer page text (Developer mode + Load unpacked steps, since Chromium can't auto-load unpacked extensions).

## Installer behavior

| Concern | Decision |
|---|---|
| Privileges | **Per-user** install at `%LOCALAPPDATA%\Programs\Interceptor`. No admin / no UAC. `PrivilegesRequiredOverridesAllowed=dialog` lets a power user opt into per-machine. |
| Native messaging | HKCU keys for Chrome / Brave / Edge — same registry layout as `scripts/install.ps1`. |
| Manifest | `com.interceptor.host.json` rendered at install time via Pascal `[Code]` step with the absolute daemon path baked in. (The repo template uses `__DAEMON_PATH__` placeholder.) |
| PATH | Optional task adds install dir to user PATH (`HKCU\Environment`). Cleaned up on uninstall. |
| Upgrade | Stable `AppId` GUID across versions. Running a newer installer over an older one is an in-place silent upgrade. `CloseApplications=yes` lets Restart Manager handle a running `interceptor-daemon.exe`. |
| Uninstall | Standard Add/Remove Programs entry. Removes manifest, registry keys, and PATH entry. |

## Scope

Browser surface only. `interceptor macos *` is out of scope on Windows (no bridge), and the reserved `interceptor windows` namespace is unchanged. `status` reports `mode: browser-only`, matching the macOS browser pkg.

## What's deliberately not included

- **Code signing.** The `.exe` is unsigned. SmartScreen will show "Windows protected your PC" on first run. The workflow has a comment explaining how to add a `signtool` step + `WINDOWS_PFX` / `WINDOWS_PFX_PASSWORD` secrets when a Code Signing cert is available — kept out of this PR so a maintainer can wire signing into their cert flow rather than committing to one here.
- **Sparkle / WinSparkle auto-update.** Out of scope; matches the current state of the macOS pkg flow (`publish-sparkle.sh` is run separately after testing).
- **Per-machine installer.** Skipped because Chromium scopes native messaging hosts per-user, so a per-machine install would still need per-user post-install steps. `PrivilegesRequiredOverridesAllowed=dialog` keeps the door open if someone wants to elevate at the prompt.

## Tested

End-to-end on Windows 11 from a fork of this repo:

1. Pushed the branch to the fork; the workflow ran on manual dispatch (`windows-latest`, ~3 min).
2. Downloaded the `.exe` artifact, ran it locally — no UAC prompt, installer completed at `%LOCALAPPDATA%\Programs\Interceptor`.
3. Loaded the unpacked extension from `<install-dir>\extension` in Edge.
4. `interceptor status` → `mode: browser-only`, `daemon: running` after first command.
5. `interceptor open https://www.linkedin.com/feed/ --activate` returned tree + text against the real logged-in session (passive network capture working, no debugger banner).

## Notes for review

- The extension `key` in `extension/manifest.json` is the upstream HVM key, so the resulting unpacked extension has the canonical `hkjbaciefhhgekldhncknbjkofbpenng` ID — no allowed_origins drift.
- Daemon binary at `{app}\daemon\interceptor-daemon.exe` matches what `scripts/install.ps1` registers, so a user upgrading from a source-built install still gets a working manifest path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows installer build added with manual-triggered packaging and automated upload to Releases.
  * Installer provides a per-user install, registers the browser native messaging host, and can add/remove the install directory to the user PATH.

* **Documentation**
  * Added Windows post-install instructions covering extension enablement, CLI verification, and PATH refresh steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->