### PR TITLE
fix(daemon): prevent secondary daemon cleanup from killing running daemon's socket

### DIFF
--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -441,6 +441,7 @@ if (existsSync(PID_PATH)) {
         process.kill(existingPid, 0)
         if (STANDALONE) {
           log(`another daemon already running (pid ${existingPid}) — exiting`)
+          ;(process as any)._skipCleanup = true
           process.exit(0)
         }
         // Native-messaging mode: become a relay instead of exiting
@@ -1071,6 +1072,7 @@ function gracefulShutdown(signal: string) {
 }
 
 process.on("exit", (code) => {
+  if ((process as any)._skipCleanup) return
   log(`exiting with code ${code}`)
   try { unlinkSync(SOCKET_PATH) } catch {}
   try { unlinkSync(PID_PATH) } catch {}


### PR DESCRIPTION
## Problem

When a second daemon instance starts and detects an existing running daemon, it calls `process.exit(0)`. The `process.on("exit")` handler unconditionally deletes `/tmp/interceptor.sock` and `/tmp/interceptor.pid`, which breaks the *original* running daemon — its socket and PID file vanish out from under it.

## Fix

Added a `_skipCleanup` flag on `process` set to `true` before `process.exit(0)` in the "another daemon already running" path. The exit handler checks this flag and skips file cleanup.

## Verification

```
# Start daemon 1
interceptor-daemon --standalone &
sleep 1
interceptor status → running, pid 12345

# Start daemon 2 — exits immediately, socket files preserved
interceptor-daemon --standalone &
sleep 1
interceptor status → still running, pid 12345
```

Also verified end-to-end with Chromium + extension via `interceptor open http://localhost:4321/` — returns full page content, exit code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon restart reliability by preventing unnecessary cleanup of socket and process ID files when a newer daemon instance detects an existing daemon already running in standalone mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->