### PR TITLE
fix(status): omit socket line on Windows (TCP transport)

### DIFF
--- a/cli/lib/status-renderer.ts
+++ b/cli/lib/status-renderer.ts
@@ -244,11 +244,22 @@ export function formatStatus(snap: StatusSnapshot, opts: { verbose?: boolean }):
     lines.push(`daemon: ${snap.daemon ? "running" : "not running"}`)
   }
   if (snap.pid) lines.push(`pid: ${snap.pid}`)
+  // Only render the socket line on platforms that actually use a Unix socket.
+  // On Windows the daemon is reached over TCP (transport: tcp:127.0.0.1:...),
+  // so a "socket: not found" line next to "daemon: running" reads as a
+  // contradiction to anything (or anyone) parsing this output. The transport
+  // line below already reports the real connection path.
+  const usesUnixSocket = snap.transport.startsWith("unix:")
+  if (usesUnixSocket) {
+    if (v) {
+      lines.push(`socket (Unix socket the CLI uses to reach the daemon): ${snap.socket ?? "not found"}`)
+    } else {
+      lines.push(`socket: ${snap.socket ?? "not found"}`)
+    }
+  }
   if (v) {
-    lines.push(`socket (Unix socket the CLI uses to reach the daemon): ${snap.socket ?? "not found"}`)
     lines.push(`transport (how the CLI reaches the daemon): ${snap.transport}`)
   } else {
-    lines.push(`socket: ${snap.socket ?? "not found"}`)
     lines.push(`transport: ${snap.transport}`)
   }
 

--- a/test/cli-meta-additions.test.ts
+++ b/test/cli-meta-additions.test.ts
@@ -182,6 +182,39 @@ describe("formatStatus (#49 + #52)", () => {
     expect(out).toContain("no tabs in interceptor group")
   })
 
+  test("omits socket line when transport is TCP (Windows)", () => {
+    // On Windows the daemon listens over TCP, not a Unix socket. The socket
+    // field is structurally null and a "socket: not found" line next to
+    // "daemon: running" misleads agents parsing this output.
+    const out = formatStatus(
+      fakeSnapshot({
+        daemon: true,
+        pid: 27476,
+        socket: null,
+        transport: "tcp:127.0.0.1:19221",
+      }),
+      { verbose: false },
+    )
+    expect(out).toContain("daemon: running")
+    expect(out).toContain("transport: tcp:127.0.0.1:19221")
+    expect(out).not.toContain("socket:")
+    expect(out).not.toContain("not found")
+  })
+
+  test("omits socket line on TCP transport even in verbose mode", () => {
+    const out = formatStatus(
+      fakeSnapshot({
+        daemon: true,
+        pid: 27476,
+        socket: null,
+        transport: "tcp:127.0.0.1:19221",
+      }),
+      { verbose: true },
+    )
+    expect(out).toContain("transport (how the CLI reaches the daemon): tcp:127.0.0.1:19221")
+    expect(out).not.toContain("(Unix socket the CLI uses to reach the daemon)")
+  })
+
   test("bridge block only renders when mode != browser-only", () => {
     const browserOnly = formatStatus(fakeSnapshot({ mode: "browser-only" }), { verbose: false })
     expect(browserOnly).not.toContain("bridge:")


### PR DESCRIPTION
## Problem

On Windows, `interceptor status` always prints `socket: not found` next to `daemon: running`:

```
mode: browser-only

daemon: running
pid: 27476
socket: not found
transport: tcp:127.0.0.1:19221
```

The daemon is fine — Windows just doesn't use a Unix socket. `shared/platform.ts` already routes Windows over TCP (`127.0.0.1:19221`), and `readStatusSnapshot` short-circuits the `existsSync` check with `!IS_WIN && existsSync(SOCKET_PATH)`, so `snap.socket` is structurally always `null` on Windows. The renderer then prints `socket: not found` regardless of daemon health.

This reads as a contradiction — especially to agents parsing the output, which start second-guessing whether the daemon is actually reachable.

## Fix

Gate the `socket:` line on `transport.startsWith("unix:")`. The transport line below already conveys the real connection path on every platform, so nothing is lost on Windows; `unix:` platforms are unaffected.

## Output after

```
mode: browser-only

daemon: running
pid: 27476
transport: tcp:127.0.0.1:19221
```

Verbose mode similarly drops the `socket (Unix socket the CLI uses to reach the daemon): ...` line on Windows.

## JSON contract

`snapshotToJson` is **unchanged** — `socket: null` stays in the structured output. `null` is unambiguous for code consumers; the noise was specifically in the human-readable text format.

## Tests

Two new cases in `test/cli-meta-additions.test.ts`:
- terse mode with `transport: tcp:127.0.0.1:19221` must not contain `socket:` or `not found`
- verbose mode with the same transport must not contain the socket annotation

Existing tests (which use `unix:/tmp/interceptor.sock` in their fake snapshot) continue to pass — 19/19.

## Verified locally

`bun test test/cli-meta-additions.test.ts` → 19 pass / 0 fail
`bun run cli/index.ts status` and `status --verbose` on Windows → no socket line, transport correctly reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CLI daemon status output now correctly displays transport information for all connection types without misleading error messages
  * Fixed socket-related messages appearing on Windows when using TCP connections

* **Tests**
  * Added tests to verify correct status output formatting across different connection types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->