### PR TITLE
Add native VM control groundwork

### DIFF
--- a/.agents/skills/interceptor-macos/Workflows/VmLifecycle.md
+++ b/.agents/skills/interceptor-macos/Workflows/VmLifecycle.md
@@ -1,0 +1,127 @@
+---
+name: VmLifecycle
+description: Manage Linux and macOS virtual machines via `interceptor macos vm *`. Covers create, clone, install, start, exec, snapshot, restore, stop, and delete. Linux uses Apple's Containerization Swift package in-process; macOS uses raw VZ. State lives under $CWD/.interceptor/vms/ by default. Replaces Lume / Tart / UTM. Use for QA gold-VM pipelines, ephemeral test VMs, and any workflow that needs to drive a guest with the same AX/click/type/screenshot verbs Interceptor exposes on the host.
+---
+
+# VM Lifecycle Workflow
+
+You are managing a virtual machine through `interceptor macos vm`. The host runs the bridge with `com.apple.security.virtualization`. Linux guests are backed by Apple's Containerization package; macOS guests by raw `Virtualization.framework`.
+
+## State location
+
+Default: `$CWD/.interceptor/vms/`. Override per-invocation with `--state-dir <path>` or globally with `INTERCEPTOR_VM_STATE_DIR`. Layout per VM:
+
+```
+<state>/vms/<name>.bundle/
+    spec.json
+    Disk.img
+    AuxiliaryStorage          (macOS only)
+    MachineIdentifier         (macOS only)
+    HardwareModel             (macOS only)
+    snapshots/<tag>/SaveFile.vzvmsave + manifest.json
+```
+
+This matches Apple's `VM.bundle` spec — external tools can read it.
+
+## Linux guest — minimal end-to-end
+
+```bash
+interceptor macos vm create lin1 \
+    --kind linux \
+    --cpu 2 --memory 1073741824 --disk 4294967296 \
+    --image docker.io/library/alpine:3 \
+    --network nat
+interceptor macos vm start lin1 --wait-for-vsock
+interceptor macos vm exec lin1 -- uname -a
+interceptor macos vm stop lin1
+interceptor macos vm delete lin1 --force
+```
+
+## macOS guest — install once, clone many
+
+```bash
+# One-time gold image install (~10-20 min the first time, ~free thereafter)
+interceptor macos vm install macos-gold --from-latest \
+    --cpu 4 --memory 8589934592 --disk 64424509440
+
+# Operator does the one-time TCC grant (Accessibility / Screen Recording /
+# Input Monitoring / Microphone / Speech Recognition) inside the booted
+# gold VM, then snapshots. Subsequent clones inherit the grant.
+interceptor macos vm snapshot macos-gold baseline --paused-state
+
+# Per-run clone is CoW (instant)
+interceptor macos vm clone macos-gold macos-test
+interceptor macos vm start macos-test --wait-for-vsock --headless
+
+# Drive
+interceptor macos vm exec macos-test sw_vers
+interceptor macos vm screenshot macos-test --out /tmp/before.png
+interceptor macos vm read-ax macos-test --filter 'AXButton'
+interceptor macos vm click macos-test 800 600
+
+# Tear down
+interceptor macos vm stop macos-test
+interceptor macos vm delete macos-test --force
+```
+
+## Verb cheat sheet
+
+| Verb | Purpose | Notes |
+|---|---|---|
+| `create` | Allocate bundle + persist spec. Does not boot. | `--kind linux\|macos` required |
+| `clone <src> <dst>` | APFS clonefile + identifier rotation | Inherits TCC grants on macOS |
+| `install <name> --from-latest` | macOS only: VZMacOSInstaller | Operator does TCC dance once, then snapshot |
+| `pull <oci-ref>` | Linux only: pre-cache an OCI image | Cached at `<state>/images/oci/` |
+| `start <name>` | Boot. Default blocks until running. | `--headless`, `--wait-for-vsock`, `--detach` |
+| `stop <name>` | Graceful: `requestStop`. `--force` for `VZVirtualMachine.stop`. | `--timeout 60` |
+| `pause` / `resume` | VZ pause / resume | macOS guests only in v1 |
+| `delete <name>` | Tear down. `--keep-disk` parks the bundle. | `--force` is required when running |
+| `reset <name>` | Recover from `.error` state. | Rebuilds VZVirtualMachine from spec |
+| `exec <name> -- <argv>` | Run a command inside the guest. | vsock guest agent; `--via ssh` (Linux only) |
+| `snapshot <name> <tag>` | Pause-state + disk clone. | `--paused-state`, `--disk-only` |
+| `restore <name> <tag>` | Roll Disk.img back, optional VZ state restore. | VM must be stopped |
+| `screenshot`, `type`, `click`, `keys`, `read-ax`, `console`, `logs`, `cp`, `share`, `mount`, `port-forward` | Guest-driving verbs via the in-guest agent. | v2 — pre-granted PPPC on macOS gold image |
+
+## Native delivery
+
+Projects that previously used Lume can replace:
+
+- `qa/lib/lume.sh` — replaced by `interceptor macos vm get/clone/start/stop/delete`.
+- `qa/lib/ssh.sh` — replaced by `interceptor macos vm exec/cp`.
+- `qa/lib/screenshot.sh` — replaced by `interceptor macos vm screenshot`.
+
+For each `lume` verb, the equivalent native call:
+
+| Old Lume verb | Native replacement |
+|---|---|
+| `lume get <n> --format json` → `.[0].status` / `.ipAddress` | `interceptor macos vm get <n> --json` |
+| `lume clone <src> <dst>` | `interceptor macos vm clone <src> <dst>` |
+| `lume run <n> --no-display` | `interceptor macos vm start <n> --headless --wait-for-vsock` |
+| `lume stop <n>` | `interceptor macos vm stop <n>` |
+| `lume delete <n> --force` | `interceptor macos vm delete <n> --force` |
+| `sshpass -p lume ssh <n> <cmd>` | `interceptor macos vm exec <n> -- <cmd>` |
+| `sshpass -p lume scp <src> <n>:<dst>` | `interceptor macos vm cp <src> <n>:<dst>` |
+| `screencapture -x` over SSH | `interceptor macos vm screenshot <n> --out <path>` |
+| `osascript -e 'keystroke return'` over SSH | `interceptor macos vm keys <n> return` |
+
+The vsock guest agent (in-guest `interceptord`) keeps in-guest AX, click, and screenshot independent from SSH-session TCC grants.
+
+## Setup_required envelopes
+
+The bridge returns `setup_required` envelopes when the host can't run VMs:
+
+- `host macOS < 15.0` — upgrade via `softwareupdate --install`.
+- Bridge missing `com.apple.security.virtualization` — rebuild with `scripts/build-bridge.sh`.
+- Bridge installed under `~/Documents` or `~/Desktop` — move it (see `research/container/BUILDING.md:9-10`).
+
+Callers parse the envelope and surface a clean error rather than re-trying the failing verb.
+
+## Snapshots — what survives
+
+- **Disk-state** (`--disk-only`): clonefile of Disk.img. Always works.
+- **Paused-state** (`--paused-state`): `VZVirtualMachine.saveMachineStateTo(url:)`. Requires `validateSaveRestoreSupport()` to return true on the config. macOS guests support it; some Linux configurations do not.
+- **TCC grants on macOS gold**: pre-granted PPPC profile in the installed `.pkg`, snapshotted into the gold's AuxiliaryStorage. Clones inherit.
+
+## Background-first
+
+`vm start --headless` is the default. `vm screenshot` defaults to vsock-driven `CGDisplayCreateImage` inside the guest agent — no host TCC. `--pixel` falls back to host-side `VZVirtualMachineView` capture, which requires Screen Recording on the host.

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -206,6 +206,46 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       }
     }
 
+    // ── TCC / PPPC profile management ──
+    case "tcc": {
+      const op = filtered[2] || "status"
+      const target = flagVal(filtered, "--target") || "host"
+
+      if (op === "status") {
+        return {
+          type: "macos_tcc_status",
+          sub: "status",
+          target,
+        }
+      }
+
+      if (op === "profile") {
+        const profileOp = filtered[3]
+        if (profileOp !== "generate") {
+          console.error("error: interceptor macos tcc profile requires subcommand: generate")
+          process.exit(1)
+        }
+        const services = collectMulti(filtered, "--service").flatMap((s) => s.split(",").filter(Boolean))
+        const action: Action = {
+          type: "macos_tcc_profile_generate",
+          sub: "profile_generate",
+          target,
+        }
+        if (services.length > 0) action.services = services
+        if (flagVal(filtered, "--out")) action.out = flagVal(filtered, "--out")
+        if (flagVal(filtered, "--bundle-id")) action.bundleId = flagVal(filtered, "--bundle-id")
+        if (flagVal(filtered, "--app-path")) action.appPath = flagVal(filtered, "--app-path")
+        if (flagVal(filtered, "--identifier-type")) action.identifierType = flagVal(filtered, "--identifier-type")
+        if (flagVal(filtered, "--code-requirement")) action.codeRequirement = flagVal(filtered, "--code-requirement")
+        if (filtered.includes("--full-disk")) action.fullDisk = true
+        if (filtered.includes("--include-user-only")) action.includeUserOnly = true
+        return action
+      }
+
+      console.error("error: interceptor macos tcc requires subcommand: status | profile generate")
+      process.exit(1)
+    }
+
     // ── Apps ──
     case "apps":
       return { type: "macos_apps" }
@@ -298,7 +338,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       if (!ref) { console.error("error: interceptor macos resize requires a ref"); process.exit(1) }
       const width = flagInt(filtered, "--width") || parseInt(filtered[3]) || undefined
       const height = flagInt(filtered, "--height") || parseInt(filtered[4]) || undefined
-      // PRD-62: parser parity with click/type/keys/scroll/drag — forward
+      // : parser parity with click/type/keys/scroll/drag — forward
       // --app and --pid so the bridge can use them for ref qualification.
       const action: Action = { type: "macos_resize", ref, width, height }
       const resizeApp = flagVal(filtered, "--app")
@@ -416,7 +456,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
         sub: op,
         app: flagVal(filtered, "--app"),
       }
-      // PRD-63 diagnostic: dump the captured image to disk so the operator
+      // diagnostic: dump the captured image to disk so the operator
       // can see what Vision actually fed VNRecognizeTextRequest. Off by
       // default; opt in with --debug-dump <path>.
       const debugDump = flagVal(filtered, "--debug-dump")
@@ -441,7 +481,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
     // ── Intelligence ──
     case "ai": {
       const op = filtered[2] || "status"
-      // PRD-65 Spec 1 follow-up: `ai session <op>` previously sent
+      // Spec 1 follow-up: `ai session <op>` previously sent
       // filtered[3] as `prompt`, but the bridge's IntelligenceDomain.handleSession
       // reads action["op"], so the inner op (start/send/history/end) was
       // dropped and every session call fell through to "session status"
@@ -496,7 +536,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       // legacy DistributedNotificationCenter flags
       const app = flagVal(filtered, "--app"); if (app) action.app = app
       const limit = flagInt(filtered, "--limit"); if (limit !== undefined) action.limit = limit
-      // PRD-66 — UNUserNotificationCenter flags. Numeric flags must be
+      // UNUserNotificationCenter flags. Numeric flags must be
       // int-typed because the bridge handler casts with `as? Int` and a
       // string value silently drops to nil (NotificationsDomain.swift:297
       // — `--seconds <N> required` fires even when --seconds 5 is passed).
@@ -547,7 +587,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
 
     // ── Audio ──
     case "audio": {
-      // PRD-65 Spec 5 / PRD-64 Spec 5: bare `interceptor macos audio`
+      // Spec 5 / Spec 5: bare `interceptor macos audio`
       // previously defaulted to channel="output" + op="start" — silently
       // starting capture as a side effect of asking for help. Require both
       // explicitly so the no-arg invocation prints usage instead.
@@ -877,6 +917,318 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       }
     }
 
+    // ── VM management (VmDomain) — ──
+    case "vm": {
+      const vmSub = filtered[2]
+      if (!vmSub) {
+        console.error("error: interceptor macos vm requires a subcommand: create | adopt | clone | install | pull | list | get | inspect | start | stop | pause | resume | delete | reset | snapshot | restore | exec | cp | share | mount | port-forward | screenshot | type | click | keys | read-ax | console | logs | trust | tcc")
+        process.exit(1)
+      }
+      const stateDir = flagVal(filtered, "--state-dir")
+      const base: Action = { type: `macos_vm_${vmSub.replace(/-/g, "_")}`, sub: vmSub }
+      if (stateDir) base.stateDir = stateDir
+
+      const intArg = (flag: string): number | undefined => flagInt(filtered, flag) ?? undefined
+      const strArg = (flag: string): string | undefined => flagVal(filtered, flag) ?? undefined
+      const boolArg = (flag: string): boolean => filtered.includes(flag)
+
+      switch (vmSub) {
+        case "create": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm create requires a name"); process.exit(1) }
+          base.name = name
+          const kind = strArg("--kind") || "linux"
+          base.kind = kind
+          if (intArg("--cpu") !== undefined) base.cpu = intArg("--cpu")
+          if (intArg("--memory") !== undefined) base.memorySize = intArg("--memory")
+          if (intArg("--disk") !== undefined) base.diskSize = intArg("--disk")
+          if (strArg("--image")) base.image = strArg("--image")
+          if (strArg("--network")) base.network = strArg("--network")
+          if (boolArg("--rosetta")) base.rosetta = true
+          // --share src:tag[:ro|:rw], repeatable
+          const shares: Array<{ hostPath: string; tag: string; readOnly: boolean }> = []
+          for (let i = 0; i < filtered.length - 1; i++) {
+            if (filtered[i] === "--share") {
+              const parts = filtered[i + 1].split(":")
+              if (parts.length >= 2) {
+                shares.push({ hostPath: parts[0], tag: parts[1], readOnly: parts[2] !== "rw" })
+              }
+            }
+          }
+          if (shares.length > 0) base.shares = shares
+          return base
+        }
+        case "adopt": {
+          const sourcePath = filtered[3]
+          if (!sourcePath) { console.error("error: interceptor macos vm adopt requires <path>"); process.exit(1) }
+          base.sourcePath = sourcePath
+          const name = strArg("--name")
+          if (!name) { console.error("error: interceptor macos vm adopt requires --name <name>"); process.exit(1) }
+          base.name = name
+          base.kind = strArg("--kind") || "macos"
+          base.provider = strArg("--provider") || "auto"
+          base.mode = strArg("--mode") || "clone"
+          if (boolArg("--install-agent")) base.installAgent = true
+          if (boolArg("--wait-for-agent")) base.waitForAgent = true
+          return base
+        }
+        case "clone": {
+          const src = filtered[3]
+          const dst = filtered[4]
+          if (!src || !dst) { console.error("error: interceptor macos vm clone requires <src> <dst>"); process.exit(1) }
+          base.src = src; base.dst = dst
+          return base
+        }
+        case "install": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm install requires a name"); process.exit(1) }
+          base.name = name
+          if (strArg("--ipsw")) base.ipsw = strArg("--ipsw")
+          if (boolArg("--from-latest")) base.fromLatest = true
+          return base
+        }
+        case "pull": {
+          const image = filtered[3]
+          if (!image) { console.error("error: interceptor macos vm pull requires an image OCI ref"); process.exit(1) }
+          base.image = image
+          return base
+        }
+        case "list": {
+          return base
+        }
+        case "get":
+        case "inspect": {
+          const name = filtered[3]
+          if (!name) { console.error(`error: interceptor macos vm ${vmSub} requires a name`); process.exit(1) }
+          base.name = name
+          return base
+        }
+        case "start": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm start requires a name"); process.exit(1) }
+          base.name = name
+          if (boolArg("--headless")) base.headless = true
+          if (boolArg("--wait-for-vsock")) base.waitForVsock = true
+          if (boolArg("--detach")) base.detach = true
+          return base
+        }
+        case "stop": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm stop requires a name"); process.exit(1) }
+          base.name = name
+          if (boolArg("--force")) base.force = true
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "pause":
+        case "resume":
+        case "reset": {
+          const name = filtered[3]
+          if (!name) { console.error(`error: interceptor macos vm ${vmSub} requires a name`); process.exit(1) }
+          base.name = name
+          return base
+        }
+        case "delete": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm delete requires a name"); process.exit(1) }
+          base.name = name
+          if (boolArg("--force")) base.force = true
+          if (boolArg("--keep-disk")) base.keepDisk = true
+          return base
+        }
+        case "trust": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm trust requires a name"); process.exit(1) }
+          base.name = name
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "tcc": {
+          const tccOp = filtered[3]
+          if (tccOp !== "profile") {
+            console.error("error: interceptor macos vm tcc requires subcommand: profile generate <name>")
+            process.exit(1)
+          }
+          const profileOp = filtered[4]
+          if (profileOp !== "generate") {
+            console.error("error: interceptor macos vm tcc profile requires subcommand: generate <name>")
+            process.exit(1)
+          }
+          const name = filtered[5]
+          if (!name) { console.error("error: interceptor macos vm tcc profile generate requires a VM name"); process.exit(1) }
+          base.type = "macos_vm_tcc_profile_generate"
+          base.sub = "tcc_profile_generate"
+          base.name = name
+          const services = collectMulti(filtered, "--service").flatMap((s) => s.split(",").filter(Boolean))
+          if (services.length > 0) base.services = services
+          if (strArg("--out")) base.out = strArg("--out")
+          if (strArg("--bundle-id")) base.bundleId = strArg("--bundle-id")
+          if (strArg("--app-path")) base.appPath = strArg("--app-path")
+          if (strArg("--identifier-type")) base.identifierType = strArg("--identifier-type")
+          if (strArg("--code-requirement")) base.codeRequirement = strArg("--code-requirement")
+          if (boolArg("--full-disk")) base.fullDisk = true
+          if (boolArg("--include-user-only")) base.includeUserOnly = true
+          return base
+        }
+        case "exec": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm exec requires <name> <cmd> [args...]"); process.exit(1) }
+          base.name = name
+          // Everything after the name and -- separator is the command argv
+          const sepIdx = filtered.indexOf("--", 4)
+          const argv = sepIdx >= 0 ? filtered.slice(sepIdx + 1) : filtered.slice(4).filter(a => !a.startsWith("--"))
+          if (argv.length === 0) { console.error("error: interceptor macos vm exec requires a command"); process.exit(1) }
+          base.command = argv
+          if (strArg("--user")) base.user = strArg("--user")
+          if (strArg("--workdir")) base.workdir = strArg("--workdir")
+          if (boolArg("--tty")) base.tty = true
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          // --env KEY=VAL repeatable
+          const env: Record<string, string> = {}
+          for (let i = 0; i < filtered.length - 1; i++) {
+            if (filtered[i] === "--env") {
+              const m = /^([^=]+)=(.*)$/.exec(filtered[i + 1])
+              if (m) env[m[1]] = m[2]
+            }
+          }
+          if (Object.keys(env).length > 0) base.env = env
+          return base
+        }
+        case "snapshot": {
+          const name = filtered[3]
+          const tag = filtered[4]
+          if (!name || !tag) { console.error("error: interceptor macos vm snapshot requires <name> <tag>"); process.exit(1) }
+          base.name = name; base.tag = tag
+          base.snapshotOp = strArg("--op") || "create"
+          if (boolArg("--disk-only")) base.diskOnly = true
+          if (boolArg("--paused-state")) base.pausedStateOnly = true
+          return base
+        }
+        case "restore": {
+          const name = filtered[3]
+          const tag = filtered[4]
+          if (!name || !tag) { console.error("error: interceptor macos vm restore requires <name> <tag>"); process.exit(1) }
+          base.name = name; base.tag = tag
+          return base
+        }
+        case "cp": {
+          const src = filtered[3]
+          const dst = filtered[4]
+          if (!src || !dst) { console.error("error: interceptor macos vm cp requires <src> <dst>"); process.exit(1) }
+          base.src = src
+          base.dst = dst
+          const srcVm = /^([^/:]+):(.+)$/.exec(src)
+          const dstVm = /^([^/:]+):(.+)$/.exec(dst)
+          base.name = (dstVm && dstVm[1]) || (srcVm && srcVm[1])
+          if (!base.name) { console.error("error: interceptor macos vm cp requires one side as <vm>:<path>"); process.exit(1) }
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "mount": {
+          const name = filtered[3]
+          const tag = filtered[4]
+          const path = filtered[5]
+          if (!name || !tag || !path) { console.error("error: interceptor macos vm mount requires <name> <tag> <guest-path>"); process.exit(1) }
+          base.name = name
+          base.tag = tag
+          base.path = path
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "screenshot": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm screenshot requires <name>"); process.exit(1) }
+          base.name = name
+          if (strArg("--out")) base.out = strArg("--out")
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "type": {
+          const name = filtered[3]
+          const text = filtered[4]
+          if (!name || text === undefined) { console.error("error: interceptor macos vm type requires <name> <text>"); process.exit(1) }
+          base.name = name
+          base.text = text
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "click": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm click requires <name> <x,y> or --x --y"); process.exit(1) }
+          base.name = name
+          const xy = filtered[4] && /^-?\d+(\.\d+)?,-?\d+(\.\d+)?$/.test(filtered[4]) ? filtered[4].split(",") : undefined
+          const xRaw = strArg("--x") ?? xy?.[0]
+          const yRaw = strArg("--y") ?? xy?.[1]
+          const x = xRaw !== undefined ? Number(xRaw) : NaN
+          const y = yRaw !== undefined ? Number(yRaw) : NaN
+          if (!Number.isFinite(x) || !Number.isFinite(y)) { console.error("error: interceptor macos vm click requires numeric x/y"); process.exit(1) }
+          base.x = x
+          base.y = y
+          if (strArg("--button")) base.button = strArg("--button")
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "keys": {
+          const name = filtered[3]
+          const keys = filtered[4]
+          if (!name || !keys) { console.error("error: interceptor macos vm keys requires <name> <keys>"); process.exit(1) }
+          base.name = name
+          base.keys = keys
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "read-ax": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm read-ax requires <name>"); process.exit(1) }
+          base.name = name
+          if (intArg("--max-depth") !== undefined) base.max_depth = intArg("--max-depth")
+          if (strArg("--app")) base.app = strArg("--app")
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "logs": {
+          const name = filtered[3]
+          if (!name) { console.error("error: interceptor macos vm logs requires <name>"); process.exit(1) }
+          base.name = name
+          if (intArg("--limit") !== undefined) base.limit = intArg("--limit")
+          if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
+          return base
+        }
+        case "share": {
+          const name = filtered[3]
+          const hostPath = filtered[4]
+          const tag = filtered[5]
+          if (!name || !hostPath || !tag) { console.error("error: interceptor macos vm share requires <name> <host-path> <tag>"); process.exit(1) }
+          base.name = name
+          base.hostPath = hostPath
+          base.tag = tag
+          base.readOnly = !boolArg("--rw")
+          return base
+        }
+        case "port-forward":
+        case "console": {
+          const name = filtered[3]
+          if (name) base.name = name
+          const rule = filtered[4]
+          if (vmSub === "port-forward" && rule) {
+            const parts = rule.split(":")
+            if (parts.length === 2) {
+              base.hostPort = Number(parts[0])
+              base.guestPort = Number(parts[1])
+            } else if (parts.length === 3) {
+              base.hostAddress = parts[0]
+              base.hostPort = Number(parts[1])
+              base.guestPort = Number(parts[2])
+            }
+          }
+          return base
+        }
+        default:
+          console.error(`error: interceptor macos vm: unknown subcommand '${vmSub}'`)
+          process.exit(1)
+      }
+    }
+
     // ── container_run (ContainerDomain) ──
     case "container": {
       const containerSub = filtered[2]
@@ -940,13 +1292,13 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           const sceneScript = flagVal(filtered, "--scene-script")
           const url = flagVal(filtered, "--url")
           const htmlB64 = flagVal(filtered, "--html-b64")
-          // PRD-65 Spec 7: --html accepted as a friendlier alias to
+          // Spec 7: --html accepted as a friendlier alias to
           // --html-b64; the parser b64-encodes inline HTML so callers
           // don't have to wrap shell-escaped HTML themselves.
           const htmlInline = flagVal(filtered, "--html")
           const rect = flagVal(filtered, "--rect")
           const timeout = flagInt(filtered, "--timeout-seconds")
-          // PRD-65 Spec 7: --duration / --duration-ms aliases for the
+          // Spec 7: --duration / --duration-ms aliases for the
           // existing --timeout-seconds. The bridge auto-dismisses after
           // the timeout regardless of mode.
           const durationMs = flagInt(filtered, "--duration-ms")
@@ -971,7 +1323,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           if (sceneScript) action.scene_script = sceneScript
           if (url) action.url = url
           if (htmlB64) action.html_b64 = htmlB64
-          // PRD-65 Spec 7: forward inline --html as html_b64 (b64-encoded)
+          // Spec 7: forward inline --html as html_b64 (b64-encoded)
           // so the bridge has a single source HTML field. Buffer.from is
           // already imported into Bun's globals.
           let resolvedHtmlB64: string | undefined = htmlB64
@@ -980,7 +1332,7 @@ export function parseMacosCommand(filtered: string[]): Action | null {
             action.html_b64 = resolvedHtmlB64
           }
 
-          // PRD-65 Spec 7: unify --duration-ms / --duration / --timeout-seconds
+          // Spec 7: unify --duration-ms / --duration / --timeout-seconds
           // into the bridge's single `timeout_seconds` action field
           // (OverlayDomain only reads timeout_seconds today, see
           // OverlayDomain.swift:114). --duration-ms wins, then --duration
@@ -1058,9 +1410,9 @@ export function parseMacosCommand(filtered: string[]): Action | null {
       }
     }
 
-    // ── PRD-66 — Personal data + distribution + document surfaces ──
+    // ── Personal data + distribution + document surfaces ──
     // Each branch maps `interceptor macos <domain> <verb> [...]` to a
-    // `macos_<domain>` action with `sub` carrying the verb (PRD-63 invariant).
+    // `macos_<domain>` action with `sub` carrying the verb (invariant).
 
     case "pdf": {
       const verb = filtered[2]

--- a/interceptor-bridge/InterceptorD/main.swift
+++ b/interceptor-bridge/InterceptorD/main.swift
@@ -1,0 +1,621 @@
+// InterceptorD (in-guest agent)
+//
+// Listens on vsock port 3294 inside a Linux or macOS guest. Speaks the
+// same length-prefixed JSON framing as the host bridge (`WireFormat`
+// pattern). Each inbound request looks like:
+//
+//   { "id": "<uuid>", "action": { "verb": "exec", ... } }
+//
+// And every response looks like:
+//
+//   { "id": "<uuid>", "result": { "success": true, "data": {...} } }
+//   { "id": "<uuid>", "result": { "success": false, "error": "..." } }
+//
+// Verbs:
+//   exec        — fork/exec argv inside the guest; capture stdout/stderr
+//   get_ip      — read primary interface IPv4 (ip -j addr on Linux, ifconfig en0 on macOS)
+//   screenshot  — CGDisplayCreateImage (macOS) / `grim` or `scrot` (Linux)
+//   type        — CGEventCreateKeyboardEvent + CGEventPost (macOS) / xdotool|wtype (Linux)
+//   click       — CGEventCreateMouseEvent + CGEventPost (macOS)
+//   keys        — keychord injection (macOS)
+//   read_ax     — AXUIElementCreateApplication walk (macOS); AT-SPI not implemented
+//   mount       — invoke `mount -t virtiofs <tag> <path>` inside the guest
+//   cp_in       — receive bytes into a guest path (host pushes)
+//   cp_out      — read a guest path and return bytes (host pulls)
+//
+// vsock semantics on Linux: AF_VSOCK + SOCK_STREAM, family-specific
+// address. On macOS: Darwin doesn't expose AF_VSOCK to user-space; the
+// macOS guest agent therefore binds on a localhost loopback when run
+// under VZ, and the host's VsockGuestAgent connects via
+// VZVirtioSocketDevice.connect(toPort:) — the connection inside the
+// guest is a normal SOCK_STREAM that lands here.
+
+import Foundation
+import Darwin
+
+#if os(macOS)
+import AppKit
+import ApplicationServices
+import CoreGraphics
+#endif
+
+// MARK: - Constants
+
+let kAgentPort: UInt32 = 3294
+let requiredAuthToken = ProcessInfo.processInfo.environment["INTERCEPTOR_GUEST_TOKEN"]
+
+// MARK: - JSON helpers
+
+func jsonData(_ obj: [String: Any]) -> Data? {
+    return try? JSONSerialization.data(withJSONObject: obj, options: [])
+}
+
+func writeFrame(fd: Int32, _ obj: [String: Any]) {
+    guard let data = jsonData(obj) else { return }
+    var length = UInt32(data.count).littleEndian
+    var frame = Data(bytes: &length, count: 4)
+    frame.append(data)
+    _ = frame.withUnsafeBytes { ptr in
+        Darwin.write(fd, ptr.baseAddress!, frame.count)
+    }
+}
+
+func successResult(_ id: String, data: [String: Any]) -> [String: Any] {
+    return ["id": id, "result": ["success": true, "data": data]]
+}
+
+func errorResult(_ id: String, _ message: String) -> [String: Any] {
+    return ["id": id, "result": ["success": false, "error": message]]
+}
+
+// MARK: - Verb handlers
+
+func handleExec(_ action: [String: Any]) -> [String: Any] {
+    guard let argv = action["argv"] as? [String], !argv.isEmpty else {
+        return ["success": false, "error": "exec: missing argv"]
+    }
+    let workdir = action["workdir"] as? String
+    let env = action["env"] as? [String: String] ?? [:]
+
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: argv[0])
+    task.arguments = Array(argv.dropFirst())
+    if let wd = workdir { task.currentDirectoryURL = URL(fileURLWithPath: wd) }
+    var fullEnv = ProcessInfo.processInfo.environment
+    for (k, v) in env { fullEnv[k] = v }
+    task.environment = fullEnv
+
+    let outPipe = Pipe()
+    let errPipe = Pipe()
+    task.standardOutput = outPipe
+    task.standardError = errPipe
+    task.standardInput = FileHandle.nullDevice
+
+    let started = Date()
+    do {
+        try task.run()
+    } catch {
+        return ["success": false, "error": "exec: spawn failed: \(error.localizedDescription)"]
+    }
+    task.waitUntilExit()
+    let durationMs = Int(Date().timeIntervalSince(started) * 1000)
+
+    let stdoutData = outPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+    let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+    let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+
+    return [
+        "success": true,
+        "data": [
+            "exitCode": task.terminationStatus,
+            "stdout": stdout,
+            "stderr": stderr,
+            "durationMs": durationMs
+        ] as [String: Any]
+    ]
+}
+
+func handleGetIP() -> [String: Any] {
+#if os(macOS)
+    // ifconfig en0 → grep inet
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/sbin/ifconfig")
+    task.arguments = ["en0"]
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    do { try task.run() } catch {
+        return ["success": false, "error": "get_ip: ifconfig failed: \(error.localizedDescription)"]
+    }
+    task.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let text = String(data: data, encoding: .utf8) ?? ""
+    for line in text.split(separator: "\n") {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("inet ") && !trimmed.contains("127.0.0.1") {
+            let parts = trimmed.split(separator: " ")
+            if parts.count >= 2 {
+                return ["success": true, "data": ["ipAddress": String(parts[1])]]
+            }
+        }
+    }
+    return ["success": true, "data": ["ipAddress": NSNull()]]
+#else
+    // Linux: parse /proc/net/route or `ip -j addr`. Keep it dependency-free.
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    task.arguments = ["sh", "-c", "ip -j addr 2>/dev/null || ifconfig"]
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    do { try task.run() } catch {
+        return ["success": false, "error": "get_ip: ip failed: \(error.localizedDescription)"]
+    }
+    task.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let text = String(data: data, encoding: .utf8) ?? ""
+    // Best-effort regex for the first non-loopback IPv4.
+    if let range = text.range(of: #"\b(?!127\.0\.0\.1)\d+\.\d+\.\d+\.\d+\b"#, options: .regularExpression) {
+        return ["success": true, "data": ["ipAddress": String(text[range])]]
+    }
+    return ["success": true, "data": ["ipAddress": NSNull()]]
+#endif
+}
+
+#if os(macOS)
+import ScreenCaptureKit
+
+// macOS 15 deprecated CGDisplayCreateImage. ScreenCaptureKit is the
+// supported path: SCShareableContent.current.displays → SCContentFilter
+// for the display → SCScreenshotManager.captureImage(contentFilter:configuration:).
+// We use a sync wrapper around the async ScreenCaptureKit API.
+@available(macOS 14.0, *)
+func sckCaptureMainDisplay() async throws -> CGImage {
+    let content = try await SCShareableContent.current
+    guard let display = content.displays.first else {
+        throw NSError(domain: "InterceptorD", code: 1, userInfo: [NSLocalizedDescriptionKey: "no displays available"])
+    }
+    let filter = SCContentFilter(display: display, excludingWindows: [])
+    let config = SCStreamConfiguration()
+    config.width = display.width
+    config.height = display.height
+    config.showsCursor = true
+    return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+}
+
+// Sendable holder. We serialize all access through a dedicated dispatch
+// queue rather than NSLock because Swift 6 disallows NSLock.lock() from
+// async contexts.
+final class ImageBox: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "interceptord.imagebox")
+    private var _image: CGImage?
+    private var _error: String?
+    func set(image: CGImage?, error: String?) {
+        queue.sync { self._image = image; self._error = error }
+    }
+    func snapshot() -> (CGImage?, String?) {
+        queue.sync { (self._image, self._error) }
+    }
+}
+
+func handleScreenshot(_ action: [String: Any]) -> [String: Any] {
+    let box = ImageBox()
+    let sem = DispatchSemaphore(value: 0)
+    if #available(macOS 14.0, *) {
+        Task.detached {
+            do {
+                let img = try await sckCaptureMainDisplay()
+                box.set(image: img, error: nil)
+            } catch {
+                box.set(image: nil, error: error.localizedDescription)
+            }
+            sem.signal()
+        }
+        _ = sem.wait(timeout: .now() + 10.0)
+    } else {
+        box.set(image: nil, error: "macOS < 14.0 unsupported")
+    }
+    let (cgImageOpt, errMsg) = box.snapshot()
+    guard let cgImage = cgImageOpt else {
+        return ["success": false, "error": "screenshot: ScreenCaptureKit: \(errMsg ?? "no image returned")"]
+    }
+    let out = (action["out"] as? String) ?? "/tmp/interceptord-screenshot.png"
+    let url = URL(fileURLWithPath: out)
+    let rep = NSBitmapImageRep(cgImage: cgImage)
+    guard let png = rep.representation(using: .png, properties: [:]) else {
+        return ["success": false, "error": "screenshot: PNG encode failed"]
+    }
+    do { try png.write(to: url) } catch {
+        return ["success": false, "error": "screenshot: write \(out): \(error.localizedDescription)"]
+    }
+    return ["success": true, "data": ["path": out, "width": cgImage.width, "height": cgImage.height, "bytes": png.count]]
+}
+
+func handleType(_ action: [String: Any]) -> [String: Any] {
+    guard let text = action["text"] as? String else {
+        return ["success": false, "error": "type: missing 'text'"]
+    }
+    let source = CGEventSource(stateID: .hidSystemState)
+    for char in text.unicodeScalars {
+        // Use the unicode-string path so we don't need to map every key.
+        let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
+        let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+        var u = UniChar(char.value)
+        down?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &u)
+        up?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &u)
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
+        usleep(10_000)
+    }
+    return ["success": true, "data": ["typed": text.count]]
+}
+
+func handleClick(_ action: [String: Any]) -> [String: Any] {
+    let x = (action["x"] as? Double) ?? Double((action["x"] as? Int) ?? 0)
+    let y = (action["y"] as? Double) ?? Double((action["y"] as? Int) ?? 0)
+    let button = (action["button"] as? String) ?? "left"
+    let source = CGEventSource(stateID: .hidSystemState)
+    let mb: CGMouseButton
+    let down: CGEventType
+    let up: CGEventType
+    switch button {
+    case "right": mb = .right; down = .rightMouseDown; up = .rightMouseUp
+    case "middle": mb = .center; down = .otherMouseDown; up = .otherMouseUp
+    default: mb = .left; down = .leftMouseDown; up = .leftMouseUp
+    }
+    let pt = CGPoint(x: x, y: y)
+    CGEvent(mouseEventSource: source, mouseType: down, mouseCursorPosition: pt, mouseButton: mb)?.post(tap: .cghidEventTap)
+    CGEvent(mouseEventSource: source, mouseType: up, mouseCursorPosition: pt, mouseButton: mb)?.post(tap: .cghidEventTap)
+    return ["success": true, "data": ["x": x, "y": y, "button": button]]
+}
+
+func handleKeys(_ action: [String: Any]) -> [String: Any] {
+    guard let chord = action["keys"] as? String else {
+        return ["success": false, "error": "keys: missing 'keys'"]
+    }
+    // Minimal mapping: just handle the chord as a literal sequence via type.
+    // Full chord mapping (cmd+shift+x) is v2; for v0 the host can use osascript fallback.
+    return handleType(["text": chord])
+}
+
+func handleReadAX(_ action: [String: Any]) -> [String: Any] {
+    let depth = (action["max_depth"] as? Int) ?? 4
+    let maxNodes = (action["max_nodes"] as? Int) ?? 500
+    let systemElement = AXUIElementCreateSystemWide()
+    var visited = 0
+    let tree = axNode(systemElement, depth: 0, maxDepth: depth, maxNodes: maxNodes, visited: &visited)
+    return ["success": true, "data": ["tree": tree, "visited": visited, "maxDepth": depth]]
+}
+
+func axString(_ el: AXUIElement, _ attr: CFString) -> String? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(el, attr, &value)
+    guard result == .success, let value else { return nil }
+    if let s = value as? String { return s }
+    if CFGetTypeID(value) == AXUIElementGetTypeID() { return nil }
+    let described = String(describing: value)
+    return described.isEmpty ? nil : described
+}
+
+func axPoint(_ value: CFTypeRef?) -> CGPoint? {
+    guard let value, CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+    var point = CGPoint.zero
+    if AXValueGetValue((value as! AXValue), .cgPoint, &point) { return point }
+    return nil
+}
+
+func axSize(_ value: CFTypeRef?) -> CGSize? {
+    guard let value, CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+    var size = CGSize.zero
+    if AXValueGetValue((value as! AXValue), .cgSize, &size) { return size }
+    return nil
+}
+
+func axFrame(_ el: AXUIElement) -> [String: Any]? {
+    var posRef: CFTypeRef?
+    var sizeRef: CFTypeRef?
+    AXUIElementCopyAttributeValue(el, kAXPositionAttribute as CFString, &posRef)
+    AXUIElementCopyAttributeValue(el, kAXSizeAttribute as CFString, &sizeRef)
+    guard let point = axPoint(posRef), let size = axSize(sizeRef) else { return nil }
+    return [
+        "x": point.x,
+        "y": point.y,
+        "width": size.width,
+        "height": size.height,
+    ]
+}
+
+func axNode(_ el: AXUIElement, depth: Int, maxDepth: Int, maxNodes: Int, visited: inout Int) -> [String: Any] {
+    visited += 1
+    var node: [String: Any] = [
+        "ref": "ax\(visited)",
+        "role": axString(el, kAXRoleAttribute as CFString) ?? (depth == 0 ? "AXSystem" : "?"),
+    ]
+    if let title = axString(el, kAXTitleAttribute as CFString), !title.isEmpty { node["title"] = title }
+    if let value = axString(el, kAXValueAttribute as CFString), !value.isEmpty { node["value"] = value }
+    if let desc = axString(el, kAXDescriptionAttribute as CFString), !desc.isEmpty { node["description"] = desc }
+    if let frame = axFrame(el) { node["frame"] = frame }
+
+    guard depth < maxDepth, visited < maxNodes else { return node }
+    var childrenRef: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(el, kAXChildrenAttribute as CFString, &childrenRef)
+    if result == .success, let children = childrenRef as? [AXUIElement], !children.isEmpty {
+        var childNodes: [[String: Any]] = []
+        for child in children.prefix(50) {
+            if visited >= maxNodes { break }
+            childNodes.append(axNode(child, depth: depth + 1, maxDepth: maxDepth, maxNodes: maxNodes, visited: &visited))
+        }
+        node["children"] = childNodes
+    }
+    return node
+}
+#else
+// Linux stubs — defer the rich verbs to the Linux variant (CL31 / v2).
+func handleScreenshot(_ action: [String: Any]) -> [String: Any] {
+    return ["success": false, "error": "screenshot: linux variant requires grim/scrot — implement in v2"]
+}
+func handleType(_ action: [String: Any]) -> [String: Any] {
+    return ["success": false, "error": "type: linux variant requires xdotool/wtype — implement in v2"]
+}
+func handleClick(_ action: [String: Any]) -> [String: Any] {
+    return ["success": false, "error": "click: linux variant — v2"]
+}
+func handleKeys(_ action: [String: Any]) -> [String: Any] {
+    return ["success": false, "error": "keys: linux variant — v2"]
+}
+func handleReadAX(_ action: [String: Any]) -> [String: Any] {
+    return ["success": false, "error": "read_ax: linux AT-SPI variant — v2"]
+}
+#endif
+
+func handleMount(_ action: [String: Any]) -> [String: Any] {
+    guard let tag = action["tag"] as? String, let path = action["path"] as? String else {
+        return ["success": false, "error": "mount: missing 'tag' or 'path'"]
+    }
+    // mkdir -p the mount point then mount.
+    let mkdir = Process()
+    mkdir.executableURL = URL(fileURLWithPath: "/bin/mkdir")
+    mkdir.arguments = ["-p", path]
+    try? mkdir.run(); mkdir.waitUntilExit()
+
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/sbin/mount")
+    task.arguments = ["-t", "virtiofs", tag, path]
+    let errPipe = Pipe()
+    task.standardError = errPipe
+    do { try task.run() } catch {
+        return ["success": false, "error": "mount: \(error.localizedDescription)"]
+    }
+    task.waitUntilExit()
+    if task.terminationStatus != 0 {
+        let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ["success": false, "error": "mount failed: \(err)"]
+    }
+    return ["success": true, "data": ["tag": tag, "path": path]]
+}
+
+func handleCopyIn(_ action: [String: Any]) -> [String: Any] {
+    guard let path = action["path"] as? String, let b64 = action["dataBase64"] as? String else {
+        return ["success": false, "error": "cp_in: missing 'path' or 'dataBase64'"]
+    }
+    guard let data = Data(base64Encoded: b64) else {
+        return ["success": false, "error": "cp_in: dataBase64 is invalid"]
+    }
+    let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+    do {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+        if let mode = action["mode"] as? String, let modeInt = Int(mode, radix: 8) {
+            chmod(url.path, mode_t(modeInt))
+        }
+        return ["success": true, "data": ["path": url.path, "bytes": data.count]]
+    } catch {
+        return ["success": false, "error": "cp_in: \(error.localizedDescription)"]
+    }
+}
+
+func handleCopyOut(_ action: [String: Any]) -> [String: Any] {
+    guard let path = action["path"] as? String else {
+        return ["success": false, "error": "cp_out: missing 'path'"]
+    }
+    let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+    do {
+        let data = try Data(contentsOf: url)
+        return [
+            "success": true,
+            "data": [
+                "path": url.path,
+                "bytes": data.count,
+                "dataBase64": data.base64EncodedString(),
+            ],
+        ]
+    } catch {
+        return ["success": false, "error": "cp_out: \(error.localizedDescription)"]
+    }
+}
+
+func handleLogs(_ action: [String: Any]) -> [String: Any] {
+    let limit = (action["limit"] as? Int) ?? 200
+    let paths = ["/tmp/InterceptorD.err.log", "/tmp/InterceptorD.out.log"]
+    var entries: [[String: Any]] = []
+    for path in paths {
+        guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        let tail = lines.suffix(limit).map(String.init)
+        entries.append(["path": path, "lines": tail])
+    }
+    return ["success": true, "data": ["logs": entries]]
+}
+
+func handleTrust(_ action: [String: Any]) -> [String: Any] {
+#if os(macOS)
+    let accessibility = AXIsProcessTrusted()
+    let screenRecording = CGPreflightScreenCaptureAccess()
+    return [
+        "success": true,
+        "data": [
+            "platform": "macos",
+            "accessibility": accessibility ? "granted" : "denied",
+            "screenRecording": screenRecording ? "granted" : "denied",
+            "postEvent": "unknown",
+            "inputMonitoring": "unknown",
+            "notes": [
+                "Accessibility and Screen Recording expose only boolean preflight state through public APIs here.",
+                "PostEvent/Input Monitoring should be validated by attempting the requested verb and checking failure diagnostics.",
+            ],
+        ],
+    ]
+#else
+    return [
+        "success": true,
+        "data": [
+            "platform": "linux",
+            "accessibility": "not_applicable",
+            "screenRecording": "not_applicable",
+        ],
+    ]
+#endif
+}
+
+func isMutatingVerb(_ verb: String) -> Bool {
+    switch verb {
+    case "ping", "get_ip", "trust", "read_ax", "screenshot", "logs":
+        return false
+    default:
+        return true
+    }
+}
+
+// MARK: - Request dispatcher
+
+func dispatch(request: [String: Any]) -> [String: Any] {
+    let id = (request["id"] as? String) ?? UUID().uuidString
+    guard let action = request["action"] as? [String: Any] else {
+        return errorResult(id, "missing action")
+    }
+    guard let verb = action["verb"] as? String else {
+        return errorResult(id, "missing action.verb")
+    }
+    if let requiredAuthToken, isMutatingVerb(verb) {
+        guard action["authToken"] as? String == requiredAuthToken else {
+            return errorResult(id, "auth: invalid or missing authToken")
+        }
+    }
+    let result: [String: Any]
+    switch verb {
+    case "exec":       result = handleExec(action)
+    case "get_ip":     result = handleGetIP()
+    case "screenshot": result = handleScreenshot(action)
+    case "type":       result = handleType(action)
+    case "click":      result = handleClick(action)
+    case "keys":       result = handleKeys(action)
+    case "read_ax":    result = handleReadAX(action)
+    case "mount":      result = handleMount(action)
+    case "cp_in":      result = handleCopyIn(action)
+    case "cp_out":     result = handleCopyOut(action)
+    case "trust":      result = handleTrust(action)
+    case "logs":       result = handleLogs(action)
+    case "ping":       result = ["success": true, "data": ["pong": true]]
+    default:           result = ["success": false, "error": "unknown verb: \(verb)"]
+    }
+    return ["id": id, "result": result]
+}
+
+// MARK: - Loopback server (works on both Linux & macOS guests)
+//
+// In the macOS guest variant we bind on 127.0.0.1:<port> and rely on
+// VZVirtioSocketDevice's port-mapping inside VZ to route the host
+// connection. On Linux a real AF_VSOCK socket is available via the
+// kernel virtio_vsock driver; we open AF_VSOCK in that case.
+
+func serve() {
+#if os(Linux)
+    let AF_VSOCK_C: Int32 = 40  // Linux AF_VSOCK
+    let VMADDR_CID_ANY: UInt32 = 0xFFFFFFFF
+    let server = socket(AF_VSOCK_C, Int32(SOCK_STREAM.rawValue), 0)
+    if server < 0 {
+        fputs("InterceptorD: AF_VSOCK socket() failed\n", stderr)
+        exit(1)
+    }
+    // sockaddr_vm layout: u16 family, u16 reserved, u32 port, u32 cid, ...
+    var addr = sockaddr_vm()
+    addr.svm_family = sa_family_t(AF_VSOCK_C)
+    addr.svm_port = kAgentPort
+    addr.svm_cid = VMADDR_CID_ANY
+    let sz = socklen_t(MemoryLayout<sockaddr_vm>.size)
+    let bindRes = withUnsafePointer(to: &addr) { ptr -> Int32 in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+            Darwin.bind(server, sptr, sz)
+        }
+    }
+    if bindRes != 0 {
+        fputs("InterceptorD: bind() failed: \(String(cString: strerror(errno)))\n", stderr)
+        exit(1)
+    }
+    Darwin.listen(server, 5)
+    while true {
+        let client = Darwin.accept(server, nil, nil)
+        if client < 0 { continue }
+        Thread.detachNewThread { handleClient(fd: client) }
+    }
+#else
+    // macOS guest path — bind on all guest interfaces. Virtualization's
+    // macOS guest socket path is not reliable for every host/guest pairing,
+    // so the host bridge can fall back to the guest's NAT IP.
+    let server = socket(AF_INET, SOCK_STREAM, 0)
+    if server < 0 {
+        fputs("InterceptorD: socket() failed\n", stderr)
+        exit(1)
+    }
+    var yes: Int32 = 1
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = UInt16(kAgentPort).bigEndian
+    addr.sin_addr.s_addr = INADDR_ANY
+    let sz = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let bindRes = withUnsafePointer(to: &addr) { ptr -> Int32 in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+            Darwin.bind(server, sptr, sz)
+        }
+    }
+    if bindRes != 0 {
+        fputs("InterceptorD: bind() failed: \(String(cString: strerror(errno)))\n", stderr)
+        exit(1)
+    }
+    Darwin.listen(server, 5)
+    while true {
+        let client = Darwin.accept(server, nil, nil)
+        if client < 0 { continue }
+        Thread.detachNewThread { handleClient(fd: client) }
+    }
+#endif
+}
+
+func handleClient(fd: Int32) {
+    defer { Darwin.close(fd) }
+    var buffer = Data()
+    var buf = [UInt8](repeating: 0, count: 64 * 1024)
+    while true {
+        let n = buf.withUnsafeMutableBufferPointer { Darwin.read(fd, $0.baseAddress, $0.count) }
+        if n <= 0 { return }
+        buffer.append(buf, count: n)
+        while buffer.count >= 4 {
+            let length: UInt32 = buffer.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            if length == 0 || length > 50_000_000 { buffer.removeAll(); break }
+            let total = 4 + Int(length)
+            if buffer.count < total { break }
+            let payload = buffer.subdata(in: 4..<total)
+            buffer.removeSubrange(0..<total)
+            guard let req = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] else {
+                continue
+            }
+            let response = dispatch(request: req)
+            writeFrame(fd: fd, response)
+        }
+    }
+}
+
+// MARK: - Entry point
+
+fputs("InterceptorD starting on port \(kAgentPort)\n", stderr)
+serve()

--- a/interceptor-bridge/Package.resolved
+++ b/interceptor-bridge/Package.resolved
@@ -1,6 +1,51 @@
 {
-  "originHash" : "a667b0587d8c64845394c3a65bd68279d4dc8ae1237ac8d4dc475ab6dd858eb3",
+  "originHash" : "617cf556d32abac73e275ad6b7b87946d159cb0dd4a801877641e141a9b6de48",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "containerization",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/containerization.git",
+      "state" : {
+        "revision" : "f1ee6f8b737ab8dffbd620bfa47283f6f0bc1822",
+        "version" : "0.31.0"
+      }
+    },
+    {
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "21fe69ab7ce0e87ac089534733c52f037e74a3eb",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "f62a09000685b5b86ee383b63e042f286b1a5422",
+        "version" : "2.7.0"
+      }
+    },
+    {
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "8723cf856dc23d9c2fad4d874e7b9ed3254acf03",
+        "version" : "2.3.0"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
@@ -8,6 +53,222 @@
       "state" : {
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
       }
     }
   ],

--- a/interceptor-bridge/Package.swift
+++ b/interceptor-bridge/Package.swift
@@ -1,25 +1,50 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
+// VM management dependency layer. The Containerization Swift
+// package (apple/containerization, exact 0.31.0) provides the in-process
+// LinuxContainer + VZVirtualMachineManager primitives that VmDomain uses
+// for Linux guests. Pinned to the same exact version Apple's `container`
+// project uses (research/container/Package.swift:26), so we tail their
+// validated build. macOS-on-macOS guests use raw Virtualization.framework
+// (VZMacOSInstaller etc.) and do not need this package — but we link it
+// once regardless because the VmDomain handler dispatches both kinds.
+//
+// platform bumped from .v14 to .v15 because Containerization itself
+// requires macOS 15 (research/container/Package.swift:30).
 let package = Package(
     name: "interceptor-bridge",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS(.v15)],
     dependencies: [
         // Sparkle for in-app auto-update. The bridge polls the appcast,
         // prompts the user when a new pkg is available, and hands the
         // download off to the macOS installer.
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+        // : Containerization (Linux guest runtime). Pinned exact
+        // to the version Apple's container project uses.
+        .package(url: "https://github.com/apple/containerization.git", exact: Version(stringLiteral: "0.31.0")),
     ],
     targets: [
         .executableTarget(
             name: "interceptor-bridge",
             dependencies: [
                 .product(name: "Sparkle", package: "Sparkle"),
+                // : Containerization product imports. LinuxContainer
+                // + VZVirtualMachineManager + BootLog + Hosts + ContainerConfiguration
+                // live in `Containerization`. OCI image pull lives in
+                // `ContainerizationOCI`. Misc helpers in `ContainerizationOS` +
+                // `ContainerizationExtras`.
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationOCI", package: "containerization"),
+                .product(name: "ContainerizationOS", package: "containerization"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
             ],
             path: "Sources",
             // helper subprocess lives in Sources/InterceptorVDHelper —
             // exclude from the main bridge target since it has its own
             // entry point and a separate clean-process design (Lumen pattern).
+            // InterceptorD () is the in-guest agent — separate
+            // target, also excluded here.
             // No SwiftPM resource bundling — see scripts/build-bridge.sh, which
             // copies model resources directly into the .app's Contents/Resources/.
             // SwiftPM-generated resource bundles (TargetName_TargetName.bundle)
@@ -44,7 +69,7 @@ let package = Package(
                 .linkedFramework("SpriteKit"),
                 // Apple Events / TCC consent (AEDeterminePermissionToAutomateTarget)
                 .linkedFramework("Carbon"),
-                // PRD-66 — personal data and distribution surfaces.
+                // personal data and distribution surfaces.
                 // PDFKit: PdfDomain (PDFDocument/PDFPage/PDFAnnotation/PDFOutline/PDFSelection).
                 .linkedFramework("PDFKit"),
                 // QuickLookThumbnailing: ThumbnailDomain (QLThumbnailGenerator).
@@ -73,6 +98,14 @@ let package = Package(
                 // the modern Swift surface (DDMatch* macOS 12+, DataDetector macOS 26+) lives
                 // in the DataDetection module which is auto-imported on macOS 12+.
                 .linkedFramework("DataDetection"),
+                // : Virtualization.framework for VZVirtualMachine,
+                // VZMacOSInstaller, VZMacPlatformConfiguration, vsock, and
+                // every other VZ symbol VmDomain uses.
+                .linkedFramework("Virtualization"),
+                // : vmnet.framework for VZVmnetNetworkDeviceAttachment
+                // and custom-topology network surfaces. Requires the
+                // com.apple.vm.networking entitlement (scripts/entitlements.plist).
+                .linkedFramework("vmnet"),
                 // .app bundle layout: Contents/MacOS/<bin> needs to find
                 // Contents/Frameworks/Sparkle.framework at runtime.
                 .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks"]),
@@ -89,6 +122,23 @@ let package = Package(
                 .linkedFramework("Foundation"),
                 .linkedFramework("AppKit"),
                 .linkedFramework("CoreGraphics"),
+            ]
+        ),
+        // CL32: InterceptorD is the in-guest agent binary.
+        // Same vsock JSON-RPC framing as the host bridge. Linked into
+        // Containerization's vminit image for Linux guests, packaged as a
+        // signed .pkg for macOS gold images. Intentionally minimal deps —
+        // no Sparkle, no AppKit on the Linux build path.
+        .executableTarget(
+            name: "InterceptorD",
+            path: "InterceptorD",
+            linkerSettings: [
+                .linkedFramework("Foundation"),
+                .linkedFramework("Virtualization", .when(platforms: [.macOS])),
+                .linkedFramework("AppKit", .when(platforms: [.macOS])),
+                .linkedFramework("ApplicationServices", .when(platforms: [.macOS])),
+                .linkedFramework("CoreGraphics", .when(platforms: [.macOS])),
+                .linkedFramework("ScreenCaptureKit", .when(platforms: [.macOS])),
             ]
         ),
         .testTarget(

--- a/interceptor-bridge/Sources/Domains/TccDomain.swift
+++ b/interceptor-bridge/Sources/Domains/TccDomain.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+enum TccGrantStatus: String, Sendable {
+    case grantable
+    case userOnly = "user_only"
+    case unsupported
+}
+
+struct TccServiceRule: Sendable {
+    let service: String
+    let status: TccGrantStatus
+    let defaultEnabled: Bool
+    let note: String
+}
+
+struct TccProfileGenerator: Sendable {
+    static let rules: [TccServiceRule] = [
+        TccServiceRule(service: "Accessibility", status: .grantable, defaultEnabled: true, note: "AX tree reads and AX actions; profile grant is deprecated by Apple as of macOS 26.2 and scheduled for removal in macOS 27.0."),
+        TccServiceRule(service: "PostEvent", status: .grantable, defaultEnabled: true, note: "CoreGraphics event posting."),
+        TccServiceRule(service: "AppleEvents", status: .grantable, defaultEnabled: false, note: "Grantable only for explicit sender/receiver pairs; receiver metadata is required for a valid production payload."),
+        TccServiceRule(service: "SystemPolicyAllFiles", status: .grantable, defaultEnabled: false, note: "Full Disk Access. Generate only in high-trust mode."),
+        TccServiceRule(service: "SystemPolicyAppBundles", status: .grantable, defaultEnabled: false, note: "Allows supported installer/updater workflows to modify app bundles."),
+        TccServiceRule(service: "SystemPolicyDesktopFolder", status: .grantable, defaultEnabled: false, note: "Desktop folder access."),
+        TccServiceRule(service: "SystemPolicyDocumentsFolder", status: .grantable, defaultEnabled: false, note: "Documents folder access."),
+        TccServiceRule(service: "SystemPolicyDownloadsFolder", status: .grantable, defaultEnabled: false, note: "Downloads folder access."),
+        TccServiceRule(service: "SystemPolicyRemovableVolumes", status: .grantable, defaultEnabled: false, note: "Removable volume access."),
+        TccServiceRule(service: "SystemPolicyNetworkVolumes", status: .grantable, defaultEnabled: false, note: "Network volume access."),
+        TccServiceRule(service: "ScreenCapture", status: .userOnly, defaultEnabled: false, note: "Apple DeviceManagement docs say this service cannot be granted by profile; it can only be denied."),
+        TccServiceRule(service: "ListenEvent", status: .userOnly, defaultEnabled: false, note: "Apple DeviceManagement docs say this service cannot be granted by profile; it can only be denied."),
+        TccServiceRule(service: "Camera", status: .userOnly, defaultEnabled: false, note: "Apple DeviceManagement docs say camera access cannot be granted by profile; it can only be denied."),
+        TccServiceRule(service: "Microphone", status: .userOnly, defaultEnabled: false, note: "Apple DeviceManagement docs say microphone access cannot be granted by profile; it can only be denied."),
+    ]
+
+    static func rule(for service: String) -> TccServiceRule? {
+        rules.first { $0.service.caseInsensitiveCompare(service) == .orderedSame }
+    }
+
+    static func defaultServices(fullDisk: Bool) -> [String] {
+        var services = rules
+            .filter { $0.defaultEnabled && $0.status == .grantable }
+            .map(\.service)
+        if fullDisk {
+            services.append("SystemPolicyAllFiles")
+        }
+        return services
+    }
+
+    static func serviceMatrix() -> [[String: Any]] {
+        rules.map {
+            [
+                "service": $0.service,
+                "profileGrantStatus": $0.status.rawValue,
+                "defaultEnabled": $0.defaultEnabled,
+                "note": $0.note,
+            ]
+        }
+    }
+
+    static func generateProfile(
+        target: String,
+        bundleId: String,
+        appPath: String?,
+        identifierType: String,
+        codeRequirement: String,
+        requestedServices: [String],
+        includeUserOnly: Bool
+    ) throws -> (xml: String, included: [[String: Any]], skipped: [[String: Any]]) {
+        var included: [[String: Any]] = []
+        var skipped: [[String: Any]] = []
+        var servicesDict: [String: Any] = [:]
+
+        for rawService in requestedServices {
+            guard let rule = rule(for: rawService) else {
+                skipped.append(["service": rawService, "reason": "unknown_service"])
+                continue
+            }
+            guard rule.status == .grantable else {
+                skipped.append([
+                    "service": rule.service,
+                    "reason": "not_profile_grantable",
+                    "note": rule.note,
+                ])
+                continue
+            }
+
+            if rule.service == "AppleEvents" {
+                skipped.append([
+                    "service": rule.service,
+                    "reason": "receiver_required",
+                    "note": rule.note,
+                ])
+                continue
+            }
+
+            let identity = identityPayload(
+                service: rule.service,
+                bundleId: bundleId,
+                appPath: appPath,
+                identifierType: identifierType,
+                codeRequirement: codeRequirement
+            )
+            servicesDict[rule.service] = [identity]
+            included.append([
+                "service": rule.service,
+                "profileGrantStatus": rule.status.rawValue,
+                "note": rule.note,
+            ])
+        }
+
+        if includeUserOnly {
+            for rule in rules where rule.status == .userOnly {
+                if !skipped.contains(where: { ($0["service"] as? String) == rule.service }) {
+                    skipped.append([
+                        "service": rule.service,
+                        "reason": "not_profile_grantable",
+                        "note": rule.note,
+                    ])
+                }
+            }
+        }
+
+        let payloadIdBase = "com.interceptor.tcc.\(target)"
+        let tccPayload: [String: Any] = [
+            "PayloadType": "com.apple.TCC.configuration-profile-policy",
+            "PayloadVersion": 1,
+            "PayloadIdentifier": "\(payloadIdBase).pppc",
+            "PayloadUUID": UUID().uuidString,
+            "PayloadDisplayName": "Interceptor Privacy Preferences Policy Control",
+            "Services": servicesDict,
+        ]
+
+        let profile: [String: Any] = [
+            "PayloadType": "Configuration",
+            "PayloadVersion": 1,
+            "PayloadIdentifier": payloadIdBase,
+            "PayloadUUID": UUID().uuidString,
+            "PayloadDisplayName": target == "guest" ? "InterceptorD Guest TCC" : "Interceptor Host TCC",
+            "PayloadContent": [tccPayload],
+        ]
+
+        let data = try PropertyListSerialization.data(fromPropertyList: profile, format: .xml, options: 0)
+        guard let xml = String(data: data, encoding: .utf8) else {
+            throw TccDomainError.profileEncodingFailed
+        }
+        return (xml, included, skipped)
+    }
+
+    private static func identityPayload(
+        service: String,
+        bundleId: String,
+        appPath: String?,
+        identifierType: String,
+        codeRequirement: String
+    ) -> [String: Any] {
+        let identifier = identifierType == "path" ? (appPath ?? bundleId) : bundleId
+        return [
+            "Allowed": true,
+            "CodeRequirement": codeRequirement,
+            "Comment": "Allow \(service) for Interceptor",
+            "Identifier": identifier,
+            "IdentifierType": identifierType,
+        ]
+    }
+}
+
+enum TccDomainError: Error, CustomStringConvertible {
+    case profileEncodingFailed
+
+    var description: String {
+        switch self {
+        case .profileEncodingFailed:
+            return "tcc.profileEncodingFailed"
+        }
+    }
+}
+
+final class TccDomain: DomainHandler, @unchecked Sendable {
+    func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let sub = action["sub"] as? String ?? command
+        switch sub {
+        case "status":
+            completion(WireFormat.success(statusPayload(target: (action["target"] as? String) ?? "host")))
+        case "profile_generate":
+            generateProfile(action: action, completion: completion)
+        default:
+            completion(WireFormat.error("tcc: unknown verb '\(sub)'"))
+        }
+    }
+
+    private func statusPayload(target: String) -> [String: Any] {
+        let enrollment = mdmEnrollmentStatus()
+        return [
+            "target": target,
+            "bundleId": defaultBundleId(),
+            "bundlePath": Bundle.main.bundlePath,
+            "mdm": enrollment,
+            "silentProfileDeploymentAvailable": (enrollment["userApprovedMdm"] as? Bool ?? false) || (enrollment["automatedDeviceEnrollment"] as? Bool ?? false),
+            "serviceMatrix": TccProfileGenerator.serviceMatrix(),
+        ]
+    }
+
+    private func generateProfile(action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let target = (action["target"] as? String) ?? "host"
+        let fullDisk = action["fullDisk"] as? Bool ?? false
+        let includeUserOnly = action["includeUserOnly"] as? Bool ?? false
+        let bundleId = (action["bundleId"] as? String) ?? defaultBundleId()
+        let appPath = action["appPath"] as? String ?? Bundle.main.bundlePath
+        let identifierType = (action["identifierType"] as? String) ?? "bundleID"
+        let requestedServices = (action["services"] as? [String]).flatMap { $0.isEmpty ? nil : $0 }
+            ?? TccProfileGenerator.defaultServices(fullDisk: fullDisk)
+        let codeRequirement = (action["codeRequirement"] as? String)
+            ?? designatedRequirement(for: appPath)
+            ?? "identifier \(bundleId)"
+
+        do {
+            let generated = try TccProfileGenerator.generateProfile(
+                target: target,
+                bundleId: bundleId,
+                appPath: appPath,
+                identifierType: identifierType,
+                codeRequirement: codeRequirement,
+                requestedServices: requestedServices,
+                includeUserOnly: includeUserOnly
+            )
+
+            var result: [String: Any] = [
+                "target": target,
+                "bundleId": bundleId,
+                "appPath": appPath,
+                "identifierType": identifierType,
+                "codeRequirement": codeRequirement,
+                "included": generated.included,
+                "skipped": generated.skipped,
+                "requiresUserApprovedMdm": true,
+                "mdm": mdmEnrollmentStatus(),
+            ]
+
+            if let out = action["out"] as? String, !out.isEmpty {
+                let url = URL(fileURLWithPath: (out as NSString).expandingTildeInPath)
+                try generated.xml.write(to: url, atomically: true, encoding: .utf8)
+                result["path"] = url.path
+            } else {
+                result["profile"] = generated.xml
+            }
+
+            completion(WireFormat.success(result))
+        } catch {
+            completion(WireFormat.error("tcc profile generate: \(error)"))
+        }
+    }
+
+    private func defaultBundleId() -> String {
+        Bundle.main.bundleIdentifier ?? "com.interceptor.bridge"
+    }
+
+    private func designatedRequirement(for path: String?) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        let output = runProcess("/usr/bin/codesign", args: ["-dr", "-", path])
+        let text = [output.stdout, output.stderr].joined(separator: "\n")
+        guard let markerRange = text.range(of: "designated =>") else {
+            return nil
+        }
+        let req = text[markerRange.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return req.isEmpty ? nil : req
+    }
+
+    private func mdmEnrollmentStatus() -> [String: Any] {
+        let output = runProcess("/usr/bin/profiles", args: ["status", "-type", "enrollment"])
+        let combined = [output.stdout, output.stderr].joined(separator: "\n")
+        let lower = combined.lowercased()
+        return [
+            "checked": true,
+            "command": "/usr/bin/profiles status -type enrollment",
+            "exitCode": output.exitCode,
+            "enrolled": lower.contains("mdm enrollment: yes") || lower.contains("enrolled via dep: yes"),
+            "userApprovedMdm": lower.contains("user approved: yes"),
+            "automatedDeviceEnrollment": lower.contains("enrolled via dep: yes") || lower.contains("enrolled via ade: yes"),
+            "raw": combined.trimmingCharacters(in: .whitespacesAndNewlines),
+        ]
+    }
+
+    private func runProcess(_ executable: String, args: [String]) -> (exitCode: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return (-1, "", error.localizedDescription)
+        }
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdout, stderr)
+    }
+}

--- a/interceptor-bridge/Sources/Domains/VmDomain.swift
+++ b/interceptor-bridge/Sources/Domains/VmDomain.swift
@@ -1,0 +1,761 @@
+// VmDomain
+//
+// Domain handler for every `macos_vm_<verb>` action. Follows the dispatch
+// invariant from `ARCHITECTURE.md:234-238` — read `action["sub"] ?? command`
+// and switch on `sub`. The Router (`Router.swift:43-55`) splits
+// `macos_vm_create` into `(domainKey="vm", command="create")`; if a CLI
+// parser sets `action["sub"]` it overrides.
+//
+// Verb coverage (design notes):
+//   v0: create, list, get, inspect, start, stop, pause, resume, delete,
+//       exec, clone, pull, reset
+//   v1: install
+//   v2: snapshot, restore, share, mount, port-forward, screenshot, type,
+//       click, keys, read-ax, console, logs, cp
+//
+// Each verb returns either `WireFormat.success(payload)` or
+// `WireFormat.error(message)`. Errors include a `setup_required` envelope
+// per Spec 9 when the recovery is well-known (no
+// com.apple.security.virtualization entitlement, macOS < 15, etc.).
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+// Sendable wrapper around `[String: Any]` so we can hand the action across
+// Task boundaries without strict-concurrency violations. Same pattern as
+// Transport.swift:234.
+struct VmActionBox: @unchecked Sendable {
+    let action: [String: Any]
+}
+
+final class VmDomain: DomainHandler, @unchecked Sendable {
+    /// Cache of running VM instances keyed by name. Created on `vm start`,
+    /// dropped on `vm stop` / `vm delete`. The actor inside each entry
+    /// serializes per-VM verbs.
+    private let lock = NSLock()
+    private var instances: [String: VMInstance] = [:]
+
+    func handle(_ command: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) {
+        let sub = (action["sub"] as? String ?? command).replacingOccurrences(of: "-", with: "_")
+        // [String: Any] isn't Sendable; wrap in the same UncheckedSendableBox
+        // pattern Transport.swift uses (Transport.swift:234).
+        let boxed = VmActionBox(action: action)
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            await self.dispatch(sub: sub, action: boxed.action, completion: completion)
+        }
+    }
+
+    private func dispatch(sub: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async {
+        do {
+            switch sub {
+            case "create":  try await handleCreate(action, completion: completion)
+            case "adopt":   try await handleAdopt(action, completion: completion)
+            case "list":    try handleList(action, completion: completion)
+            case "get":     try handleGet(action, completion: completion)
+            case "inspect": try handleInspect(action, completion: completion)
+            case "start":   try await handleStart(action, completion: completion)
+            case "stop":    try await handleStop(action, completion: completion)
+            case "pause":   try await handlePause(action, completion: completion)
+            case "resume":  try await handleResume(action, completion: completion)
+            case "delete":  try await handleDelete(action, completion: completion)
+            case "exec":    try await handleExec(action, completion: completion)
+            case "clone":   try await handleClone(action, completion: completion)
+            case "pull":    try await handlePull(action, completion: completion)
+            case "install": try await handleInstall(action, completion: completion)
+            case "reset":   try await handleReset(action, completion: completion)
+            case "snapshot": try await handleSnapshot(action, completion: completion)
+            case "restore": try await handleRestore(action, completion: completion)
+            case "screenshot": try await handleGuestVerb("screenshot", action: action, completion: completion)
+            case "type":       try await handleGuestVerb("type", action: action, completion: completion)
+            case "click":      try await handleGuestVerb("click", action: action, completion: completion)
+            case "keys":       try await handleGuestVerb("keys", action: action, completion: completion)
+            case "read_ax":    try await handleGuestVerb("read_ax", action: action, completion: completion)
+            case "mount":      try await handleGuestVerb("mount", action: action, completion: completion)
+            case "logs":       try await handleGuestVerb("logs", action: action, completion: completion)
+            case "trust":      try await handleGuestVerb("trust", action: action, completion: completion)
+            case "cp":         try await handleCp(action, completion: completion)
+            case "share":      try await handleShare(action, completion: completion)
+            case "tcc_profile_generate": try await handleTccProfileGenerate(action, completion: completion)
+            case "console", "port_forward":
+                completion(WireFormat.error("vm \(sub): pending v2 — console/port-forward require VM runtime device wiring"))
+            default:
+                completion(WireFormat.error("vm: unknown verb '\(sub)'"))
+            }
+        } catch {
+            completion(WireFormat.error("vm \(sub): \(error)"))
+        }
+    }
+
+    // MARK: - helpers
+
+    private func stateDir(from action: [String: Any]) -> URL {
+        VMRegistry.resolveStateDir(actionOverride: action["stateDir"] as? String)
+    }
+
+    private func registry(from action: [String: Any]) throws -> VMRegistry {
+        let dir = stateDir(from: action)
+        return try VMRegistry(stateDir: dir)
+    }
+
+    private func timeInterval(from value: Any?, default defaultValue: TimeInterval) -> TimeInterval {
+        switch value {
+        case let number as NSNumber:
+            return number.doubleValue
+        case let double as Double:
+            return double
+        case let int as Int:
+            return TimeInterval(int)
+        case let string as String:
+            return TimeInterval(string) ?? defaultValue
+        default:
+            return defaultValue
+        }
+    }
+
+    private func ensureMacOSCapability() -> [String: Any]? {
+        #if canImport(Virtualization)
+        if #available(macOS 15.0, *) { return nil }
+        return [
+            "reason": "host macOS < 15.0; VM management requires macOS 15+",
+            "command": "softwareupdate --install",
+            "docs": "https://developer.apple.com/documentation/virtualization"
+        ]
+        #else
+        return [
+            "reason": "Virtualization framework not linked",
+            "command": "rebuild bridge",
+            "docs": "https://developer.apple.com/documentation/virtualization"
+        ]
+        #endif
+    }
+
+    private func instance(for name: String) -> VMInstance? {
+        lock.lock(); defer { lock.unlock() }
+        return instances[name]
+    }
+
+    private func putInstance(_ inst: VMInstance, name: String) {
+        lock.lock(); instances[name] = inst; lock.unlock()
+    }
+
+    private func dropInstance(name: String) {
+        lock.lock(); instances.removeValue(forKey: name); lock.unlock()
+    }
+
+    private func successView(for spec: VMSpec, status: VMStatus, ip: String? = nil) -> [String: Any] {
+        VMPublicView(spec: spec, status: status, ipAddress: ip).asDictionary
+    }
+
+    // MARK: - verb impls
+
+    private func handleCreate(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, !name.isEmpty else {
+            completion(WireFormat.error("vm create: missing 'name'")); return
+        }
+        guard let kindStr = action["kind"] as? String, let kind = VMKind(rawValue: kindStr) else {
+            completion(WireFormat.error("vm create: 'kind' must be 'linux' or 'macos'")); return
+        }
+        let cpu = (action["cpu"] as? Int) ?? 2
+        let memory = (action["memorySize"] as? UInt64) ?? UInt64((action["memorySize"] as? Int) ?? 1024 * 1024 * 1024)
+        let disk = (action["diskSize"] as? UInt64) ?? UInt64((action["diskSize"] as? Int) ?? 4 * 1024 * 1024 * 1024)
+        let image = (action["image"] as? String) ?? "latest"
+        let networkStr = (action["network"] as? String) ?? "nat"
+        let network = VMNetworkMode(rawValue: networkStr) ?? .nat
+        let rosetta = (action["rosetta"] as? Bool) ?? false
+        let shares: [VMShareSpec] = (action["shares"] as? [[String: Any]] ?? []).compactMap { item in
+            guard let host = item["hostPath"] as? String, let tag = item["tag"] as? String else { return nil }
+            let ro = (item["readOnly"] as? Bool) ?? true
+            return VMShareSpec(hostPath: host, tag: tag, readOnly: ro)
+        }
+        let spec = VMSpec(
+            name: name, kind: kind, cpu: cpu, memorySize: memory, diskSize: disk,
+            image: image, network: network,
+            shares: shares, rosetta: rosetta
+        )
+        let reg = try registry(from: action)
+        let bundle = try await reg.create(spec)
+        completion(WireFormat.success([
+            "name": name,
+            "id": spec.id,
+            "kind": kind.rawValue,
+            "status": VMStatus.created.rawValue,
+            "bundlePath": bundle.bundlePath.path
+        ]))
+    }
+
+    private func handleAdopt(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, !name.isEmpty else {
+            completion(WireFormat.error("vm adopt: missing 'name'")); return
+        }
+        guard let sourcePath = action["sourcePath"] as? String, !sourcePath.isEmpty else {
+            completion(WireFormat.error("vm adopt: missing 'sourcePath'")); return
+        }
+        guard let kindStr = action["kind"] as? String, let kind = VMKind(rawValue: kindStr) else {
+            completion(WireFormat.error("vm adopt: 'kind' must be 'linux' or 'macos'")); return
+        }
+        let provider = (action["provider"] as? String) ?? "auto"
+        let modeStr = (action["mode"] as? String) ?? "clone"
+        guard let mode = VMAdoptMode(rawValue: modeStr) else {
+            completion(WireFormat.error("vm adopt: --mode must be clone, move, or reference")); return
+        }
+        let source = URL(fileURLWithPath: (sourcePath as NSString).expandingTildeInPath)
+        let reg = try registry(from: action)
+        do {
+            let result = try await VMAdoption.adopt(
+                source: source,
+                name: name,
+                kind: kind,
+                requestedProvider: provider,
+                mode: mode,
+                registry: reg
+            )
+            completion(WireFormat.success(result.asDictionary))
+        } catch {
+            completion(WireFormat.error("vm adopt: \(error)"))
+        }
+    }
+
+    private func handleList(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) throws {
+        let reg = try registry(from: action)
+        Task {
+            let specs = try await reg.list()
+            let runningNames: Set<String> = {
+                lock.lock(); defer { lock.unlock() }
+                return Set(instances.keys)
+            }()
+            var vms: [[String: Any]] = []
+            for spec in specs {
+                let st: VMStatus = runningNames.contains(spec.name) ? .running : .stopped
+                vms.append(successView(for: spec, status: st))
+            }
+            completion(WireFormat.success(["vms": vms]))
+        }
+    }
+
+    private func handleGet(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm get: missing 'name'")); return
+        }
+        let reg = try registry(from: action)
+        Task {
+            do {
+                let spec = try await reg.get(name)
+                let inst = instance(for: name)
+                let st: VMStatus = await (inst?.status) ?? .stopped
+                let ip: String? = await inst?.ipAddress
+                completion(WireFormat.success(successView(for: spec, status: st, ip: ip)))
+            } catch {
+                completion(WireFormat.error("vm get: \(error)"))
+            }
+        }
+    }
+
+    private func handleInspect(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm inspect: missing 'name'")); return
+        }
+        let reg = try registry(from: action)
+        Task {
+            do {
+                let spec = try await reg.get(name)
+                let inst = instance(for: name)
+                let st: VMStatus = await (inst?.status) ?? .stopped
+                let lastError: String? = await inst?.lastError
+                var data: [String: Any] = successView(for: spec, status: st)
+                data["bundlePath"] = await reg.bundle(for: name).bundlePath.path
+                if let e = lastError { data["lastError"] = e }
+                completion(WireFormat.success(data))
+            } catch {
+                completion(WireFormat.error("vm inspect: \(error)"))
+            }
+        }
+    }
+
+    private func handleStart(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        if let setup = ensureMacOSCapability() {
+            completion(["success": false, "error": "vm start: macOS 15+ required", "setup_required": setup])
+            return
+        }
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm start: missing 'name'")); return
+        }
+        let headless = (action["headless"] as? Bool) ?? false
+        let waitForVsock = (action["waitForVsock"] as? Bool) ?? false
+        let reg = try registry(from: action)
+        let spec = try await reg.get(name)
+        let bundle = await reg.bundle(for: name)
+        if let existing = instance(for: name) {
+            let st = await existing.status
+            if st == .running {
+                completion(WireFormat.error("vm start: '\(name)' already running"))
+                return
+            }
+        }
+        let inst = VMInstance(spec: spec, bundle: bundle, status: .ready)
+        putInstance(inst, name: name)
+        do {
+            let r = try await inst.start(headless: headless, waitForVsock: waitForVsock)
+            // Persist startedAt
+            var updated = spec
+            updated.startedAt = Date()
+            try? await reg.update(updated)
+            completion(WireFormat.success([
+                "state": r.status.rawValue,
+                "transitionMs": r.transitionMs,
+                "ipAddress": r.ipAddress as Any
+            ]))
+        } catch {
+            dropInstance(name: name)
+            completion(WireFormat.error("vm start: \(error)"))
+        }
+    }
+
+    private func handleStop(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm stop: missing 'name'")); return
+        }
+        let force = (action["force"] as? Bool) ?? false
+        let timeout = timeInterval(from: action["timeout"], default: 60)
+        guard let inst = instance(for: name) else {
+            completion(WireFormat.success(["state": VMStatus.stopped.rawValue, "transitionMs": 0]))
+            return
+        }
+        do {
+            try await inst.stop(force: force, timeout: timeout)
+            dropInstance(name: name)
+            completion(WireFormat.success(["state": VMStatus.stopped.rawValue, "transitionMs": 0]))
+        } catch {
+            completion(WireFormat.error("vm stop: \(error)"))
+        }
+    }
+
+    private func handlePause(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, let inst = instance(for: name) else {
+            completion(WireFormat.error("vm pause: not running")); return
+        }
+        do {
+            try await inst.pause()
+            completion(WireFormat.success(["state": VMStatus.paused.rawValue]))
+        } catch {
+            completion(WireFormat.error("vm pause: \(error)"))
+        }
+    }
+
+    private func handleResume(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, let inst = instance(for: name) else {
+            completion(WireFormat.error("vm resume: not running")); return
+        }
+        do {
+            try await inst.resume()
+            completion(WireFormat.success(["state": VMStatus.running.rawValue]))
+        } catch {
+            completion(WireFormat.error("vm resume: \(error)"))
+        }
+    }
+
+    private func handleDelete(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm delete: missing 'name'")); return
+        }
+        let keepDisk = (action["keepDisk"] as? Bool) ?? false
+        // Stop first if running.
+        if let inst = instance(for: name) {
+            let st = await inst.status
+            if st == .running || st == .paused {
+                try? await inst.stop(force: true, timeout: 30)
+            }
+            dropInstance(name: name)
+        }
+        let reg = try registry(from: action)
+        do {
+            try await reg.delete(name, keepDisk: keepDisk)
+            completion(WireFormat.success(["state": VMStatus.deleted.rawValue]))
+        } catch {
+            completion(WireFormat.error("vm delete: \(error)"))
+        }
+    }
+
+    private func handleExec(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, let inst = instance(for: name) else {
+            completion(WireFormat.error("vm exec: '\(action["name"] as? String ?? "?")' not running"))
+            return
+        }
+        let argv = (action["command"] as? [String]) ?? []
+        if argv.isEmpty {
+            completion(WireFormat.error("vm exec: 'command' must be a non-empty argv array"))
+            return
+        }
+        let env = (action["env"] as? [String: String]) ?? [:]
+        let workdir = action["workdir"] as? String
+        let tty = (action["tty"] as? Bool) ?? false
+        let timeout = timeInterval(from: action["timeout"], default: 60)
+        do {
+            let r = try await inst.exec(argv: argv, env: env, workdir: workdir, tty: tty, timeout: timeout)
+            completion(WireFormat.success([
+                "exitCode": r.exitCode,
+                "stdout": r.stdout,
+                "stderr": r.stderr,
+                "durationMs": r.durationMs
+            ]))
+        } catch {
+            completion(WireFormat.error("vm exec: \(error)"))
+        }
+    }
+
+    private func guestInstance(from action: [String: Any], verb: String, completion: @escaping @Sendable ([String: Any]) -> Void) -> (name: String, inst: VMInstance)? {
+        guard let name = action["name"] as? String, !name.isEmpty else {
+            completion(WireFormat.error("vm \(verb): missing 'name'"))
+            return nil
+        }
+        guard let inst = instance(for: name) else {
+            completion(WireFormat.error("vm \(verb): '\(name)' not running"))
+            return nil
+        }
+        return (name, inst)
+    }
+
+    private func sanitizedGuestParams(from action: [String: Any], verb: String) -> [String: Any] {
+        var params = action
+        for key in ["type", "sub", "name", "stateDir", "timeout"] {
+            params.removeValue(forKey: key)
+        }
+        params["verb"] = verb
+        return params
+    }
+
+    private func handleGuestVerb(_ verb: String, action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let resolved = guestInstance(from: action, verb: verb, completion: completion) else { return }
+        let timeout = timeInterval(from: action["timeout"], default: 30)
+        do {
+            let result = try await resolved.inst.requestGuest(action: GuestAgentDict(sanitizedGuestParams(from: action, verb: verb)), timeout: timeout).dict
+            let success = result["success"] as? Bool ?? false
+            if !success {
+                completion(WireFormat.error("vm \(verb): \(result["error"] as? String ?? "guest verb failed")"))
+                return
+            }
+            completion(WireFormat.success((result["data"] as? [String: Any]) ?? result))
+        } catch {
+            completion(WireFormat.error("vm \(verb): \(error)"))
+        }
+    }
+
+    private func handleCp(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let resolved = guestInstance(from: action, verb: "cp", completion: completion) else { return }
+        guard let src = action["src"] as? String, let dst = action["dst"] as? String else {
+            completion(WireFormat.error("vm cp: missing 'src' or 'dst'"))
+            return
+        }
+        let timeout = timeInterval(from: action["timeout"], default: 60)
+        let guestPrefix = "\(resolved.name):"
+        do {
+            if dst.hasPrefix(guestPrefix) {
+                let guestPath = String(dst.dropFirst(guestPrefix.count))
+                let srcURL = URL(fileURLWithPath: (src as NSString).expandingTildeInPath)
+                let data = try Data(contentsOf: srcURL)
+                let result = try await resolved.inst.requestGuest(action: GuestAgentDict([
+                    "verb": "cp_in",
+                    "path": guestPath,
+                    "dataBase64": data.base64EncodedString(),
+                ]), timeout: timeout).dict
+                let success = result["success"] as? Bool ?? false
+                if !success {
+                    completion(WireFormat.error("vm cp: \(result["error"] as? String ?? "guest cp_in failed")"))
+                    return
+                }
+                completion(WireFormat.success((result["data"] as? [String: Any]) ?? result))
+                return
+            }
+            if src.hasPrefix(guestPrefix) {
+                let guestPath = String(src.dropFirst(guestPrefix.count))
+                let result = try await resolved.inst.requestGuest(action: GuestAgentDict([
+                    "verb": "cp_out",
+                    "path": guestPath,
+                ]), timeout: timeout).dict
+                let success = result["success"] as? Bool ?? false
+                if !success {
+                    completion(WireFormat.error("vm cp: \(result["error"] as? String ?? "guest cp_out failed")"))
+                    return
+                }
+                guard
+                    let dataDict = result["data"] as? [String: Any],
+                    let b64 = dataDict["dataBase64"] as? String,
+                    let data = Data(base64Encoded: b64)
+                else {
+                    completion(WireFormat.error("vm cp: guest cp_out returned no dataBase64"))
+                    return
+                }
+                let dstURL = URL(fileURLWithPath: (dst as NSString).expandingTildeInPath)
+                try data.write(to: dstURL, options: .atomic)
+                completion(WireFormat.success([
+                    "path": dstURL.path,
+                    "bytes": data.count,
+                    "source": guestPath,
+                ]))
+                return
+            }
+            completion(WireFormat.error("vm cp: one side must be \(resolved.name):<path>"))
+        } catch {
+            completion(WireFormat.error("vm cp: \(error)"))
+        }
+    }
+
+    private func handleTccProfileGenerate(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        let name = action["name"] as? String ?? "guest"
+        let fullDisk = action["fullDisk"] as? Bool ?? false
+        let includeUserOnly = action["includeUserOnly"] as? Bool ?? false
+        let bundleId = (action["bundleId"] as? String) ?? "com.interceptor.guest"
+        let appPath = (action["appPath"] as? String) ?? "/Library/PrivilegedHelperTools/InterceptorD"
+        let identifierType = (action["identifierType"] as? String) ?? "bundleID"
+        let requestedServices = (action["services"] as? [String]).flatMap { $0.isEmpty ? nil : $0 }
+            ?? TccProfileGenerator.defaultServices(fullDisk: fullDisk)
+        let codeRequirement = (action["codeRequirement"] as? String) ?? "identifier \(bundleId)"
+        do {
+            let generated = try TccProfileGenerator.generateProfile(
+                target: "guest-\(name)",
+                bundleId: bundleId,
+                appPath: appPath,
+                identifierType: identifierType,
+                codeRequirement: codeRequirement,
+                requestedServices: requestedServices,
+                includeUserOnly: includeUserOnly
+            )
+            var result: [String: Any] = [
+                "name": name,
+                "target": "guest",
+                "bundleId": bundleId,
+                "appPath": appPath,
+                "included": generated.included,
+                "skipped": generated.skipped,
+                "requiresUserApprovedMdm": true,
+            ]
+            if let out = action["out"] as? String, !out.isEmpty {
+                let url = URL(fileURLWithPath: (out as NSString).expandingTildeInPath)
+                try generated.xml.write(to: url, atomically: true, encoding: .utf8)
+                result["path"] = url.path
+            } else {
+                result["profile"] = generated.xml
+            }
+            completion(WireFormat.success(result))
+        } catch {
+            completion(WireFormat.error("vm tcc profile generate: \(error)"))
+        }
+    }
+
+    private func handleShare(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm share: missing 'name'")); return
+        }
+        guard let hostPath = action["hostPath"] as? String, let tag = action["tag"] as? String else {
+            completion(WireFormat.error("vm share: missing 'hostPath' or 'tag'")); return
+        }
+        let readOnly = action["readOnly"] as? Bool ?? true
+        let reg = try registry(from: action)
+        do {
+            var spec = try await reg.get(name)
+            spec.shares.removeAll { $0.tag == tag }
+            spec.shares.append(VMShareSpec(hostPath: hostPath, tag: tag, readOnly: readOnly))
+            try await reg.update(spec)
+            let running = instance(for: name) != nil
+            completion(WireFormat.success([
+                "name": name,
+                "tag": tag,
+                "hostPath": hostPath,
+                "readOnly": readOnly,
+                "requiresRestart": running,
+                "note": running ? "Share was added to the persisted spec; restart the VM for Virtualization.framework to attach it." : "Share will attach on next start.",
+            ]))
+        } catch {
+            completion(WireFormat.error("vm share: \(error)"))
+        }
+    }
+
+    private func handleClone(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let src = action["src"] as? String, let dst = action["dst"] as? String else {
+            completion(WireFormat.error("vm clone: missing 'src' or 'dst'")); return
+        }
+        let reg = try registry(from: action)
+        do {
+            let bundle = try await reg.clone(from: src, to: dst)
+            completion(WireFormat.success([
+                "name": dst,
+                "bundlePath": bundle.bundlePath.path,
+                "status": VMStatus.ready.rawValue
+            ]))
+        } catch {
+            completion(WireFormat.error("vm clone: \(error)"))
+        }
+    }
+
+    private func handlePull(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let image = action["image"] as? String else {
+            completion(WireFormat.error("vm pull: missing 'image' OCI ref")); return
+        }
+        let stateD = stateDir(from: action)
+        do {
+            let url = try await VMImage.resolveOCIImage(ref: image, stateDir: stateD)
+            completion(WireFormat.success(["image": image, "path": url.path]))
+        } catch {
+            completion(WireFormat.error("vm pull: \(error)"))
+        }
+    }
+
+    private func handleInstall(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        if let setup = ensureMacOSCapability() {
+            completion(["success": false, "error": "vm install: macOS 15+ required", "setup_required": setup])
+            return
+        }
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm install: missing 'name'")); return
+        }
+        let imageOverride = action["ipsw"] as? String
+        let fromLatest = (action["fromLatest"] as? Bool) ?? false
+        let stateD = stateDir(from: action)
+        let reg = try registry(from: action)
+        let spec = try await reg.get(name)
+        guard spec.kind == .macos else {
+            completion(WireFormat.error("vm install: '\(name)' is kind=\(spec.kind.rawValue); install is macOS-only"))
+            return
+        }
+        let bundle = await reg.bundle(for: name)
+
+        #if canImport(Virtualization)
+        if #available(macOS 13.0, *) {
+            do {
+                let imageSpec: String = imageOverride ?? (fromLatest ? "latest" : spec.image)
+                let ipswURL = try await VMImage.resolveMacOSImage(spec: imageSpec, stateDir: stateD)
+                try await MacRuntime.install(spec: spec, bundle: bundle, ipswURL: ipswURL)
+                completion(WireFormat.success([
+                    "name": name,
+                    "ipsw": ipswURL.path,
+                    "status": VMStatus.ready.rawValue
+                ]))
+            } catch {
+                completion(WireFormat.error("vm install: \(error)"))
+            }
+            return
+        }
+        #endif
+        completion(WireFormat.error("vm install: requires macOS 13+ host with Virtualization.framework"))
+    }
+
+    private func handleReset(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm reset: missing 'name'")); return
+        }
+        // Drop any in-memory instance so the next start rebuilds from the spec.
+        dropInstance(name: name)
+        completion(WireFormat.success(["state": VMStatus.ready.rawValue, "name": name]))
+    }
+
+    private func handleSnapshot(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        let snapSub = action["sub"] as? String  // outer dispatch already pulled this
+        // Real outer "sub" is "snapshot"; inner sub here would be passed
+        // through `snapshotSub`. CLI sends both: `sub: "snapshot"`,
+        // `snapshotOp: "create|list|delete|restore"`.
+        let op = (action["snapshotOp"] as? String) ?? "create"
+        _ = snapSub
+        guard let name = action["name"] as? String else {
+            completion(WireFormat.error("vm snapshot: missing 'name'")); return
+        }
+        let reg = try registry(from: action)
+        let bundle = await reg.bundle(for: name)
+        switch op {
+        case "list":
+            let tags = VMSnapshot.list(bundle: bundle)
+            completion(WireFormat.success(["snapshots": tags]))
+        case "delete":
+            guard let tag = action["tag"] as? String else {
+                completion(WireFormat.error("vm snapshot delete: missing 'tag'")); return
+            }
+            do {
+                try VMSnapshot.delete(bundle: bundle, tag: tag)
+                completion(WireFormat.success(["tag": tag, "deleted": true]))
+            } catch {
+                completion(WireFormat.error("vm snapshot delete: \(error)"))
+            }
+        default:
+            // create — requires the VM to be paused for paused-state snapshots.
+            guard let tag = action["tag"] as? String else {
+                completion(WireFormat.error("vm snapshot create: missing 'tag'")); return
+            }
+            let diskOnly = action["diskOnly"] as? Bool ?? false
+            let pausedStateOnly = action["pausedStateOnly"] as? Bool ?? false
+            if !diskOnly, let inst = instance(for: name) {
+                let mode: VMSnapshot.Mode = pausedStateOnly ? .pausedStateOnly : .both
+                do {
+                    let manifest = try await inst.createSnapshot(tag: tag, mode: mode)
+                    completion(WireFormat.success([
+                        "tag": manifest.tag,
+                        "kind": manifest.kind,
+                        "hasPausedState": manifest.hasPausedState,
+                        "hasDiskClone": manifest.hasDiskClone,
+                    ]))
+                } catch {
+                    completion(WireFormat.error("vm snapshot create: \(error)"))
+                }
+                return
+            }
+            if pausedStateOnly {
+                completion(WireFormat.error("vm snapshot create: paused-state snapshot requires a running paused VM"))
+                return
+            }
+            // Disk-only snapshot — clonefile of Disk.img.
+            let snapDir = bundle.snapshotDir(tag: tag)
+            if FileManager.default.fileExists(atPath: snapDir.path) {
+                completion(WireFormat.error("vm snapshot create: tag '\(tag)' already exists"))
+                return
+            }
+            do {
+                try FileManager.default.createDirectory(at: snapDir, withIntermediateDirectories: true)
+                if FileManager.default.fileExists(atPath: bundle.diskPath.path) {
+                    let dst = snapDir.appendingPathComponent("Disk.img")
+                    try FileManager.default.copyItem(at: bundle.diskPath, to: dst)
+                }
+                let m = VMSnapshotManifest(tag: tag, kind: "disk-only", createdAt: Date(), hasPausedState: false, hasDiskClone: true, notes: nil)
+                let enc = JSONEncoder()
+                enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+                enc.dateEncodingStrategy = .iso8601
+                let data = try enc.encode(m)
+                try data.write(to: bundle.snapshotManifest(tag: tag), options: .atomic)
+                completion(WireFormat.success(["tag": tag, "kind": "disk-only"]))
+            } catch {
+                completion(WireFormat.error("vm snapshot create: \(error)"))
+            }
+        }
+    }
+
+    private func handleRestore(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let name = action["name"] as? String, let tag = action["tag"] as? String else {
+            completion(WireFormat.error("vm restore: missing 'name' or 'tag'")); return
+        }
+        let reg = try registry(from: action)
+        let bundle = await reg.bundle(for: name)
+        let snapDir = bundle.snapshotDir(tag: tag)
+        let snapDisk = snapDir.appendingPathComponent("Disk.img")
+        guard FileManager.default.fileExists(atPath: snapDisk.path) else {
+            completion(WireFormat.error("vm restore: snapshot '\(tag)' has no Disk.img"))
+            return
+        }
+        // Stop the VM first if running.
+        if let inst = instance(for: name) {
+            try? await inst.stop(force: true, timeout: 10)
+            dropInstance(name: name)
+        }
+        let parked = bundle.bundlePath.appendingPathComponent("Disk.img.pre-restore-\(Int(Date().timeIntervalSince1970))")
+        do {
+            if FileManager.default.fileExists(atPath: bundle.diskPath.path) {
+                try FileManager.default.moveItem(at: bundle.diskPath, to: parked)
+            }
+            try FileManager.default.copyItem(at: snapDisk, to: bundle.diskPath)
+            try? FileManager.default.removeItem(at: parked)
+            completion(WireFormat.success(["tag": tag, "restored": "disk"]))
+        } catch {
+            // best-effort rollback
+            try? FileManager.default.moveItem(at: parked, to: bundle.diskPath)
+            completion(WireFormat.error("vm restore: \(error)"))
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/GuestAgent.swift
+++ b/interceptor-bridge/Sources/VM/GuestAgent.swift
@@ -1,0 +1,448 @@
+// GuestAgent
+//
+// vsock client used by the host bridge to dispatch verbs INTO a running
+// guest. The guest agent (InterceptorD, CL29-CL32) listens on
+// VSOCK port 3294. We connect via
+// `VZVirtioSocketDevice.connect(toPort:completionHandler:)` per
+// `apple-developer-docs/Virtualization/VZVirtioSocketDevice.md:25-30`,
+// take the resulting `VZVirtioSocketConnection.fileDescriptor`, and
+// speak the same length-prefixed JSON framing the host bridge already
+// uses (`WireFormat`).
+//
+// Wire framing (host ↔ guest):
+//   [4 bytes little-endian length][JSON payload]
+// Request shape:   {id: uuid, action: {verb: "exec", ...}}
+// Response shape:  {id: uuid, result: {success: bool, data?: ..., error?: string}}
+
+import Foundation
+import Darwin
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+/// Fixed vsock port we run the guest agent on. Chosen to avoid the
+/// well-known low-numbered range and keep typed-out as `0xCDE` (3294)
+/// for memorability. Documented in the design notes E6 evidence row.
+public let kInterceptorGuestAgentPort: UInt32 = 3294
+
+// Tiny @unchecked Sendable wrapper so we can hand a `[String: Any]` across
+// CheckedContinuation boundaries — same pattern Transport.swift uses
+// (Transport.swift:234 UncheckedSendableBox).
+public struct GuestAgentDict: @unchecked Sendable {
+    public let dict: [String: Any]
+
+    public init(_ dict: [String: Any]) {
+        self.dict = dict
+    }
+}
+
+final class GuestAgentConnectContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Int32, Error>?
+
+    init(_ continuation: CheckedContinuation<Int32, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning value: Int32) {
+        lock.lock()
+        let cc = continuation
+        continuation = nil
+        lock.unlock()
+        cc?.resume(returning: value)
+    }
+
+    func resume(throwing error: Error) {
+        lock.lock()
+        let cc = continuation
+        continuation = nil
+        lock.unlock()
+        cc?.resume(throwing: error)
+    }
+}
+
+public enum GuestAgentError: Error, CustomStringConvertible, Sendable {
+    case notConnected(String)
+    case framing(String)
+    case ioFailure(String)
+    case remote(String)
+    case timeout(String)
+
+    public var description: String {
+        switch self {
+        case .notConnected(let m): return "agent.notConnected: \(m)"
+        case .framing(let m): return "agent.framing: \(m)"
+        case .ioFailure(let m): return "agent.ioFailure: \(m)"
+        case .remote(let m): return "agent.remote: \(m)"
+        case .timeout(let m): return "agent.timeout: \(m)"
+        }
+    }
+}
+
+/// Protocol every guest-agent client implements. Single in-process actor
+/// per VM, owned by VMInstance.
+public protocol GuestAgent: Sendable {
+    /// Dial the guest agent. Implementation depends on transport (vsock
+    /// for Linux + macOS-on-macOS; SSH fallback later).
+    func connect(timeout: TimeInterval) async throws
+
+    /// Send one request and wait for its matching response. JSON dict in,
+    /// JSON dict out. Returns the `result` envelope.
+    func request(_ action: GuestAgentDict, timeout: TimeInterval) async throws -> GuestAgentDict
+
+    /// Close the underlying transport.
+    func disconnect() async
+}
+
+/// Convenience helpers built atop `request(_:)`.
+public extension GuestAgent {
+    func control(_ verb: String, params: [String: Any] = [:], timeout: TimeInterval = 30) async throws -> [String: Any] {
+        var action = params
+        action["verb"] = verb
+        let r = try await request(GuestAgentDict(action), timeout: timeout).dict
+        let success = r["success"] as? Bool ?? false
+        if !success {
+            throw GuestAgentError.remote(r["error"] as? String ?? "\(verb) failed")
+        }
+        return (r["data"] as? [String: Any]) ?? r
+    }
+
+    func exec(_ argv: [String], env: [String: String] = [:], workdir: String? = nil, tty: Bool = false, timeout: TimeInterval = 60) async throws -> (exitCode: Int32, stdout: String, stderr: String, durationMs: Int) {
+        var action: [String: Any] = ["verb": "exec", "argv": argv, "env": env, "tty": tty]
+        if let w = workdir { action["workdir"] = w }
+        let r = try await request(GuestAgentDict(action), timeout: timeout).dict
+        let success = r["success"] as? Bool ?? false
+        if !success {
+            throw GuestAgentError.remote(r["error"] as? String ?? "exec failed")
+        }
+        let data = r["data"] as? [String: Any] ?? [:]
+        let exit = (data["exitCode"] as? Int32) ?? Int32((data["exitCode"] as? Int) ?? 0)
+        let out = data["stdout"] as? String ?? ""
+        let err = data["stderr"] as? String ?? ""
+        let durMs = (data["durationMs"] as? Int) ?? 0
+        return (exit, out, err, durMs)
+    }
+
+    func getIP(timeout: TimeInterval = 10) async throws -> String? {
+        let r = try await request(GuestAgentDict(["verb": "get_ip"]), timeout: timeout).dict
+        let data = r["data"] as? [String: Any]
+        return data?["ipAddress"] as? String
+    }
+
+    func screenshot(out: String? = nil, timeout: TimeInterval = 30) async throws -> [String: Any] {
+        var params: [String: Any] = [:]
+        if let out { params["out"] = out }
+        return try await control("screenshot", params: params, timeout: timeout)
+    }
+
+    func readAX(maxDepth: Int? = nil, app: String? = nil, timeout: TimeInterval = 30) async throws -> [String: Any] {
+        var params: [String: Any] = [:]
+        if let maxDepth { params["max_depth"] = maxDepth }
+        if let app { params["app"] = app }
+        return try await control("read_ax", params: params, timeout: timeout)
+    }
+
+    func click(x: Double, y: Double, button: String = "left", timeout: TimeInterval = 10) async throws -> [String: Any] {
+        try await control("click", params: ["x": x, "y": y, "button": button], timeout: timeout)
+    }
+
+    func typeText(_ text: String, timeout: TimeInterval = 30) async throws -> [String: Any] {
+        try await control("type", params: ["text": text], timeout: timeout)
+    }
+
+    func keys(_ keys: String, timeout: TimeInterval = 10) async throws -> [String: Any] {
+        try await control("keys", params: ["keys": keys], timeout: timeout)
+    }
+
+    func mount(tag: String, path: String, timeout: TimeInterval = 30) async throws -> [String: Any] {
+        try await control("mount", params: ["tag": tag, "path": path], timeout: timeout)
+    }
+
+    func trust(timeout: TimeInterval = 10) async throws -> [String: Any] {
+        try await control("trust", timeout: timeout)
+    }
+
+    func logs(limit: Int? = nil, timeout: TimeInterval = 10) async throws -> [String: Any] {
+        var params: [String: Any] = [:]
+        if let limit { params["limit"] = limit }
+        return try await control("logs", params: params, timeout: timeout)
+    }
+
+    func copyIn(path: String, data: Data, mode: String? = nil, timeout: TimeInterval = 60) async throws -> [String: Any] {
+        var params: [String: Any] = ["path": path, "dataBase64": data.base64EncodedString()]
+        if let mode { params["mode"] = mode }
+        return try await control("cp_in", params: params, timeout: timeout)
+    }
+
+    func copyOut(path: String, timeout: TimeInterval = 60) async throws -> [String: Any] {
+        try await control("cp_out", params: ["path": path], timeout: timeout)
+    }
+}
+
+/// Concrete vsock-backed agent. Owns the raw fd from
+/// `VZVirtioSocketConnection.fileDescriptor`. State (fd + pending map) is
+/// serialized through a dedicated dispatch queue, which is async-safe
+/// under Swift 6 strict concurrency where NSLock.lock() is not.
+@available(macOS 11.0, *)
+public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
+    private let socketDevice: VZVirtioSocketDevice
+    private let connectQueue: DispatchQueue?
+    private let port: UInt32
+    private let stateQueue = DispatchQueue(label: "interceptor.bridge.vsockAgent")
+    private var fd: Int32 = -1
+    private var tcpFallbackHost: String?
+    private var pending: [String: CheckedContinuation<GuestAgentDict, Error>] = [:]
+    private var reader: Task<Void, Never>?
+
+    private func withState<R>(_ body: (inout Int32, inout [String: CheckedContinuation<GuestAgentDict, Error>]) -> R) -> R {
+        stateQueue.sync { body(&fd, &pending) }
+    }
+
+#if canImport(Virtualization)
+    public init(socketDevice: VZVirtioSocketDevice, connectQueue: DispatchQueue? = nil, port: UInt32 = kInterceptorGuestAgentPort, tcpFallbackHost: String? = nil) {
+        self.socketDevice = socketDevice
+        self.connectQueue = connectQueue
+        self.port = port
+        self.tcpFallbackHost = tcpFallbackHost
+    }
+#endif
+
+    public func setTCPFallbackHost(_ host: String?) {
+        stateQueue.sync {
+            self.tcpFallbackHost = host
+        }
+    }
+
+    private func tcpFallbackHostSnapshot() -> String? {
+        stateQueue.sync {
+            tcpFallbackHost
+        }
+    }
+
+    public func connect(timeout: TimeInterval = 30) async throws {
+        let existingFd: Int32 = withState { (f, _) in f }
+        if existingFd >= 0 {
+            return
+        }
+        // VZVirtioSocketDevice.connect(toPort:completionHandler:) returns a
+        // VZVirtioSocketConnection whose fileDescriptor is a real socket
+        // file descriptor (apple-developer-docs/.../VZVirtioSocketDevice.md:30).
+        // We drive it as a normal POSIX socket.
+        let device = self.socketDevice
+        let connectQueue = self.connectQueue
+        let port = self.port
+        // VZVirtioSocketConnection isn't Sendable; extract the fileDescriptor
+        // (Int32, Sendable) inside the completion closure and hand only that
+        // primitive across the continuation.
+        let connectedFd: Int32
+        do {
+            connectedFd = try await withCheckedThrowingContinuation { cc in
+                let gate = GuestAgentConnectContinuation(cc)
+                let startConnect = {
+                    device.connect(toPort: port) { result in
+                        switch result {
+                        case .success(let conn):
+                            gate.resume(returning: conn.fileDescriptor)
+                        case .failure(let err):
+                            gate.resume(throwing: GuestAgentError.notConnected("vsock connect port \(port): \(err.localizedDescription)"))
+                        }
+                    }
+                }
+                if let connectQueue {
+                    connectQueue.async(execute: startConnect)
+                } else {
+                    startConnect()
+                }
+                if timeout > 0 {
+                    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                        gate.resume(throwing: GuestAgentError.timeout("vsock connect port \(port) after \(Int(timeout))s"))
+                    }
+                }
+            }
+        } catch {
+            guard let host = tcpFallbackHostSnapshot(), !host.isEmpty else {
+                throw error
+            }
+            do {
+                connectedFd = try Self.connectTCP(host: host, port: port, timeout: timeout)
+            } catch {
+                throw GuestAgentError.notConnected("vsock failed and tcp fallback \(host):\(port) failed: \(error)")
+            }
+        }
+        withState { (f, _) in f = connectedFd }
+
+        // Spawn a reader task that demuxes inbound frames to pending continuations.
+        self.reader = Task.detached(priority: .utility) { [weak self] in
+            await self?.readLoop()
+        }
+    }
+
+    private static func connectTCP(host: String, port: UInt32, timeout: TimeInterval) throws -> Int32 {
+        let sock = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else {
+            throw GuestAgentError.ioFailure("tcp socket: \(String(cString: strerror(errno)))")
+        }
+
+        let originalFlags = Darwin.fcntl(sock, F_GETFL, 0)
+        guard originalFlags >= 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(sock)
+            throw GuestAgentError.ioFailure("tcp fcntl(F_GETFL): \(message)")
+        }
+        guard Darwin.fcntl(sock, F_SETFL, originalFlags | O_NONBLOCK) == 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(sock)
+            throw GuestAgentError.ioFailure("tcp fcntl(F_SETFL): \(message)")
+        }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        let parsed = host.withCString { inet_pton(AF_INET, $0, &addr.sin_addr) }
+        guard parsed == 1 else {
+            Darwin.close(sock)
+            throw GuestAgentError.notConnected("tcp fallback host is not IPv4: \(host)")
+        }
+
+        let addrSize = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let connectResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                Darwin.connect(sock, sptr, addrSize)
+            }
+        }
+        if connectResult == 0 {
+            _ = Darwin.fcntl(sock, F_SETFL, originalFlags)
+            return sock
+        }
+
+        let connectErrno = errno
+        guard connectErrno == EINPROGRESS else {
+            let message = String(cString: strerror(connectErrno))
+            Darwin.close(sock)
+            throw GuestAgentError.notConnected("tcp connect \(host):\(port): \(message)")
+        }
+
+        let timeoutMs: Int32
+        if timeout <= 0 {
+            timeoutMs = -1
+        } else {
+            timeoutMs = Int32(min(Double(Int32.max), ceil(timeout * 1000)))
+        }
+        var pfd = pollfd(fd: sock, events: Int16(POLLOUT), revents: 0)
+        let pollResult = Darwin.poll(&pfd, 1, timeoutMs)
+        guard pollResult > 0 else {
+            let message = pollResult == 0 ? "after \(Int(timeout))s" : String(cString: strerror(errno))
+            Darwin.close(sock)
+            if pollResult == 0 {
+                throw GuestAgentError.timeout("tcp connect \(host):\(port) \(message)")
+            }
+            throw GuestAgentError.notConnected("tcp connect \(host):\(port): \(message)")
+        }
+
+        var socketError: Int32 = 0
+        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+        guard Darwin.getsockopt(sock, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) == 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(sock)
+            throw GuestAgentError.ioFailure("tcp getsockopt(SO_ERROR): \(message)")
+        }
+        guard socketError == 0 else {
+            let message = String(cString: strerror(socketError))
+            Darwin.close(sock)
+            throw GuestAgentError.notConnected("tcp connect \(host):\(port): \(message)")
+        }
+
+        _ = Darwin.fcntl(sock, F_SETFL, originalFlags)
+        return sock
+    }
+
+    public func request(_ action: GuestAgentDict, timeout: TimeInterval = 60) async throws -> GuestAgentDict {
+        let id = UUID().uuidString
+        var payload: [String: Any] = ["id": id, "action": action.dict]
+        if payload["action"] == nil { payload["action"] = action.dict }
+
+        let data: Data
+        do {
+            data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        } catch {
+            throw GuestAgentError.framing("encode request: \(error.localizedDescription)")
+        }
+
+        let fdSnapshot: Int32 = withState { (f, _) in f }
+        guard fdSnapshot >= 0 else { throw GuestAgentError.notConnected("no fd") }
+
+        let wrapped = try await withCheckedThrowingContinuation { (cc: CheckedContinuation<GuestAgentDict, Error>) in
+            self.withState { (_, p) in p[id] = cc }
+
+            var length = UInt32(data.count).littleEndian
+            var header = Data(bytes: &length, count: 4)
+            header.append(data)
+            header.withUnsafeBytes { ptr in
+                _ = Darwin.write(fdSnapshot, ptr.baseAddress!, header.count)
+            }
+
+            if timeout > 0 {
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) { [weak self] in
+                    guard let self = self else { return }
+                    let pendingCC: CheckedContinuation<GuestAgentDict, Error>? = self.withState { (_, p) in p.removeValue(forKey: id) }
+                    pendingCC?.resume(throwing: GuestAgentError.timeout("no response for \(id.prefix(8)) after \(Int(timeout))s"))
+                }
+            }
+        }
+        return wrapped
+    }
+
+    public func disconnect() async {
+        reader?.cancel()
+        reader = nil
+        let (f, pendingCopy): (Int32, [String: CheckedContinuation<GuestAgentDict, Error>]) = withState { (fd, pending) in
+            let snapshotPending = pending
+            let snapshotFd = fd
+            fd = -1
+            pending.removeAll()
+            return (snapshotFd, snapshotPending)
+        }
+        for (_, cc) in pendingCopy {
+            cc.resume(throwing: GuestAgentError.notConnected("disconnected"))
+        }
+        if f >= 0 { Darwin.close(f) }
+    }
+
+    // MARK: - read loop
+
+    private func readLoop() async {
+        var buffer = Data()
+        var buf = [UInt8](repeating: 0, count: 64 * 1024)
+        while !Task.isCancelled {
+            let fdSnapshot: Int32 = withState { (f, _) in f }
+            if fdSnapshot < 0 { return }
+            let n = buf.withUnsafeMutableBufferPointer { Darwin.read(fdSnapshot, $0.baseAddress, $0.count) }
+            if n <= 0 {
+                await self.disconnect()
+                return
+            }
+            buffer.append(buf, count: n)
+
+            while buffer.count >= 4 {
+                let length: UInt32 = buffer.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+                let totalSize = 4 + Int(length)
+                if length == 0 || length > 50_000_000 {
+                    buffer.removeAll()
+                    break
+                }
+                if buffer.count < totalSize { break }
+                let payload = buffer.subdata(in: 4..<totalSize)
+                buffer.removeSubrange(0..<totalSize)
+
+                guard let obj = try? JSONSerialization.jsonObject(with: payload, options: []) as? [String: Any] else {
+                    continue
+                }
+                guard let id = obj["id"] as? String else { continue }
+                let result = (obj["result"] as? [String: Any]) ?? [:]
+                let cc: CheckedContinuation<GuestAgentDict, Error>? = withState { (_, p) in p.removeValue(forKey: id) }
+                cc?.resume(returning: GuestAgentDict(result))
+            }
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/LinuxRuntime.swift
+++ b/interceptor-bridge/Sources/VM/LinuxRuntime.swift
@@ -1,0 +1,146 @@
+// LinuxRuntime
+//
+// Wraps the Apple Containerization Swift package's high-level
+// `LinuxContainer` API for in-process Linux guest lifecycle. This is the
+// recipe `apple/container`'s SandboxService uses at
+// `research/container/Sources/Services/ContainerSandboxService/Server/SandboxService.swift:164-261`:
+//
+//     let vmm = VZVirtualMachineManager(kernel:..., initialFilesystem:..., rosetta:..., logger:...)
+//     let container = try LinuxContainer(id, rootfs: rootfs, vmm: vmm, logger: log) { czConfig in
+//         czConfig.interfaces = ...
+//         czConfig.process.stdout = ...
+//         czConfig.hosts = Hosts(entries: ...)
+//         czConfig.bootLog = BootLog.file(path: bundle.bootlog, append: true)
+//     }
+//     try await container.create()      // boot the VM
+//     try await container.start()       // start init process
+//     try await container.exec(id, configuration:) // run new process
+//     try await container.kill(SIGTERM) // signal
+//     try await container.stop()        // graceful stop
+//
+// In v0 we instantiate Containerization types unconditionally, but everything
+// is gated `#if canImport(Containerization)` so the bridge can still build on
+// dev environments where the package hasn't been resolved.
+
+import Foundation
+
+#if canImport(Containerization)
+import Containerization
+#endif
+
+#if canImport(ContainerizationOCI)
+import ContainerizationOCI
+#endif
+
+public enum LinuxRuntimeError: Error, CustomStringConvertible, Sendable {
+    case packageUnavailable(String)
+    case prepareFailed(String)
+    case lifecycleFailed(String)
+
+    public var description: String {
+        switch self {
+        case .packageUnavailable(let m): return "linux.packageUnavailable: \(m)"
+        case .prepareFailed(let m): return "linux.prepareFailed: \(m)"
+        case .lifecycleFailed(let m): return "linux.lifecycleFailed: \(m)"
+        }
+    }
+}
+
+/// Thin facade over `Containerization.LinuxContainer`. One instance per
+/// running Linux VM, owned by `VMInstance`. We accept the runtime cost of
+/// wrapping the type so VMInstance does not need to import Containerization
+/// directly (and so VmDomainTests can stub via protocol).
+public protocol LinuxRuntimeHandle: AnyObject, Sendable {
+    func create() async throws
+    func start() async throws
+    func stop() async throws
+    func kill(signal: Int32) async throws
+    func wait() async throws -> Int32
+    func execve(_ argv: [String], env: [String: String], workdir: String?, tty: Bool) async throws -> (exitCode: Int32, stdout: String, stderr: String)
+    func ipAddress() async -> String?
+}
+
+public struct LinuxRuntime: Sendable {
+
+    /// Build a runtime handle. Reads the Containerization kernel+initrd
+    /// bundle laid out by `vm pull <oci-ref>` under
+    /// `<state>/images/oci/<safe-ref>/` and starts a fresh
+    /// `VZVirtualMachineManager` + `LinuxContainer`.
+    ///
+    /// In v0 we keep the implementation defensive: if Containerization
+    /// hasn't been resolved (offline build, etc.) we throw a clean
+    /// `packageUnavailable` so the VmDomain surfaces a `setup_required`
+    /// envelope rather than crashing the bridge.
+    public static func prepare(spec: VMSpec, bundle: VMBundle) async throws -> LinuxRuntimeHandle {
+#if canImport(Containerization)
+        return try await LinuxRuntimeImpl(spec: spec, bundle: bundle)
+#else
+        throw LinuxRuntimeError.packageUnavailable(
+            "Containerization Swift package not linked — rebuild the bridge with `swift package update` first"
+        )
+#endif
+    }
+}
+
+#if canImport(Containerization)
+/// Concrete handle, in-process LinuxContainer wrapper.
+final class LinuxRuntimeImpl: LinuxRuntimeHandle, @unchecked Sendable {
+    private let spec: VMSpec
+    private let bundle: VMBundle
+    // We do not store the LinuxContainer here as a typed property because
+    // Containerization's actual public API surface evolves between
+    // releases. Storing it via `Any` plus a few helper closures keeps the
+    // bridge buildable across point releases while we tail Apple's pin.
+    private var container: Any?
+
+    init(spec: VMSpec, bundle: VMBundle) async throws {
+        self.spec = spec
+        self.bundle = bundle
+        // Eager construction would require us to enumerate the kernel +
+        // initrd inside Containerization's bundle layout, which is
+        // documented but version-sensitive. v0 defers construction to
+        // `create()` so a `vm create` that does not boot doesn't pay the
+        // cost of locating Containerization assets.
+    }
+
+    func create() async throws {
+        // Real Containerization initialization happens here in v0+. For
+        // the bridge to build cleanly without resolving the package we
+        // gate the body with `if false`-style availability — once
+        // `swift package update` brings in containerization 0.31.0 the
+        // body becomes the SandboxService.swift recipe documented at the
+        // top of this file. Until then we surface a clear error.
+        throw LinuxRuntimeError.prepareFailed(
+            "LinuxRuntime.create() pending Containerization runtime wiring. The package is linked, but the LinuxContainer boot recipe still needs to be mapped to the current Containerization API before Linux guests can boot."
+        )
+    }
+
+    func start() async throws {
+        throw LinuxRuntimeError.lifecycleFailed("start: container not yet created")
+    }
+
+    func stop() async throws {
+        throw LinuxRuntimeError.lifecycleFailed("stop: container not yet created")
+    }
+
+    func kill(signal: Int32) async throws {
+        throw LinuxRuntimeError.lifecycleFailed("kill: container not yet created")
+    }
+
+    func wait() async throws -> Int32 {
+        throw LinuxRuntimeError.lifecycleFailed("wait: container not yet created")
+    }
+
+    func execve(_ argv: [String], env: [String: String], workdir: String?, tty: Bool) async throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        // Once container is created we use container.exec(id, configuration:)
+        // and capture stdout/stderr through the process's stdio handles.
+        throw LinuxRuntimeError.lifecycleFailed("execve: container not yet created")
+    }
+
+    func ipAddress() async -> String? {
+        // Containerization exposes the interfaces via the container config;
+        // we'll wire this once the package resolves.
+        return nil
+    }
+}
+#endif

--- a/interceptor-bridge/Sources/VM/MacRuntime.swift
+++ b/interceptor-bridge/Sources/VM/MacRuntime.swift
@@ -1,0 +1,282 @@
+// MacRuntime
+//
+// Raw Virtualization framework wrapper for macOS-on-macOS guests. Drops
+// the entire Apple sample recipe from
+// `apple-developer-docs/Virtualization/running-macos-in-a-virtual-machine-on-apple-silicon.md`
+// and `apple-developer-docs/Virtualization/installing-macos-on-a-virtual-machine.md:14-46`
+// into one type that VMInstance owns.
+//
+// Apple's container project does NOT support macOS guests (verified by
+// `rg 'VZMacOSInstaller' research/container/Sources` → no matches), so
+// MacRuntime drives VZMacOSInstaller directly. Bundle layout follows
+// Apple's `VM.bundle` spec: Disk.img, AuxiliaryStorage, MachineIdentifier,
+// HardwareModel, RestoreImage.ipsw.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public enum MacRuntimeError: Error, CustomStringConvertible, Sendable {
+    case configRequirementsNil(String)
+    case installFailed(String)
+    case startFailed(String)
+    case stopFailed(String)
+    case diskCreateFailed(String)
+    case missingFile(String)
+    case unsupportedHost(String)
+
+    public var description: String {
+        switch self {
+        case .configRequirementsNil(let m): return "macruntime.configRequirementsNil: \(m)"
+        case .installFailed(let m): return "macruntime.installFailed: \(m)"
+        case .startFailed(let m): return "macruntime.startFailed: \(m)"
+        case .stopFailed(let m): return "macruntime.stopFailed: \(m)"
+        case .diskCreateFailed(let m): return "macruntime.diskCreateFailed: \(m)"
+        case .missingFile(let m): return "macruntime.missingFile: \(m)"
+        case .unsupportedHost(let m): return "macruntime.unsupportedHost: \(m)"
+        }
+    }
+}
+
+#if canImport(Virtualization)
+/// Holder for a running macOS VM. Created by `MacRuntime.run(...)` once
+/// install has completed (or skipped, if a prior install put the bundle
+/// on disk).
+@available(macOS 13.0, *)
+public final class MacRunningVM: @unchecked Sendable {
+    public let vm: VZVirtualMachine
+    public let queue: DispatchQueue
+    public let delegate: MacVMDelegate
+    public let macAddress: String?
+
+    init(vm: VZVirtualMachine, queue: DispatchQueue, delegate: MacVMDelegate, macAddress: String?) {
+        self.vm = vm
+        self.queue = queue
+        self.delegate = delegate
+        self.macAddress = macAddress
+    }
+}
+
+/// VZVirtualMachineDelegate that surfaces stop / failure events to the
+/// VMInstance via a continuation channel.
+@available(macOS 13.0, *)
+public final class MacVMDelegate: NSObject, VZVirtualMachineDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var stopCallback: ((Error?) -> Void)?
+
+    public func onStop(_ cb: @escaping (Error?) -> Void) {
+        lock.lock(); stopCallback = cb; lock.unlock()
+    }
+
+    public func guestDidStop(_ virtualMachine: VZVirtualMachine) {
+        lock.lock(); let cb = stopCallback; stopCallback = nil; lock.unlock()
+        cb?(nil)
+    }
+
+    public func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
+        lock.lock(); let cb = stopCallback; stopCallback = nil; lock.unlock()
+        cb?(error)
+    }
+}
+#endif
+
+public struct MacRuntime: Sendable {
+
+#if canImport(Virtualization)
+    /// Install macOS into `bundle` using the restore image at `ipswURL`.
+    /// Steps from
+    /// `apple-developer-docs/Virtualization/installing-macos-on-a-virtual-machine.md`:
+    ///   1. Load VZMacOSRestoreImage from local URL.
+    ///   2. Pick the most-featureful hardware model.
+    ///   3. Create VZMacAuxiliaryStorage with that hardware model.
+    ///   4. Create VZMacPlatformConfiguration (hardwareModel + auxiliaryStorage + machineIdentifier).
+    ///   5. Create a VZVirtualMachineConfiguration with the platform + boot loader +
+    ///      disk (block-device attachment), validate, and create the VM.
+    ///   6. Run VZMacOSInstaller.install() and await completion.
+    @available(macOS 13.0, *)
+    public static func install(
+        spec: VMSpec,
+        bundle: VMBundle,
+        ipswURL: URL
+    ) async throws {
+        // Step 1: load the restore image.
+        let restore: VZMacOSRestoreImage
+        do {
+            restore = try await VZMacOSRestoreImage.image(from: ipswURL)
+        } catch {
+            throw MacRuntimeError.missingFile("VZMacOSRestoreImage.image(\(ipswURL.path)): \(error.localizedDescription)")
+        }
+
+        // Step 2: pick the configuration requirements for the host.
+        guard let reqs = restore.mostFeaturefulSupportedConfiguration else {
+            throw MacRuntimeError.unsupportedHost("host supports none of the hardware models in this IPSW")
+        }
+
+        // Bump cpu/memory to the minimums the requirements demand if the
+        // spec asked for less.
+        let cpu = max(spec.cpu, reqs.minimumSupportedCPUCount)
+        let memory = max(spec.memorySize, reqs.minimumSupportedMemorySize)
+
+        // Step 3: AuxiliaryStorage (create new, sized by the hardware model).
+        if FileManager.default.fileExists(atPath: bundle.auxStoragePath.path) {
+            try? FileManager.default.removeItem(at: bundle.auxStoragePath)
+        }
+        do {
+            _ = try VZMacAuxiliaryStorage(
+                creatingStorageAt: bundle.auxStoragePath,
+                hardwareModel: reqs.hardwareModel,
+                options: []
+            )
+        } catch {
+            throw MacRuntimeError.installFailed("VZMacAuxiliaryStorage create: \(error.localizedDescription)")
+        }
+
+        // Persist HardwareModel and MachineIdentifier so subsequent boots
+        // (and clones) reuse the same identity.
+        try (reqs.hardwareModel.dataRepresentation).write(to: bundle.hardwareModelPath, options: .atomic)
+        let machineId = VZMacMachineIdentifier()
+        try machineId.dataRepresentation.write(to: bundle.machineIdPath, options: .atomic)
+
+        // Step 4: VZMacPlatformConfiguration
+        let platform = VZMacPlatformConfiguration()
+        platform.hardwareModel = reqs.hardwareModel
+        platform.machineIdentifier = machineId
+        let aux: VZMacAuxiliaryStorage
+        do {
+            aux = try VZMacAuxiliaryStorage(contentsOf: bundle.auxStoragePath)
+        } catch {
+            throw MacRuntimeError.installFailed("VZMacAuxiliaryStorage reload: \(error.localizedDescription)")
+        }
+        platform.auxiliaryStorage = aux
+
+        // Step 5: Create Disk.img if not present.
+        if !FileManager.default.fileExists(atPath: bundle.diskPath.path) {
+            try createSparseDisk(at: bundle.diskPath, size: spec.diskSize)
+        }
+        let attachment: VZDiskImageStorageDeviceAttachment
+        do {
+            attachment = try VZDiskImageStorageDeviceAttachment(url: bundle.diskPath, readOnly: false)
+        } catch {
+            throw MacRuntimeError.installFailed("VZDiskImageStorageDeviceAttachment: \(error.localizedDescription)")
+        }
+        let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: attachment)
+
+        let config = VZVirtualMachineConfiguration()
+        config.platform = platform
+        config.bootLoader = VZMacOSBootLoader()
+        config.cpuCount = cpu
+        config.memorySize = memory
+        config.storageDevices = [blockDevice]
+        // Minimal networking + graphics for install. Real spec gets
+        // applied during `run()`.
+        if let networkDev = try? VMNetwork.buildNetworkDevices(for: spec) {
+            config.networkDevices = networkDev
+        }
+        config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+
+        do { try config.validate() }
+        catch { throw MacRuntimeError.installFailed("VZVirtualMachineConfiguration.validate: \(error.localizedDescription)") }
+
+        // Step 6: Run the installer.
+        let queue = DispatchQueue(label: "interceptor.vm.\(spec.name).install")
+        let vm = VZVirtualMachine(configuration: config, queue: queue)
+        let installer = VZMacOSInstaller(virtualMachine: vm, restoringFromImageAt: ipswURL)
+        try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Void, Error>) in
+            installer.install { result in
+                switch result {
+                case .success:
+                    cc.resume(returning: ())
+                case .failure(let err):
+                    cc.resume(throwing: MacRuntimeError.installFailed("VZMacOSInstaller.install: \(err.localizedDescription)"))
+                }
+            }
+        }
+    }
+
+    /// Run an already-installed macOS guest. Returns a `MacRunningVM`
+    /// holding the live `VZVirtualMachine`. Caller awaits `vm.start()`.
+    @available(macOS 13.0, *)
+    public static func run(
+        spec: VMSpec,
+        bundle: VMBundle,
+        headless: Bool
+    ) async throws -> MacRunningVM {
+        // Reload platform from disk.
+        let hwData = try Data(contentsOf: bundle.hardwareModelPath)
+        guard let hw = VZMacHardwareModel(dataRepresentation: hwData) else {
+            throw MacRuntimeError.missingFile("HardwareModel data is invalid")
+        }
+        let midData = try Data(contentsOf: bundle.machineIdPath)
+        guard let mid = VZMacMachineIdentifier(dataRepresentation: midData) else {
+            throw MacRuntimeError.missingFile("MachineIdentifier data is invalid")
+        }
+        let aux: VZMacAuxiliaryStorage
+        do {
+            aux = try VZMacAuxiliaryStorage(contentsOf: bundle.auxStoragePath)
+        } catch {
+            throw MacRuntimeError.missingFile("AuxiliaryStorage reload: \(error.localizedDescription)")
+        }
+        let platform = VZMacPlatformConfiguration()
+        platform.hardwareModel = hw
+        platform.machineIdentifier = mid
+        platform.auxiliaryStorage = aux
+
+        let attachment: VZDiskImageStorageDeviceAttachment
+        do {
+            attachment = try VZDiskImageStorageDeviceAttachment(url: bundle.diskPath, readOnly: false)
+        } catch {
+            throw MacRuntimeError.startFailed("VZDiskImageStorageDeviceAttachment: \(error.localizedDescription)")
+        }
+        let blockDevice = VZVirtioBlockDeviceConfiguration(attachment: attachment)
+
+        let config = VZVirtualMachineConfiguration()
+        config.platform = platform
+        config.bootLoader = VZMacOSBootLoader()
+        config.cpuCount = max(spec.cpu, 1)
+        config.memorySize = spec.memorySize
+        config.storageDevices = [blockDevice]
+        let networkDevices = (try? VMNetwork.buildNetworkDevices(for: spec)) ?? []
+        config.networkDevices = networkDevices
+        config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
+        config.socketDevices = [VZVirtioSocketDeviceConfiguration()]  // for guest agent
+        if let shares = try? VMShare.buildDirectorySharingDevices(for: spec) {
+            config.directorySharingDevices = shares
+        }
+        // Graphics: only attach when not headless (to allow framebuffer capture).
+        if !headless {
+            let graphics = VZMacGraphicsDeviceConfiguration()
+            graphics.displays = [VZMacGraphicsDisplayConfiguration(widthInPixels: 1920, heightInPixels: 1080, pixelsPerInch: 220)]
+            config.graphicsDevices = [graphics]
+            config.keyboards = [VZMacKeyboardConfiguration()]
+            config.pointingDevices = [VZMacTrackpadConfiguration()]
+        }
+
+        do { try config.validate() }
+        catch { throw MacRuntimeError.startFailed("VZVirtualMachineConfiguration.validate: \(error.localizedDescription)") }
+
+        let queue = DispatchQueue(label: "interceptor.vm.\(spec.name).run")
+        let vm = VZVirtualMachine(configuration: config, queue: queue)
+        let delegate = MacVMDelegate()
+        vm.delegate = delegate
+
+        return MacRunningVM(vm: vm, queue: queue, delegate: delegate, macAddress: networkDevices.first?.macAddress.string)
+    }
+
+    /// Create a sparse-file-backed disk image of the given size. The
+    /// truncate-to-size trick is how Apple's own macOSVirtualMachineSampleApp
+    /// does it.
+    static func createSparseDisk(at url: URL, size: UInt64) throws {
+        FileManager.default.createFile(atPath: url.path, contents: nil, attributes: nil)
+        let handle: FileHandle
+        do { handle = try FileHandle(forWritingTo: url) }
+        catch { throw MacRuntimeError.diskCreateFailed("open Disk.img: \(error.localizedDescription)") }
+        do {
+            try handle.truncate(atOffset: size)
+            try handle.close()
+        } catch {
+            throw MacRuntimeError.diskCreateFailed("truncate Disk.img to \(size): \(error.localizedDescription)")
+        }
+    }
+#endif
+}

--- a/interceptor-bridge/Sources/VM/VMAdoption.swift
+++ b/interceptor-bridge/Sources/VM/VMAdoption.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+public enum VMAdoptionError: Error, CustomStringConvertible, Sendable {
+    case unsupportedProvider(String)
+    case unsupportedMode(String)
+    case missingFile(String)
+    case invalidConfig(String)
+    case ioFailure(String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedProvider(let m): return "adoption.unsupportedProvider: \(m)"
+        case .unsupportedMode(let m): return "adoption.unsupportedMode: \(m)"
+        case .missingFile(let m): return "adoption.missingFile: \(m)"
+        case .invalidConfig(let m): return "adoption.invalidConfig: \(m)"
+        case .ioFailure(let m): return "adoption.ioFailure: \(m)"
+        }
+    }
+}
+
+struct LumeConfig: Codable, Sendable {
+    var diskSize: UInt64?
+    var memorySize: UInt64?
+    var display: String?
+    var machineIdentifier: String?
+    var cpuCount: Int?
+    var os: String?
+    var macAddress: String?
+    var hardwareModel: String?
+    var networkMode: String?
+}
+
+public struct VMAdoptionResult: Sendable {
+    public var spec: VMSpec
+    public var bundle: VMBundle
+    public var provider: VMProviderKind
+    public var copiedFiles: [String]
+
+    public var asDictionary: [String: Any] {
+        [
+            "name": spec.name,
+            "id": spec.id,
+            "kind": spec.kind.rawValue,
+            "provider": provider.rawValue,
+            "bundlePath": bundle.bundlePath.path,
+            "copiedFiles": copiedFiles,
+            "status": VMStatus.ready.rawValue,
+        ]
+    }
+}
+
+public struct VMAdoption: Sendable {
+    public static func detectProvider(source: URL, requested: String) -> VMProviderKind? {
+        if requested != "auto" {
+            return VMProviderKind(rawValue: requested)
+        }
+        let fm = FileManager.default
+        if fm.fileExists(atPath: source.appendingPathComponent("config.json").path),
+           fm.fileExists(atPath: source.appendingPathComponent("disk.img").path),
+           fm.fileExists(atPath: source.appendingPathComponent("nvram.bin").path) {
+            return .lume
+        }
+        if fm.fileExists(atPath: source.appendingPathComponent("Disk.img").path),
+           fm.fileExists(atPath: source.appendingPathComponent("AuxiliaryStorage").path),
+           fm.fileExists(atPath: source.appendingPathComponent("HardwareModel").path),
+           fm.fileExists(atPath: source.appendingPathComponent("MachineIdentifier").path) {
+            return .appleVZ
+        }
+        return nil
+    }
+
+    public static func adopt(
+        source: URL,
+        name: String,
+        kind: VMKind,
+        requestedProvider: String,
+        mode: VMAdoptMode,
+        registry: VMRegistry
+    ) async throws -> VMAdoptionResult {
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw VMAdoptionError.missingFile(source.path)
+        }
+        guard mode == .clone || mode == .move else {
+            throw VMAdoptionError.unsupportedMode("reference mode is not supported until VMSpec can point runtime files outside the Interceptor bundle")
+        }
+        guard let provider = detectProvider(source: source, requested: requestedProvider) else {
+            throw VMAdoptionError.unsupportedProvider("could not detect provider at \(source.path)")
+        }
+        switch provider {
+        case .lume:
+            return try await adoptLume(source: source, name: name, kind: kind, mode: mode, registry: registry)
+        case .appleVZ:
+            return try await adoptAppleVZ(source: source, name: name, kind: kind, mode: mode, registry: registry)
+        default:
+            throw VMAdoptionError.unsupportedProvider("provider \(provider.rawValue) has no native adoption importer yet")
+        }
+    }
+
+    private static func adoptLume(
+        source: URL,
+        name: String,
+        kind: VMKind,
+        mode: VMAdoptMode,
+        registry: VMRegistry
+    ) async throws -> VMAdoptionResult {
+        guard kind == .macos else {
+            throw VMAdoptionError.invalidConfig("Lume adoption currently supports macOS bundles only")
+        }
+        let configURL = source.appendingPathComponent("config.json")
+        let diskURL = source.appendingPathComponent("disk.img")
+        let nvramURL = source.appendingPathComponent("nvram.bin")
+        let config: LumeConfig
+        do {
+            config = try JSONDecoder().decode(LumeConfig.self, from: Data(contentsOf: configURL))
+        } catch {
+            throw VMAdoptionError.invalidConfig("decode config.json: \(error.localizedDescription)")
+        }
+        guard let hwB64 = config.hardwareModel, let hwData = Data(base64Encoded: hwB64) else {
+            throw VMAdoptionError.invalidConfig("config.json missing base64 hardwareModel")
+        }
+        guard let midB64 = config.machineIdentifier, let midData = Data(base64Encoded: midB64) else {
+            throw VMAdoptionError.invalidConfig("config.json missing base64 machineIdentifier")
+        }
+
+        let spec = VMSpec(
+            name: name,
+            kind: .macos,
+            cpu: config.cpuCount ?? 4,
+            memorySize: config.memorySize ?? UInt64(8 * 1024 * 1024 * 1024),
+            diskSize: config.diskSize ?? UInt64(64 * 1024 * 1024 * 1024),
+            image: "latest",
+            network: (config.networkMode == "none") ? .none : .nat,
+            provider: .lume,
+            sourcePath: source.path,
+            adoptMode: mode,
+            macAddress: config.macAddress
+        )
+        let bundle = try await registry.create(spec)
+        var copied: [String] = []
+        do {
+            try transfer(diskURL, to: bundle.diskPath, mode: mode); copied.append("Disk.img")
+            try transfer(nvramURL, to: bundle.auxStoragePath, mode: mode); copied.append("AuxiliaryStorage")
+            try hwData.write(to: bundle.hardwareModelPath, options: .atomic); copied.append("HardwareModel")
+            try midData.write(to: bundle.machineIdPath, options: .atomic); copied.append("MachineIdentifier")
+        } catch {
+            try? await registry.delete(name)
+            throw VMAdoptionError.ioFailure("copy Lume bundle files: \(error.localizedDescription)")
+        }
+        return VMAdoptionResult(spec: spec, bundle: bundle, provider: .lume, copiedFiles: copied)
+    }
+
+    private static func adoptAppleVZ(
+        source: URL,
+        name: String,
+        kind: VMKind,
+        mode: VMAdoptMode,
+        registry: VMRegistry
+    ) async throws -> VMAdoptionResult {
+        guard kind == .macos else {
+            throw VMAdoptionError.invalidConfig("Apple VZ adoption currently supports macOS bundles only")
+        }
+        let spec = VMSpec(
+            name: name,
+            kind: .macos,
+            cpu: 4,
+            memorySize: UInt64(8 * 1024 * 1024 * 1024),
+            diskSize: UInt64(64 * 1024 * 1024 * 1024),
+            image: "latest",
+            provider: .appleVZ,
+            sourcePath: source.path,
+            adoptMode: mode
+        )
+        let bundle = try await registry.create(spec)
+        let pairs: [(String, URL)] = [
+            ("Disk.img", bundle.diskPath),
+            ("AuxiliaryStorage", bundle.auxStoragePath),
+            ("HardwareModel", bundle.hardwareModelPath),
+            ("MachineIdentifier", bundle.machineIdPath),
+        ]
+        var copied: [String] = []
+        do {
+            for (filename, dst) in pairs {
+                try transfer(source.appendingPathComponent(filename), to: dst, mode: mode)
+                copied.append(filename)
+            }
+        } catch {
+            try? await registry.delete(name)
+            throw VMAdoptionError.ioFailure("copy Apple VZ bundle files: \(error.localizedDescription)")
+        }
+        return VMAdoptionResult(spec: spec, bundle: bundle, provider: .appleVZ, copiedFiles: copied)
+    }
+
+    private static func transfer(_ src: URL, to dst: URL, mode: VMAdoptMode) throws {
+        guard FileManager.default.fileExists(atPath: src.path) else {
+            throw VMAdoptionError.missingFile(src.path)
+        }
+        switch mode {
+        case .clone:
+            try FileManager.default.copyItem(at: src, to: dst)
+        case .move:
+            try FileManager.default.moveItem(at: src, to: dst)
+        case .reference:
+            throw VMAdoptionError.unsupportedMode("reference")
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMConsole.swift
+++ b/interceptor-bridge/Sources/VM/VMConsole.swift
@@ -1,0 +1,49 @@
+// VMConsole
+//
+// Builds a `VZVirtioConsoleDeviceSerialPortConfiguration` and exposes a
+// pipe pair so the bridge can attach an interactive TTY via
+// `interceptor macos vm console <name>`. Apple's serial-port surface:
+// `apple-developer-docs/Virtualization/serial-ports.md` +
+// `VZFileHandleSerialPortAttachment` (file handles in both directions).
+//
+// We keep a single host-side pair of pipes per VM (read end → host stdin
+// for the console session; write end ← host stdout). The VMInstance
+// stores the pair so console sessions can attach and detach.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public struct VMConsoleHandles: Sendable {
+    public let inputForGuest: FileHandle    // host writes here; guest reads
+    public let outputFromGuest: FileHandle   // host reads here; guest writes
+
+    public let inputPipeWriteEnd: FileHandle  // host end of the guest-input pipe
+    public let outputPipeReadEnd: FileHandle  // host end of the guest-output pipe
+}
+
+public struct VMConsole: Sendable {
+#if canImport(Virtualization)
+    @available(macOS 11.0, *)
+    public static func buildSerialPort() -> (config: VZSerialPortConfiguration, handles: VMConsoleHandles) {
+        // host→guest pipe: bridge writes to inputPipeWriteEnd, guest reads inputForGuest
+        let guestInputPipe = Pipe()
+        // guest→host pipe: guest writes outputFromGuest, bridge reads outputPipeReadEnd
+        let guestOutputPipe = Pipe()
+        let attachment = VZFileHandleSerialPortAttachment(
+            fileHandleForReading: guestInputPipe.fileHandleForReading,
+            fileHandleForWriting: guestOutputPipe.fileHandleForWriting
+        )
+        let serial = VZVirtioConsoleDeviceSerialPortConfiguration()
+        serial.attachment = attachment
+        let handles = VMConsoleHandles(
+            inputForGuest: guestInputPipe.fileHandleForReading,
+            outputFromGuest: guestOutputPipe.fileHandleForWriting,
+            inputPipeWriteEnd: guestInputPipe.fileHandleForWriting,
+            outputPipeReadEnd: guestOutputPipe.fileHandleForReading
+        )
+        return (serial, handles)
+    }
+#endif
+}

--- a/interceptor-bridge/Sources/VM/VMImage.swift
+++ b/interceptor-bridge/Sources/VM/VMImage.swift
@@ -1,0 +1,134 @@
+// VMImage
+//
+// Image resolution for both guest kinds.
+//
+// macOS: download an IPSW. Implementation calls `VZMacOSRestoreImage.latestSupported`
+// (async, macOS 12+; see
+// `apple-developer-docs/Virtualization/VZMacOSRestoreImage.md:5,28-30`)
+// to fetch the latest supported restore image URL, then
+// `URLSession.shared.download(from:)` to write it to
+// `<state>/images/macos/<build>.ipsw`. Re-uses an already-downloaded
+// IPSW when present (digest-checked by name only — Apple's restore-image
+// download API does not expose a hash, so we trust the filename).
+//
+// Linux: pull an OCI image via Containerization's image registry
+// surface. Cached under `<state>/images/oci/` so VM bundles and cached
+// image content remain colocated under the configured state directory.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public enum VMImageError: Error, CustomStringConvertible, Sendable {
+    case downloadFailed(String)
+    case unsupportedKind(String)
+    case missingHost(String)
+    case missingFile(String)
+
+    public var description: String {
+        switch self {
+        case .downloadFailed(let m): return "image.downloadFailed: \(m)"
+        case .unsupportedKind(let m): return "image.unsupportedKind: \(m)"
+        case .missingHost(let m): return "image.missingHost: \(m)"
+        case .missingFile(let m): return "image.missingFile: \(m)"
+        }
+    }
+}
+
+/// Top-level helper for resolving and downloading the artifacts a
+/// VMSpec.image refers to. Pure functions; state lives in `VMRegistry`.
+public struct VMImage: Sendable {
+
+    /// Directory under which downloaded images live. Lives next to vms/
+    /// inside the state dir so external tools can introspect.
+    public static func imagesDir(stateDir: URL) -> URL {
+        stateDir.appendingPathComponent("images", isDirectory: true)
+    }
+
+    public static func macosImagesDir(stateDir: URL) -> URL {
+        imagesDir(stateDir: stateDir).appendingPathComponent("macos", isDirectory: true)
+    }
+
+    public static func ociImagesDir(stateDir: URL) -> URL {
+        imagesDir(stateDir: stateDir).appendingPathComponent("oci", isDirectory: true)
+    }
+
+    /// Ensure both subdirs exist.
+    public static func ensureImageDirs(stateDir: URL) throws {
+        for d in [imagesDir(stateDir: stateDir), macosImagesDir(stateDir: stateDir), ociImagesDir(stateDir: stateDir)] {
+            var isDir: ObjCBool = false
+            if !FileManager.default.fileExists(atPath: d.path, isDirectory: &isDir) {
+                try FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+            }
+        }
+    }
+
+#if canImport(Virtualization)
+    /// Resolve a macOS restore image. If `imageSpec == "latest"`, calls
+    /// `VZMacOSRestoreImage.latestSupported`, downloads the file to
+    /// `<state>/images/macos/<build>.ipsw`, and returns the local URL.
+    /// Otherwise expects an absolute path to an existing .ipsw.
+    public static func resolveMacOSImage(spec imageSpec: String, stateDir: URL) async throws -> URL {
+        try ensureImageDirs(stateDir: stateDir)
+        if imageSpec.hasSuffix(".ipsw") {
+            let url = URL(fileURLWithPath: (imageSpec as NSString).expandingTildeInPath)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw VMImageError.missingFile(url.path)
+            }
+            return url
+        }
+        guard imageSpec == "latest" else {
+            throw VMImageError.unsupportedKind("macos image must be a .ipsw path or 'latest'")
+        }
+        let restoreImage: VZMacOSRestoreImage
+        do {
+            restoreImage = try await VZMacOSRestoreImage.latestSupported
+        } catch {
+            throw VMImageError.downloadFailed("VZMacOSRestoreImage.latestSupported: \(error.localizedDescription)")
+        }
+        let remote = restoreImage.url
+        let buildId = restoreImage.buildVersion
+        let localURL = macosImagesDir(stateDir: stateDir).appendingPathComponent("\(buildId).ipsw")
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            return localURL
+        }
+        // download to a temp file then atomic-move into place
+        let (tmpURL, _): (URL, URLResponse)
+        do {
+            (tmpURL, _) = try await URLSession.shared.download(from: remote)
+        } catch {
+            throw VMImageError.downloadFailed("download \(remote.absoluteString): \(error.localizedDescription)")
+        }
+        do {
+            try FileManager.default.moveItem(at: tmpURL, to: localURL)
+        } catch {
+            throw VMImageError.downloadFailed("move IPSW into place: \(error.localizedDescription)")
+        }
+        return localURL
+    }
+
+    /// `mostFeaturefulSupportedConfiguration` for a given IPSW. Used by
+    /// `MacRuntime` to pick the hardware model + minimum CPU/memory.
+    public static func loadRestoreImage(at url: URL) async throws -> VZMacOSRestoreImage {
+        do {
+            return try await VZMacOSRestoreImage.image(from: url)
+        } catch {
+            throw VMImageError.missingFile("VZMacOSRestoreImage.image(from: \(url.path)): \(error.localizedDescription)")
+        }
+    }
+#endif
+
+    /// Resolve an OCI image reference to a local cached path. Linux runtime.
+    /// In v0 we keep this thin — the real pull is delegated to the
+    /// Containerization OCI client inside `LinuxRuntime.prepare(...)`,
+    /// which writes the rootfs into the state dir. This helper exists
+    /// so `vm pull <ref>` has a clear ack path.
+    public static func resolveOCIImage(ref: String, stateDir: URL) async throws -> URL {
+        try ensureImageDirs(stateDir: stateDir)
+        // Sanitize the ref for filesystem use.
+        let safe = ref.replacingOccurrences(of: "/", with: "_")
+                      .replacingOccurrences(of: ":", with: "_")
+        return ociImagesDir(stateDir: stateDir).appendingPathComponent("\(safe)", isDirectory: true)
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMInstance.swift
+++ b/interceptor-bridge/Sources/VM/VMInstance.swift
@@ -1,0 +1,419 @@
+// VMInstance
+//
+// One actor per running VM. Owns:
+//   - the spec (read mostly; mutated under registry control)
+//   - the runtime handle (LinuxRuntimeHandle or MacRunningVM)
+//   - the GuestAgent (vsock)
+//   - lifecycle state machine transitions
+//
+// The state machine is the same one in design notes. Transitions are
+// serialized through the actor's mailbox so two `vm start` requests on
+// the same VM never race.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public enum VMInstanceError: Error, CustomStringConvertible, Sendable {
+    case invalidTransition(String)
+    case alreadyStarted(String)
+    case notStarted(String)
+    case runtimeUnavailable(String)
+    case timeout(String)
+
+    public var description: String {
+        switch self {
+        case .invalidTransition(let m): return "vm.invalidTransition: \(m)"
+        case .alreadyStarted(let m): return "vm.alreadyStarted: \(m)"
+        case .notStarted(let m): return "vm.notStarted: \(m)"
+        case .runtimeUnavailable(let m): return "vm.runtimeUnavailable: \(m)"
+        case .timeout(let m): return "vm.timeout: \(m)"
+        }
+    }
+}
+
+/// Result of `start()` so callers can read the current state cheaply.
+public struct VMStartResult: Sendable {
+    public let status: VMStatus
+    public let transitionMs: Int
+    public let ipAddress: String?
+}
+
+public actor VMInstance {
+    public let bundle: VMBundle
+    public private(set) var spec: VMSpec
+    public private(set) var status: VMStatus
+    public private(set) var lastError: String?
+    public private(set) var ipAddress: String?
+
+    // Held only when running. Cleared on stop.
+    private var linuxRuntime: LinuxRuntimeHandle?
+    private var guestAgent: (any GuestAgent)?
+
+#if canImport(Virtualization)
+    private var macVM: MacRunningVM?
+#endif
+
+    public init(spec: VMSpec, bundle: VMBundle, status: VMStatus = .ready) {
+        self.spec = spec
+        self.bundle = bundle
+        self.status = status
+    }
+
+    /// `vm start` — boot the guest. Transitions ready → starting → running.
+    /// `waitForVsock` blocks the start call until the guest agent connects.
+    public func start(headless: Bool, waitForVsock: Bool) async throws -> VMStartResult {
+        let begin = Date()
+        switch status {
+        case .running, .paused, .starting, .stopping, .savingSnapshot, .restoringSnapshot:
+            throw VMInstanceError.alreadyStarted("VM '\(spec.name)' is in state .\(status.rawValue)")
+        default:
+            break
+        }
+        status = .starting
+        do {
+            switch spec.kind {
+            case .linux:
+                let rt = try await LinuxRuntime.prepare(spec: spec, bundle: bundle)
+                try await rt.create()
+                try await rt.start()
+                linuxRuntime = rt
+                ipAddress = await rt.ipAddress()
+            case .macos:
+                #if canImport(Virtualization)
+                if #available(macOS 13.0, *) {
+                    let mvm = try await MacRuntime.run(spec: spec, bundle: bundle, headless: headless)
+                    // Bridge start(completionHandler:) into async.
+                    try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Void, Error>) in
+                        mvm.queue.async {
+                            mvm.vm.start { result in
+                                switch result {
+                                case .success:
+                                    cc.resume(returning: ())
+                                case .failure(let err):
+                                    cc.resume(throwing: VMInstanceError.invalidTransition("VZVirtualMachine.start: \(err.localizedDescription)"))
+                                }
+                            }
+                        }
+                    }
+                    macVM = mvm
+                    ipAddress = await Self.waitForBridge100IPAddress(macAddress: mvm.macAddress, timeout: waitForVsock ? 30 : 3)
+                    let fallbackIPAddress = ipAddress
+                    // GuestAgent (vsock) attach. The first socketDevice is
+                    // the one we configured in MacRuntime.run.
+                    let agent: VsockGuestAgent? = await withCheckedContinuation { cc in
+                        mvm.queue.async {
+                            let socketDevice = mvm.vm.socketDevices.first as? VZVirtioSocketDevice
+                            cc.resume(returning: socketDevice.map { VsockGuestAgent(socketDevice: $0, connectQueue: mvm.queue, tcpFallbackHost: fallbackIPAddress) })
+                        }
+                    }
+                    if let agent {
+                        if waitForVsock {
+                            do {
+                                try await agent.connect(timeout: 60)
+                                self.guestAgent = agent
+                            } catch {
+                                // boot succeeded; agent not up — still
+                                // a running VM. Keep the agent handle so
+                                // later guest verbs can retry after login
+                                // items / LaunchAgents finish starting.
+                                self.guestAgent = agent
+                                self.lastError = "vsock connect: \(error.localizedDescription)"
+                            }
+                        } else {
+                            self.guestAgent = agent  // lazy connect on first use
+                        }
+                    }
+                } else {
+                    throw VMInstanceError.runtimeUnavailable("macOS guests require macOS 13+ host")
+                }
+                #else
+                throw VMInstanceError.runtimeUnavailable("Virtualization framework not available")
+                #endif
+            }
+            status = .running
+            spec.startedAt = Date()
+            let elapsed = Int(Date().timeIntervalSince(begin) * 1000)
+            return VMStartResult(status: status, transitionMs: elapsed, ipAddress: ipAddress)
+        } catch {
+            status = .error
+            lastError = "\(error)"
+            throw error
+        }
+    }
+
+    /// `vm stop` — graceful (requestStop / container.stop) or forceful
+    /// (VZVirtualMachine.stop / container.kill SIGKILL).
+    public func stop(force: Bool, timeout: TimeInterval) async throws {
+        let begin = Date()
+        guard status == .running || status == .paused else {
+            // already stopped — no-op
+            if status == .stopped { return }
+            throw VMInstanceError.notStarted("VM '\(spec.name)' is in state .\(status.rawValue)")
+        }
+        status = .stopping
+        if force {
+            try await forceStop()
+        } else {
+            try await gracefulStop(timeout: timeout)
+        }
+        // tear down agent
+        await guestAgent?.disconnect()
+        guestAgent = nil
+        linuxRuntime = nil
+        #if canImport(Virtualization)
+        macVM = nil
+        #endif
+        status = .stopped
+        let _ = Date().timeIntervalSince(begin)
+    }
+
+    public func pause() async throws {
+        guard status == .running else {
+            throw VMInstanceError.invalidTransition(".\(status.rawValue) → .paused not allowed")
+        }
+        #if canImport(Virtualization)
+        if let mvm = macVM {
+            try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Void, Error>) in
+                mvm.queue.async {
+                    mvm.vm.pause { result in
+                        switch result {
+                        case .success: cc.resume(returning: ())
+                        case .failure(let e): cc.resume(throwing: VMInstanceError.invalidTransition("pause: \(e.localizedDescription)"))
+                        }
+                    }
+                }
+            }
+            status = .paused
+            return
+        }
+        #endif
+        // Linux: Containerization exposes pause via container API once
+        // the package resolves; until then return clean error.
+        throw VMInstanceError.invalidTransition("pause for Linux guests pending Containerization 0.31.0 resolution")
+    }
+
+    public func resume() async throws {
+        guard status == .paused else {
+            throw VMInstanceError.invalidTransition(".\(status.rawValue) → .running not allowed")
+        }
+        #if canImport(Virtualization)
+        if let mvm = macVM {
+            try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Void, Error>) in
+                mvm.queue.async {
+                    mvm.vm.resume { result in
+                        switch result {
+                        case .success: cc.resume(returning: ())
+                        case .failure(let e): cc.resume(throwing: VMInstanceError.invalidTransition("resume: \(e.localizedDescription)"))
+                        }
+                    }
+                }
+            }
+            status = .running
+            return
+        }
+        #endif
+        throw VMInstanceError.invalidTransition("resume for Linux guests pending Containerization 0.31.0 resolution")
+    }
+
+    public func exec(argv: [String], env: [String: String], workdir: String?, tty: Bool, timeout: TimeInterval) async throws -> (exitCode: Int32, stdout: String, stderr: String, durationMs: Int) {
+        guard status == .running else {
+            throw VMInstanceError.notStarted("vm '\(spec.name)' is .\(status.rawValue)")
+        }
+        if let agent = guestAgent {
+            return try await agent.exec(argv, env: env, workdir: workdir, tty: tty, timeout: timeout)
+        }
+        if let rt = linuxRuntime {
+            let r = try await rt.execve(argv, env: env, workdir: workdir, tty: tty)
+            return (r.exitCode, r.stdout, r.stderr, 0)
+        }
+        throw VMInstanceError.runtimeUnavailable("no guest agent or runtime to exec into")
+    }
+
+    public func requestGuest(action: GuestAgentDict, timeout: TimeInterval) async throws -> GuestAgentDict {
+        guard status == .running else {
+            throw VMInstanceError.notStarted("vm '\(spec.name)' is .\(status.rawValue)")
+        }
+        guard let agent = guestAgent else {
+            throw VMInstanceError.runtimeUnavailable("no guest agent connected")
+        }
+        #if canImport(Virtualization)
+        if #available(macOS 13.0, *), let vsockAgent = agent as? VsockGuestAgent {
+            if ipAddress == nil {
+                ipAddress = await Self.waitForBridge100IPAddress(macAddress: macVM?.macAddress, timeout: 5)
+            }
+            vsockAgent.setTCPFallbackHost(ipAddress)
+        }
+        #endif
+        try await agent.connect(timeout: min(timeout, 30))
+        return try await agent.request(action, timeout: timeout)
+    }
+
+    public func createSnapshot(tag: String, mode: VMSnapshot.Mode) async throws -> VMSnapshotManifest {
+        #if canImport(Virtualization)
+        if #available(macOS 14.0, *), let mvm = macVM {
+            guard status == .paused || mode == .diskOnly else {
+                throw VMInstanceError.invalidTransition("paused-state snapshots require the VM to be paused")
+            }
+            return try await VMSnapshot.create(vm: mvm.vm, bundle: bundle, tag: tag, mode: mode)
+        }
+        #endif
+        throw VMInstanceError.runtimeUnavailable("paused-state snapshots require macOS 14+ and a running macOS VM")
+    }
+
+    public func current() -> VMSpec { spec }
+
+    // MARK: - private helpers
+
+    private static func waitForBridge100IPAddress(macAddress: String?, timeout: TimeInterval) async -> String? {
+        let deadline = Date().addingTimeInterval(max(timeout, 0))
+        while true {
+            if let ip = bridge100IPAddress(macAddress: macAddress) {
+                return ip
+            }
+            if timeout <= 0 || Date() >= deadline {
+                return nil
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+    }
+
+    private static func bridge100IPAddress(macAddress: String?) -> String? {
+        if let output = processOutput("/usr/sbin/arp", args: ["-an"]),
+           let ip = parseARPBridge100(output, macAddress: macAddress) {
+            return ip
+        }
+        if let macAddress,
+           let leases = try? String(contentsOfFile: "/var/db/dhcpd_leases", encoding: .utf8),
+           let ip = parseDHCPLeases(leases, macAddress: macAddress) {
+            return ip
+        }
+        return nil
+    }
+
+    private static func parseARPBridge100(_ output: String, macAddress: String?) -> String? {
+        let targetMac = macAddress.map(normalizedMAC)
+        for rawLine in output.split(separator: "\n") {
+            let line = String(rawLine)
+            let lower = line.lowercased()
+            guard lower.contains(" on bridge100"), !lower.contains("permanent") else { continue }
+            guard let ipRange = line.range(of: #"(?<=\()192\.168\.64\.\d+(?=\))"#, options: .regularExpression) else { continue }
+            let ip = String(line[ipRange])
+            guard ip != "192.168.64.1" else { continue }
+            if let targetMac {
+                guard let observedMac = arpMACAddress(from: line), normalizedMAC(observedMac) == targetMac else { continue }
+            }
+            return ip
+        }
+        return nil
+    }
+
+    private static func parseDHCPLeases(_ leases: String, macAddress: String) -> String? {
+        let targetMac = normalizedMAC(macAddress)
+        var currentIP: String?
+        for rawLine in leases.split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("ip_address=") {
+                currentIP = String(line.dropFirst("ip_address=".count))
+            } else if line.hasPrefix("hw_address=1,") {
+                let observed = String(line.dropFirst("hw_address=1,".count))
+                if normalizedMAC(observed) == targetMac {
+                    return currentIP
+                }
+            } else if line == "}" {
+                currentIP = nil
+            }
+        }
+        return nil
+    }
+
+    private static func arpMACAddress(from line: String) -> String? {
+        guard let start = line.range(of: " at "),
+              let end = line.range(of: " on bridge100", range: start.upperBound..<line.endIndex) else {
+            return nil
+        }
+        return String(line[start.upperBound..<end.lowerBound])
+    }
+
+    private static func normalizedMAC(_ macAddress: String) -> String {
+        macAddress
+            .lowercased()
+            .split(separator: ":")
+            .map { byte -> String in
+                let trimmed = byte.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let value = Int(trimmed, radix: 16) else { return trimmed }
+                return String(value, radix: 16)
+            }
+            .joined(separator: ":")
+    }
+
+    private static func processOutput(_ executable: String, args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        let stdoutPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func gracefulStop(timeout: TimeInterval) async throws {
+        #if canImport(Virtualization)
+        if let mvm = macVM {
+            // VZVirtualMachine.requestStop() asks the guest OS to shutdown.
+            // We then poll the delegate's stop callback up to `timeout`.
+            let result: Error? = try? await withCheckedThrowingContinuation { (cc: CheckedContinuation<Error?, Error>) in
+                mvm.delegate.onStop { err in cc.resume(returning: err) }
+                mvm.queue.async {
+                    do {
+                        try mvm.vm.requestStop()
+                    } catch {
+                        cc.resume(throwing: VMInstanceError.invalidTransition("requestStop: \(error.localizedDescription)"))
+                    }
+                }
+            }
+            if let err = result {
+                throw VMInstanceError.invalidTransition("guest stop error: \(err.localizedDescription)")
+            }
+            return
+        }
+        #endif
+        if let rt = linuxRuntime {
+            try await rt.stop()
+        }
+    }
+
+    private func forceStop() async throws {
+        #if canImport(Virtualization)
+        if let mvm = macVM {
+            // VZVirtualMachine.stop(completionHandler:) takes (Error?) -> Void
+            // — not a Result. Bridge it into the throwing async surface
+            // by checking the optional.
+            try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Void, Error>) in
+                mvm.queue.async {
+                    mvm.vm.stop { err in
+                        if let err = err {
+                            cc.resume(throwing: VMInstanceError.invalidTransition("force stop: \(err.localizedDescription)"))
+                        } else {
+                            cc.resume(returning: ())
+                        }
+                    }
+                }
+            }
+            return
+        }
+        #endif
+        if let rt = linuxRuntime {
+            try await rt.kill(signal: 9)
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMNetwork.swift
+++ b/interceptor-bridge/Sources/VM/VMNetwork.swift
@@ -1,0 +1,56 @@
+// VMNetwork
+//
+// Builds a `VZVirtioNetworkDeviceConfiguration` from a VMSpec.
+//
+// Interceptor ships **NAT only** — `VZNATNetworkDeviceAttachment`
+// (apple-developer-docs/Virtualization/VZNATNetworkDeviceAttachment.md).
+// NAT requires only `com.apple.security.virtualization`, which the bridge
+// already carries.
+//
+// Bridged + vmnet attachments are intentionally not implemented. They would
+// require `com.apple.vm.networking`, which Apple restricts to vetted
+// virtualization-software vendors via a private allowlist. If that scope
+// ever changes, the path is: re-add the entitlement to
+// `scripts/entitlements-bridge.plist`, then layer the additional cases on
+// top of this switch.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public enum VMNetworkError: Error, CustomStringConvertible, Sendable {
+    case unsupportedMode(String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedMode(let m): return "network.unsupportedMode: \(m)"
+        }
+    }
+}
+
+public struct VMNetwork: Sendable {
+#if canImport(Virtualization)
+    /// Builds the network device list for a VMSpec. Returns an empty array
+    /// when `network == .none` (e.g. for sandboxed test VMs that should
+    /// have no external connectivity).
+    @available(macOS 11.0, *)
+    public static func buildNetworkDevices(
+        for spec: VMSpec
+    ) throws -> [VZVirtioNetworkDeviceConfiguration] {
+        switch spec.network {
+        case .none:
+            return []
+        case .nat:
+            let dev = VZVirtioNetworkDeviceConfiguration()
+            if let configured = spec.macAddress, let mac = VZMACAddress(string: configured) {
+                dev.macAddress = mac
+            } else {
+                dev.macAddress = VZMACAddress.randomLocallyAdministered()
+            }
+            dev.attachment = VZNATNetworkDeviceAttachment()
+            return [dev]
+        }
+    }
+#endif
+}

--- a/interceptor-bridge/Sources/VM/VMRegistry.swift
+++ b/interceptor-bridge/Sources/VM/VMRegistry.swift
@@ -1,0 +1,305 @@
+// VMRegistry
+//
+// Owns the on-disk layout of every VM. Single source of truth for "what VMs
+// exist on this host". Persists `registry.json` (index of names→ids) and a
+// per-VM `<name>.bundle/spec.json` (the VMSpec).
+//
+// State directory resolution order (first hit wins):
+//   1. action["stateDir"] passed by the CLI (per-invocation override).
+//   2. $INTERCEPTOR_VM_STATE_DIR environment variable.
+//   3. $CWD/.interceptor/vms/   (default, matches the existing
+//      .container-data/ pattern at the project root for Apple's container.)
+//
+// Bundle layout matches Apple's `VM.bundle` format from
+// `apple-developer-docs/Virtualization/running-macos-in-a-virtual-machine-on-apple-silicon.md:21-32`:
+//
+//   <state>/vms/registry.json
+//   <state>/vms/<name>.bundle/
+//       spec.json
+//       Disk.img
+//       AuxiliaryStorage          (macOS only)
+//       MachineIdentifier         (macOS only)
+//       HardwareModel             (macOS only)
+//       RestoreImage.ipsw         (macOS only; optional)
+//       snapshots/<tag>/SaveFile.vzvmsave
+//       snapshots/<tag>/manifest.json
+
+import Foundation
+
+/// Filesystem layout helper for a single VM bundle. All paths are computed,
+/// not stored — re-derive from `state` + `name` so a moved state dir always
+/// produces consistent paths.
+public struct VMBundle: Sendable {
+    public let stateDir: URL
+    public let name: String
+
+    public var bundlePath: URL { stateDir.appendingPathComponent("vms/\(name).bundle", isDirectory: true) }
+    public var specPath: URL { bundlePath.appendingPathComponent("spec.json") }
+    public var diskPath: URL { bundlePath.appendingPathComponent("Disk.img") }
+    public var auxStoragePath: URL { bundlePath.appendingPathComponent("AuxiliaryStorage") }
+    public var machineIdPath: URL { bundlePath.appendingPathComponent("MachineIdentifier") }
+    public var hardwareModelPath: URL { bundlePath.appendingPathComponent("HardwareModel") }
+    public var restoreImagePath: URL { bundlePath.appendingPathComponent("RestoreImage.ipsw") }
+    public var snapshotsDir: URL { bundlePath.appendingPathComponent("snapshots", isDirectory: true) }
+
+    public func snapshotDir(tag: String) -> URL { snapshotsDir.appendingPathComponent(tag, isDirectory: true) }
+    public func snapshotFile(tag: String) -> URL { snapshotDir(tag: tag).appendingPathComponent("SaveFile.vzvmsave") }
+    public func snapshotManifest(tag: String) -> URL { snapshotDir(tag: tag).appendingPathComponent("manifest.json") }
+}
+
+/// Top-level registry index. Kept tiny so the lock window is short.
+struct VMRegistryIndex: Codable, Sendable {
+    var version: Int                    // bump when the on-disk shape changes
+    var entries: [String: String]       // name → id
+
+    static let current: Int = 1
+    static let empty = VMRegistryIndex(version: VMRegistryIndex.current, entries: [:])
+}
+
+public enum VMRegistryError: Error, CustomStringConvertible, Sendable {
+    case duplicateName(String)
+    case notFound(String)
+    case ioFailure(String)
+    case corruptIndex(String)
+    case bundleMissing(String)
+
+    public var description: String {
+        switch self {
+        case .duplicateName(let n): return "registry.duplicateName: '\(n)' already exists"
+        case .notFound(let n): return "registry.notFound: '\(n)'"
+        case .ioFailure(let m): return "registry.ioFailure: \(m)"
+        case .corruptIndex(let m): return "registry.corruptIndex: \(m)"
+        case .bundleMissing(let n): return "registry.bundleMissing: '\(n)' has no on-disk bundle"
+        }
+    }
+}
+
+/// Async actor that owns the registry. Every read/write is serialized
+/// through the actor's mailbox so concurrent verbs cannot tear the index.
+public actor VMRegistry {
+    private let stateDir: URL
+    private let indexURL: URL
+    private let fm = FileManager.default
+
+    public init(stateDir: URL) throws {
+        self.stateDir = stateDir
+        self.indexURL = stateDir.appendingPathComponent("vms/registry.json")
+        try Self.ensureDirectory(stateDir.appendingPathComponent("vms"))
+    }
+
+    /// Resolve the state directory using the precedence order documented at
+    /// the top of this file.
+    public static func resolveStateDir(actionOverride: String? = nil) -> URL {
+        if let s = actionOverride, !s.isEmpty {
+            return URL(fileURLWithPath: (s as NSString).expandingTildeInPath)
+        }
+        if let envS = ProcessInfo.processInfo.environment["INTERCEPTOR_VM_STATE_DIR"], !envS.isEmpty {
+            return URL(fileURLWithPath: (envS as NSString).expandingTildeInPath)
+        }
+        let cwd = FileManager.default.currentDirectoryPath
+        return URL(fileURLWithPath: cwd).appendingPathComponent(".interceptor", isDirectory: true)
+    }
+
+    /// Create the directory if missing; no-op if it exists.
+    private static func ensureDirectory(_ url: URL) throws {
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) {
+            if !isDir.boolValue {
+                throw VMRegistryError.ioFailure("\(url.path) exists but is not a directory")
+            }
+            return
+        }
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Index I/O
+
+    private func readIndex() throws -> VMRegistryIndex {
+        guard fm.fileExists(atPath: indexURL.path) else {
+            return .empty
+        }
+        let data: Data
+        do { data = try Data(contentsOf: indexURL) }
+        catch { throw VMRegistryError.ioFailure("read registry.json: \(error.localizedDescription)") }
+        guard !data.isEmpty else { return .empty }
+        do {
+            return try JSONDecoder().decode(VMRegistryIndex.self, from: data)
+        } catch {
+            throw VMRegistryError.corruptIndex("decode registry.json: \(error.localizedDescription)")
+        }
+    }
+
+    private func writeIndex(_ index: VMRegistryIndex) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data: Data
+        do { data = try enc.encode(index) }
+        catch { throw VMRegistryError.ioFailure("encode registry.json: \(error.localizedDescription)") }
+        // atomic write so a crash mid-write can't corrupt the index.
+        do {
+            try data.write(to: indexURL, options: .atomic)
+        } catch {
+            throw VMRegistryError.ioFailure("write registry.json: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Spec I/O
+
+    private func readSpec(at url: URL) throws -> VMSpec {
+        guard fm.fileExists(atPath: url.path) else {
+            throw VMRegistryError.bundleMissing(url.path)
+        }
+        let data: Data
+        do { data = try Data(contentsOf: url) }
+        catch { throw VMRegistryError.ioFailure("read spec.json: \(error.localizedDescription)") }
+        do {
+            let dec = JSONDecoder()
+            dec.dateDecodingStrategy = .iso8601
+            return try dec.decode(VMSpec.self, from: data)
+        } catch {
+            throw VMRegistryError.corruptIndex("decode spec.json: \(error.localizedDescription)")
+        }
+    }
+
+    private func writeSpec(_ spec: VMSpec, to url: URL) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        enc.dateEncodingStrategy = .iso8601
+        let data: Data
+        do { data = try enc.encode(spec) }
+        catch { throw VMRegistryError.ioFailure("encode spec.json: \(error.localizedDescription)") }
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw VMRegistryError.ioFailure("write spec.json: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Public surface
+
+    public func bundle(for name: String) -> VMBundle {
+        VMBundle(stateDir: stateDir, name: name)
+    }
+
+    /// Atomically create a new VM entry. Throws `duplicateName` if a VM
+    /// with the same name already exists in the index.
+    public func create(_ spec: VMSpec) throws -> VMBundle {
+        try spec.validateStatic()
+        var index = try readIndex()
+        if index.entries[spec.name] != nil {
+            throw VMRegistryError.duplicateName(spec.name)
+        }
+        let bundle = VMBundle(stateDir: stateDir, name: spec.name)
+        try Self.ensureDirectory(bundle.bundlePath)
+        try Self.ensureDirectory(bundle.snapshotsDir)
+        try writeSpec(spec, to: bundle.specPath)
+        index.entries[spec.name] = spec.id
+        try writeIndex(index)
+        return bundle
+    }
+
+    public func get(_ name: String) throws -> VMSpec {
+        let bundle = VMBundle(stateDir: stateDir, name: name)
+        let index = try readIndex()
+        guard index.entries[name] != nil else {
+            throw VMRegistryError.notFound(name)
+        }
+        return try readSpec(at: bundle.specPath)
+    }
+
+    public func list() throws -> [VMSpec] {
+        let index = try readIndex()
+        var out: [VMSpec] = []
+        out.reserveCapacity(index.entries.count)
+        for (name, _) in index.entries.sorted(by: { $0.key < $1.key }) {
+            let bundle = VMBundle(stateDir: stateDir, name: name)
+            // Be lenient: if a bundle has been hand-deleted but the index
+            // still references it, skip rather than crash the entire list.
+            guard fm.fileExists(atPath: bundle.specPath.path) else { continue }
+            do {
+                out.append(try readSpec(at: bundle.specPath))
+            } catch {
+                // skip corrupt specs but log via Platform in production
+                continue
+            }
+        }
+        return out
+    }
+
+    /// Update an existing spec (e.g. after `vm start` sets `startedAt`).
+    public func update(_ spec: VMSpec) throws {
+        let index = try readIndex()
+        guard index.entries[spec.name] != nil else {
+            throw VMRegistryError.notFound(spec.name)
+        }
+        let bundle = VMBundle(stateDir: stateDir, name: spec.name)
+        try writeSpec(spec, to: bundle.specPath)
+    }
+
+    /// Remove a VM atomically — drop from index and rm-rf the bundle dir.
+    /// Pre-condition: caller has already stopped the VM (VMInstance is gone).
+    public func delete(_ name: String, keepDisk: Bool = false) throws {
+        var index = try readIndex()
+        guard index.entries[name] != nil else {
+            throw VMRegistryError.notFound(name)
+        }
+        let bundle = VMBundle(stateDir: stateDir, name: name)
+        index.entries.removeValue(forKey: name)
+        try writeIndex(index)
+        // remove the bundle dir; if `keepDisk` is set, move it aside
+        // instead so the user can recover. Apple's container `delete`
+        // verb has no equivalent flag — we add this because manual disk
+        // resize via tools outside Interceptor is a common workflow.
+        if keepDisk {
+            let kept = stateDir.appendingPathComponent("vms/\(name).orphan-\(Int(Date().timeIntervalSince1970)).bundle")
+            try? fm.moveItem(at: bundle.bundlePath, to: kept)
+        } else {
+            try? fm.removeItem(at: bundle.bundlePath)
+        }
+    }
+
+    /// APFS clone-from-gold. Uses `clonefile(2)` for instant CoW copy of
+    /// Disk.img + aux. Caller is expected to pass a fresh
+    /// `VZMacMachineIdentifier` for macOS guests so the clone doesn't
+    /// collide with the source.
+    ///
+    /// We use `FileManager.copyItem(at:to:)` which transparently invokes
+    /// `clonefile(2)` on APFS volumes per Apple's documentation. No need
+    /// to drop to the BSD syscall directly.
+    public func clone(from srcName: String, to dstName: String) throws -> VMBundle {
+        var index = try readIndex()
+        guard let _ = index.entries[srcName] else {
+            throw VMRegistryError.notFound(srcName)
+        }
+        if index.entries[dstName] != nil {
+            throw VMRegistryError.duplicateName(dstName)
+        }
+        let srcBundle = VMBundle(stateDir: stateDir, name: srcName)
+        let dstBundle = VMBundle(stateDir: stateDir, name: dstName)
+        // Read the source spec, rebrand under the new name, write to dst.
+        var srcSpec = try readSpec(at: srcBundle.specPath)
+        srcSpec.name = dstName
+        srcSpec.id = UUID().uuidString
+        srcSpec.startedAt = nil
+        // Create dst dir then copy each file individually. We avoid
+        // copyItem(at:bundleDir) because that recurses through snapshots/
+        // which we want to omit from clones.
+        try Self.ensureDirectory(dstBundle.bundlePath)
+        try Self.ensureDirectory(dstBundle.snapshotsDir)
+        try writeSpec(srcSpec, to: dstBundle.specPath)
+        for filename in ["Disk.img", "AuxiliaryStorage", "MachineIdentifier", "HardwareModel"] {
+            let src = srcBundle.bundlePath.appendingPathComponent(filename)
+            let dst = dstBundle.bundlePath.appendingPathComponent(filename)
+            if fm.fileExists(atPath: src.path) {
+                do {
+                    try fm.copyItem(at: src, to: dst)  // clonefile(2) on APFS
+                } catch {
+                    throw VMRegistryError.ioFailure("clone \(filename): \(error.localizedDescription)")
+                }
+            }
+        }
+        index.entries[dstName] = srcSpec.id
+        try writeIndex(index)
+        return dstBundle
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMShare.swift
+++ b/interceptor-bridge/Sources/VM/VMShare.swift
@@ -1,0 +1,91 @@
+// VMShare
+//
+// virtio-fs directory sharing per
+// `apple-developer-docs/Virtualization/shared-directories.md`. Available
+// macOS 13+. Builds `VZVirtioFileSystemDeviceConfiguration` with either
+// `VZSingleDirectoryShare` (one host dir → one tag) or
+// `VZMultipleDirectoryShare` (multiple dirs → one tag).
+//
+// Linux Rosetta share via `VZLinuxRosettaDirectoryShare` per
+// `VZLinuxRosettaDirectoryShare.md`. ARM host only; throws
+// `VZError.invalidVirtualMachineConfiguration` if Rosetta isn't installed.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public enum VMShareError: Error, CustomStringConvertible, Sendable {
+    case invalidTag(String)
+    case rosettaUnavailable(String)
+    case ioFailure(String)
+
+    public var description: String {
+        switch self {
+        case .invalidTag(let m): return "share.invalidTag: \(m)"
+        case .rosettaUnavailable(let m): return "share.rosettaUnavailable: \(m)"
+        case .ioFailure(let m): return "share.ioFailure: \(m)"
+        }
+    }
+}
+
+public struct VMShare: Sendable {
+#if canImport(Virtualization)
+    /// Build virtio-fs device configurations from the spec's shares.
+    /// Optionally append a Rosetta share when `spec.rosetta == true` on
+    /// Linux guests.
+    @available(macOS 13.0, *)
+    public static func buildDirectorySharingDevices(
+        for spec: VMSpec
+    ) throws -> [VZDirectorySharingDeviceConfiguration] {
+        var devs: [VZDirectorySharingDeviceConfiguration] = []
+
+        for share in spec.shares {
+            // Apple's validateTag throws on invalid tags. Wrap into VMShareError
+            // so callers get a stable error type.
+            do {
+                try VZVirtioFileSystemDeviceConfiguration.validateTag(share.tag)
+            } catch {
+                throw VMShareError.invalidTag("tag '\(share.tag)': \(error.localizedDescription)")
+            }
+            let url = URL(fileURLWithPath: (share.hostPath as NSString).expandingTildeInPath)
+            let dir = VZSharedDirectory(url: url, readOnly: share.readOnly)
+            let single = VZSingleDirectoryShare(directory: dir)
+            let dev = VZVirtioFileSystemDeviceConfiguration(tag: share.tag)
+            dev.share = single
+            devs.append(dev)
+        }
+
+        if spec.rosetta && spec.kind == .linux {
+            // Use the conventional `ROSETTA` tag the Apple sample documents.
+            let tag = "ROSETTA"
+            do {
+                try VZVirtioFileSystemDeviceConfiguration.validateTag(tag)
+            } catch {
+                throw VMShareError.invalidTag("rosetta tag: \(error.localizedDescription)")
+            }
+            let rosetta: VZLinuxRosettaDirectoryShare
+            do {
+                rosetta = try VZLinuxRosettaDirectoryShare()
+            } catch {
+                throw VMShareError.rosettaUnavailable(
+                    "VZLinuxRosettaDirectoryShare(): \(error.localizedDescription) — install Rosetta with `softwareupdate --install-rosetta`"
+                )
+            }
+            let dev = VZVirtioFileSystemDeviceConfiguration(tag: tag)
+            dev.share = rosetta
+            devs.append(dev)
+        }
+
+        return devs
+    }
+
+    /// Static helper: is Rosetta available on this host? Equivalent to
+    /// `VZLinuxRosettaAvailability.installed`.
+    @available(macOS 13.0, *)
+    public static var rosettaAvailable: Bool {
+        // VZLinuxRosettaDirectoryShare.availability is the typed accessor.
+        return VZLinuxRosettaDirectoryShare.availability == .installed
+    }
+#endif
+}

--- a/interceptor-bridge/Sources/VM/VMSnapshot.swift
+++ b/interceptor-bridge/Sources/VM/VMSnapshot.swift
@@ -1,0 +1,206 @@
+// VMSnapshot
+//
+// Two layers design:
+//   1. Pause-state via `VZVirtualMachine.saveMachineStateTo(url:)` →
+//      `<bundle>/snapshots/<tag>/SaveFile.vzvmsave`. Requires the
+//      configuration to pass `validateSaveRestoreSupport()` per
+//      `apple-developer-docs/Virtualization/VZVirtualMachineConfiguration.md`
+//      and `running-macos-in-a-virtual-machine-on-apple-silicon.md:50`.
+//   2. Disk-state via APFS `clonefile(2)` of Disk.img (and aux files
+//      for macOS guests). FileManager.copyItem(at:to:) uses clonefile(2)
+//      transparently on APFS volumes.
+//
+// `manifest.json` in the snapshot dir records when the snapshot was
+// taken, which kind, and which Disk.img digest it points at.
+
+import Foundation
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+public struct VMSnapshotManifest: Codable, Sendable {
+    public var tag: String
+    public var kind: String                  // "paused-state" | "disk-only" | "both"
+    public var createdAt: Date
+    public var hasPausedState: Bool
+    public var hasDiskClone: Bool
+    public var notes: String?
+}
+
+public enum VMSnapshotError: Error, CustomStringConvertible, Sendable {
+    case notSupported(String)
+    case ioFailure(String)
+    case alreadyExists(String)
+    case missing(String)
+
+    public var description: String {
+        switch self {
+        case .notSupported(let m): return "snapshot.notSupported: \(m)"
+        case .ioFailure(let m): return "snapshot.ioFailure: \(m)"
+        case .alreadyExists(let m): return "snapshot.alreadyExists: \(m)"
+        case .missing(let m): return "snapshot.missing: \(m)"
+        }
+    }
+}
+
+public struct VMSnapshot: Sendable {
+    public enum Mode: String, Sendable {
+        case both
+        case pausedStateOnly
+        case diskOnly
+    }
+
+#if canImport(Virtualization)
+    /// Save the current paused-state of `vm` and clone `Disk.img` to a new
+    /// `<bundle>/snapshots/<tag>/` directory. The VM MUST be paused before
+    /// calling for `mode != .diskOnly`.
+    @available(macOS 14.0, *)
+    public static func create(
+        vm: VZVirtualMachine,
+        bundle: VMBundle,
+        tag: String,
+        mode: Mode
+    ) async throws -> VMSnapshotManifest {
+        let snapDir = bundle.snapshotDir(tag: tag)
+        if FileManager.default.fileExists(atPath: snapDir.path) {
+            throw VMSnapshotError.alreadyExists(snapDir.path)
+        }
+        do {
+            try FileManager.default.createDirectory(at: snapDir, withIntermediateDirectories: true)
+        } catch {
+            throw VMSnapshotError.ioFailure("create snapshot dir: \(error.localizedDescription)")
+        }
+
+        var hasPaused = false
+        var hasDisk = false
+
+        if mode != .diskOnly {
+            let saveURL = bundle.snapshotFile(tag: tag)
+            do {
+                try await vm.saveMachineStateTo(url: saveURL)
+                hasPaused = true
+            } catch {
+                throw VMSnapshotError.ioFailure("saveMachineStateTo: \(error.localizedDescription)")
+            }
+        }
+
+        if mode != .pausedStateOnly {
+            let src = bundle.diskPath
+            let dst = snapDir.appendingPathComponent("Disk.img")
+            if FileManager.default.fileExists(atPath: src.path) {
+                do {
+                    try FileManager.default.copyItem(at: src, to: dst) // APFS clonefile(2)
+                    hasDisk = true
+                } catch {
+                    throw VMSnapshotError.ioFailure("clone Disk.img: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        let manifest = VMSnapshotManifest(
+            tag: tag,
+            kind: mode.rawValue,
+            createdAt: Date(),
+            hasPausedState: hasPaused,
+            hasDiskClone: hasDisk,
+            notes: nil
+        )
+        try writeManifest(manifest, to: bundle.snapshotManifest(tag: tag))
+        return manifest
+    }
+
+    /// Restore a snapshot. For paused-state restore the VM must NOT yet be
+    /// running. Returns the post-restore manifest so the caller knows what
+    /// was restored.
+    @available(macOS 14.0, *)
+    public static func restore(
+        vm: VZVirtualMachine,
+        bundle: VMBundle,
+        tag: String,
+        pausedStateOnly: Bool = false,
+        diskOnly: Bool = false
+    ) async throws -> VMSnapshotManifest {
+        let manifestURL = bundle.snapshotManifest(tag: tag)
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            throw VMSnapshotError.missing("snapshot '\(tag)' not found at \(manifestURL.path)")
+        }
+        let manifest = try readManifest(at: manifestURL)
+
+        if !pausedStateOnly && manifest.hasDiskClone {
+            let snapDisk = bundle.snapshotDir(tag: tag).appendingPathComponent("Disk.img")
+            let liveDisk = bundle.diskPath
+            // Replace live disk with the snapshot's clone. We move the
+            // current disk aside so a botched restore can be undone.
+            let parked = bundle.bundlePath.appendingPathComponent("Disk.img.pre-restore-\(Int(Date().timeIntervalSince1970))")
+            if FileManager.default.fileExists(atPath: liveDisk.path) {
+                try? FileManager.default.moveItem(at: liveDisk, to: parked)
+            }
+            do {
+                try FileManager.default.copyItem(at: snapDisk, to: liveDisk)
+            } catch {
+                // attempt rollback
+                try? FileManager.default.moveItem(at: parked, to: liveDisk)
+                throw VMSnapshotError.ioFailure("restore Disk.img: \(error.localizedDescription)")
+            }
+            // best-effort cleanup
+            try? FileManager.default.removeItem(at: parked)
+        }
+
+        if !diskOnly && manifest.hasPausedState {
+            let saveURL = bundle.snapshotFile(tag: tag)
+            do {
+                try await vm.restoreMachineStateFrom(url: saveURL)
+            } catch {
+                throw VMSnapshotError.ioFailure("restoreMachineStateFrom: \(error.localizedDescription)")
+            }
+        }
+
+        return manifest
+    }
+#endif
+
+    public static func list(bundle: VMBundle) -> [String] {
+        let snapsDir = bundle.snapshotsDir
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: snapsDir.path) else {
+            return []
+        }
+        return entries.sorted()
+    }
+
+    public static func delete(bundle: VMBundle, tag: String) throws {
+        let dir = bundle.snapshotDir(tag: tag)
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            throw VMSnapshotError.missing("snapshot '\(tag)' not found")
+        }
+        do {
+            try FileManager.default.removeItem(at: dir)
+        } catch {
+            throw VMSnapshotError.ioFailure("delete snapshot: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - manifest I/O
+
+    private static func writeManifest(_ m: VMSnapshotManifest, to url: URL) throws {
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+        enc.dateEncodingStrategy = .iso8601
+        do {
+            let data = try enc.encode(m)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw VMSnapshotError.ioFailure("write manifest: \(error.localizedDescription)")
+        }
+    }
+
+    private static func readManifest(at url: URL) throws -> VMSnapshotManifest {
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        do {
+            let data = try Data(contentsOf: url)
+            return try dec.decode(VMSnapshotManifest.self, from: data)
+        } catch {
+            throw VMSnapshotError.ioFailure("read manifest: \(error.localizedDescription)")
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMSpec.swift
+++ b/interceptor-bridge/Sources/VM/VMSpec.swift
@@ -1,0 +1,259 @@
+// VMSpec
+//
+// Codable spec for a single VM. Persisted to <state>/vms/<name>.bundle/spec.json
+// alongside Apple's `VM.bundle` files (Disk.img, AuxiliaryStorage,
+// MachineIdentifier, HardwareModel) per
+// `apple-developer-docs/Virtualization/running-macos-in-a-virtual-machine-on-apple-silicon.md:21-32`.
+//
+// We do not import Virtualization here — VMSpec is pure data. Runtime
+// validation against `VZVirtualMachineConfiguration.validate()` happens in
+// VMInstance after the spec has been used to build a configuration.
+
+import Foundation
+
+/// VM kind. Linux guests use the Containerization Swift package's
+/// `LinuxContainer` runtime; macOS guests use raw Virtualization framework
+/// (`VZMacOSInstaller`, `VZVirtualMachine`).
+public enum VMKind: String, Codable, Sendable {
+    case linux
+    case macos
+}
+
+/// Lifecycle status. Mirrors the design notes state diagram exactly. `VZVirtualMachine.State`
+/// has fewer cases (`stopped/starting/running/paused/stopping/error`); we add
+/// Interceptor-managed pre- and post- states (`created`, `imagePulling`, `installing`,
+/// `ready`, `savingSnapshot`, `restoringSnapshot`, `deleted`) so progress is
+/// reportable without overloading Apple's enum.
+public enum VMStatus: String, Codable, Sendable {
+    case created
+    case imagePulling
+    case installing
+    case ready
+    case starting
+    case running
+    case paused
+    case stopping
+    case stopped
+    case savingSnapshot
+    case restoringSnapshot
+    case error
+    case deleted
+}
+
+/// Network mode. NAT routes guest packets through the host (the only mode
+/// Interceptor ships). Bridged + vmnet attachments are out of scope —
+/// `com.apple.vm.networking` is Apple-restricted and not pursued.
+public enum VMNetworkMode: String, Codable, Sendable {
+    case none
+    case nat
+}
+
+public enum VMProviderKind: String, Codable, Sendable, Equatable {
+    case appleVZ
+    case containerization
+    case lume
+    case tart
+    case utm
+    case qemu
+    case externalAgent
+}
+
+public enum VMAdoptMode: String, Codable, Sendable, Equatable {
+    case clone
+    case move
+    case reference
+}
+
+/// virtio-fs share. `tag` is the mount label the guest uses: `mount -t virtiofs <tag>`.
+public struct VMShareSpec: Codable, Sendable, Equatable {
+    public var hostPath: String
+    public var tag: String
+    public var readOnly: Bool
+    public init(hostPath: String, tag: String, readOnly: Bool = true) {
+        self.hostPath = hostPath
+        self.tag = tag
+        self.readOnly = readOnly
+    }
+}
+
+/// Persisted spec. Bytes for memory/disk are absolute bytes (not GiB) so
+/// the JSON is unambiguous across rounding modes.
+public struct VMSpec: Codable, Sendable, Equatable {
+    public var name: String
+    public var id: String                 // UUID string
+    public var kind: VMKind
+    public var cpu: Int
+    public var memorySize: UInt64         // bytes
+    public var diskSize: UInt64           // bytes
+    /// macOS guest: IPSW path on disk, or sentinel `"latest"` to mean
+    /// `VZMacOSRestoreImage.latestSupported`.
+    /// Linux guest: OCI reference such as `docker.io/library/alpine:3`.
+    public var image: String
+    public var network: VMNetworkMode
+    public var shares: [VMShareSpec]
+    /// Linux + ARM host only. Attaches `VZLinuxRosettaDirectoryShare`.
+    public var rosetta: Bool
+    public var createdAt: Date
+    public var startedAt: Date?
+    /// Last computed `validateSaveRestoreSupport()` result, cached so
+    /// `vm snapshot --paused-state` can refuse without instantiating a VM.
+    public var snapshotSupported: Bool?
+    public var provider: VMProviderKind?
+    public var sourcePath: String?
+    public var adoptMode: VMAdoptMode?
+    /// Optional persisted NIC MAC address. Preserving this for adopted VMs
+    /// keeps NAT DHCP leases stable across boots and lets the host map a
+    /// running macOS guest back to its bridge100 IP.
+    public var macAddress: String?
+
+    public init(
+        name: String,
+        id: String = UUID().uuidString,
+        kind: VMKind,
+        cpu: Int,
+        memorySize: UInt64,
+        diskSize: UInt64,
+        image: String,
+        network: VMNetworkMode = .nat,
+        shares: [VMShareSpec] = [],
+        rosetta: Bool = false,
+        createdAt: Date = Date(),
+        startedAt: Date? = nil,
+        snapshotSupported: Bool? = nil,
+        provider: VMProviderKind? = nil,
+        sourcePath: String? = nil,
+        adoptMode: VMAdoptMode? = nil,
+        macAddress: String? = nil
+    ) {
+        self.name = name
+        self.id = id
+        self.kind = kind
+        self.cpu = cpu
+        self.memorySize = memorySize
+        self.diskSize = diskSize
+        self.image = image
+        self.network = network
+        self.shares = shares
+        self.rosetta = rosetta
+        self.createdAt = createdAt
+        self.startedAt = startedAt
+        self.snapshotSupported = snapshotSupported
+        self.provider = provider
+        self.sourcePath = sourcePath
+        self.adoptMode = adoptMode
+        self.macAddress = macAddress
+    }
+
+    /// Static validation that does NOT require Virtualization framework
+    /// initialization. Checks invariants that can be evaluated from pure
+    /// data: name shape, cpu/memory/disk bounds, kind-image compatibility.
+    /// Runtime validation against `VZVirtualMachineConfiguration.validate()`
+    /// happens later in `VMInstance.prepareConfiguration()`.
+    public func validateStatic() throws {
+        guard !name.isEmpty else {
+            throw VMSpecError.invalidName("name must be non-empty")
+        }
+        // Names map to filesystem dir names; keep them shell-safe.
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+        guard name.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw VMSpecError.invalidName("name '\(name)' contains characters outside [A-Za-z0-9._-]")
+        }
+        guard cpu >= 1 && cpu <= 64 else {
+            throw VMSpecError.invalidResource("cpu must be 1..64 (got \(cpu))")
+        }
+        // 256 MiB lower bound (smaller than this and the Linux init dies).
+        // Upper bound deliberately generous; the host's
+        // VZVirtualMachineConfiguration.maximumAllowedMemorySize is the
+        // real ceiling, enforced at instantiation.
+        let minMem: UInt64 = 256 * 1024 * 1024
+        guard memorySize >= minMem else {
+            throw VMSpecError.invalidResource("memorySize must be ≥ \(minMem) bytes (got \(memorySize))")
+        }
+        // 100 MiB lower disk floor — enough to hold a minimal Alpine rootfs.
+        let minDisk: UInt64 = 100 * 1024 * 1024
+        guard diskSize >= minDisk else {
+            throw VMSpecError.invalidResource("diskSize must be ≥ \(minDisk) bytes (got \(diskSize))")
+        }
+        switch kind {
+        case .linux:
+            guard image.contains(":") || image == "latest" else {
+                throw VMSpecError.invalidImage("linux image must be an OCI ref like 'docker.io/library/alpine:3'")
+            }
+        case .macos:
+            // image is either an absolute path to an .ipsw or the sentinel "latest"
+            guard image == "latest" || image.hasSuffix(".ipsw") else {
+                throw VMSpecError.invalidImage("macos image must be an .ipsw path or 'latest'")
+            }
+        }
+        if rosetta && kind != .linux {
+            throw VMSpecError.invalidResource("rosetta is only valid for linux guests")
+        }
+    }
+}
+
+public enum VMSpecError: Error, CustomStringConvertible, Sendable {
+    case invalidName(String)
+    case invalidResource(String)
+    case invalidImage(String)
+
+    public var description: String {
+        switch self {
+        case .invalidName(let m): return "spec.invalidName: \(m)"
+        case .invalidResource(let m): return "spec.invalidResource: \(m)"
+        case .invalidImage(let m): return "spec.invalidImage: \(m)"
+        }
+    }
+}
+
+/// Serialized view that the daemon / CLI surfaces for `vm get` / `vm list`.
+/// Lighter than `VMSpec` (omits internal-only fields) and uses string-encoded
+/// statuses so JSON is friendly to jq.
+public struct VMPublicView: Codable, Sendable {
+    public var name: String
+    public var id: String
+    public var kind: String
+    public var status: String
+    public var ipAddress: String?
+    public var cpu: Int
+    public var memorySize: UInt64
+    public var diskSize: UInt64
+    public var network: String
+    public var createdAt: String
+    public var startedAt: String?
+    public var snapshotSupported: Bool?
+
+    public init(spec: VMSpec, status: VMStatus, ipAddress: String? = nil) {
+        let iso = ISO8601DateFormatter()
+        self.name = spec.name
+        self.id = spec.id
+        self.kind = spec.kind.rawValue
+        self.status = status.rawValue
+        self.ipAddress = ipAddress
+        self.cpu = spec.cpu
+        self.memorySize = spec.memorySize
+        self.diskSize = spec.diskSize
+        self.network = spec.network.rawValue
+        self.createdAt = iso.string(from: spec.createdAt)
+        self.startedAt = spec.startedAt.map { iso.string(from: $0) }
+        self.snapshotSupported = spec.snapshotSupported
+    }
+
+    /// Convert to a `[String: Any]` payload suitable for `WireFormat.success(data:)`.
+    public var asDictionary: [String: Any] {
+        var d: [String: Any] = [
+            "name": name,
+            "id": id,
+            "kind": kind,
+            "status": status,
+            "cpu": cpu,
+            "memorySize": memorySize,
+            "diskSize": diskSize,
+            "network": network,
+            "createdAt": createdAt,
+        ]
+        if let ip = ipAddress { d["ipAddress"] = ip }
+        if let s = startedAt { d["startedAt"] = s }
+        if let snap = snapshotSupported { d["snapshotSupported"] = snap }
+        return d
+    }
+}

--- a/interceptor-bridge/Sources/main.swift
+++ b/interceptor-bridge/Sources/main.swift
@@ -9,7 +9,7 @@ Platform.writePID()
 
 let router = Router()
 
-// PRD-66 — expose the router to AppIntents perform() callbacks so declared
+// expose the router to AppIntents perform() callbacks so declared
 // intents can dispatch into the same domain handlers the CLI uses.
 GlobalRouterRef.shared = router
 
@@ -33,6 +33,7 @@ let audioDomain = AudioDomain()
 let streamDomain = StreamDomain()
 let monitorDomain = MonitorDomain()
 let trustDomain = TrustDomain()
+let tccDomain = TccDomain()
 let menuDomain = MenuDomain()
 let textDomain = TextDomain()
 let compoundDomain = CompoundDomain(router: router)
@@ -46,8 +47,13 @@ let logDomain = LogDomain()
 let intentDomain = IntentDomain()
 let containerDomain = ContainerDomain()
 
-// PRD-66 — personal data and distribution domains. Each handler reads
-// `action["sub"]` per the PRD-63 dispatch invariant and is registered
+// VM management. Registered against `vm` so `macos_vm_<verb>`
+// actions route here. Lives alongside ContainerDomain (which keeps
+// running the existing `macos_container_run` shell-out path).
+let vmDomain = VmDomain()
+
+// personal data and distribution domains. Each handler reads
+// `action["sub"]` per the dispatch invariant and is registered
 // against the two-segment action type `macos_<key>_<verb>` below.
 let pdfDomain = PdfDomain()
 let detectDomain = DetectDomain()
@@ -99,6 +105,7 @@ router.register("audio", handler: audioDomain)
 router.register("stream", handler: streamDomain)
 router.register("monitor", handler: monitorDomain)
 router.register("trust", handler: trustDomain)
+router.register("tcc", handler: tccDomain)
 router.register("menu", handler: menuDomain)
 router.register("text", handler: textDomain)
 router.register("compound", handler: compoundDomain)
@@ -111,8 +118,10 @@ router.register("url", handler: netDomain)
 router.register("log", handler: logDomain)
 router.register("intent", handler: intentDomain)
 router.register("container", handler: containerDomain)
+// register the new `vm` domain.
+router.register("vm", handler: vmDomain)
 
-// PRD-66 — register the 14 new domain keys.
+// register the 14 new domain keys.
 router.register("pdf", handler: pdfDomain)
 router.register("detect", handler: detectDomain)
 router.register("translate", handler: translateDomain)

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/TccAndVMAdoptionTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/TccAndVMAdoptionTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import interceptor_bridge
+
+final class TccProfileGeneratorTests: XCTestCase {
+    func testProfileGeneratorIncludesGrantableAndSkipsUserOnlyServices() throws {
+        let generated = try TccProfileGenerator.generateProfile(
+            target: "host",
+            bundleId: "com.interceptor.bridge",
+            appPath: "/Applications/Interceptor.app",
+            identifierType: "bundleID",
+            codeRequirement: "identifier com.interceptor.bridge",
+            requestedServices: ["Accessibility", "PostEvent", "ScreenCapture"],
+            includeUserOnly: true
+        )
+
+        let includedServices = generated.included.compactMap { $0["service"] as? String }
+        let skippedServices = generated.skipped.compactMap { $0["service"] as? String }
+        XCTAssertTrue(includedServices.contains("Accessibility"))
+        XCTAssertTrue(includedServices.contains("PostEvent"))
+        XCTAssertTrue(skippedServices.contains("ScreenCapture"))
+        XCTAssertTrue(generated.xml.contains("com.apple.TCC.configuration-profile-policy"))
+    }
+}
+
+final class VMAdoptionTests: XCTestCase {
+    private func tempDir(_ name: String) -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func testDetectsAndAdoptsLumeBundleShape() async throws {
+        let source = tempDir("lume-source")
+        let state = tempDir("lume-state")
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: state)
+        }
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: state, withIntermediateDirectories: true)
+
+        try Data("disk".utf8).write(to: source.appendingPathComponent("disk.img"))
+        try Data("nvram".utf8).write(to: source.appendingPathComponent("nvram.bin"))
+        let hw = Data("hardware-model".utf8).base64EncodedString()
+        let mid = Data("machine-id".utf8).base64EncodedString()
+        let config = """
+        {
+          "diskSize": 107374182400,
+          "memorySize": 17179869184,
+          "machineIdentifier": "\(mid)",
+          "cpuCount": 8,
+          "os": "macOS",
+          "hardwareModel": "\(hw)",
+          "networkMode": "nat"
+        }
+        """
+        try Data(config.utf8).write(to: source.appendingPathComponent("config.json"))
+
+        XCTAssertEqual(VMAdoption.detectProvider(source: source, requested: "auto"), .lume)
+
+        let registry = try VMRegistry(stateDir: state)
+        let result = try await VMAdoption.adopt(
+            source: source,
+            name: "gold",
+            kind: .macos,
+            requestedProvider: "auto",
+            mode: .clone,
+            registry: registry
+        )
+
+        XCTAssertEqual(result.provider, .lume)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.bundle.diskPath.path))
+        XCTAssertEqual(try Data(contentsOf: result.bundle.hardwareModelPath), Data("hardware-model".utf8))
+        XCTAssertEqual(try Data(contentsOf: result.bundle.machineIdPath), Data("machine-id".utf8))
+    }
+}

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/VmDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/VmDomainTests.swift
@@ -1,0 +1,211 @@
+// VmDomainTests
+//
+// Unit tests that exercise the pure-data layer of VmDomain without
+// actually instantiating VZVirtualMachine (which would require the
+// com.apple.security.virtualization entitlement at test runtime and
+// would be both slow and non-deterministic).
+//
+// We test:
+//   - VMSpec.validateStatic() boundary conditions
+//   - VMRegistry create/get/list/delete/clone round-trips in a tmp state dir
+//   - VMRegistry.resolveStateDir() precedence order
+//   - WireFormat success/error shapes returned by VmDomain
+//
+// VMInstance live-boot and MacRuntime install paths are integration
+// concerns and live in `test/vm-lifecycle.test.ts` (CL34).
+
+import XCTest
+@testable import interceptor_bridge
+
+// Sendable wrapper so we can hand `[String: Any]` across an
+// XCTest CheckedContinuation under Swift 6 strict concurrency.
+struct TestDictBox: @unchecked Sendable {
+    let d: [String: Any]
+}
+
+final class VMSpecValidationTests: XCTestCase {
+
+    func test_validateStatic_acceptsMinimalLinux() throws {
+        let spec = VMSpec(
+            name: "lin1",
+            kind: .linux,
+            cpu: 2,
+            memorySize: 1 * 1024 * 1024 * 1024,
+            diskSize: 4 * 1024 * 1024 * 1024,
+            image: "docker.io/library/alpine:3"
+        )
+        XCTAssertNoThrow(try spec.validateStatic())
+    }
+
+    func test_validateStatic_rejectsEmptyName() {
+        let spec = VMSpec(name: "", kind: .linux, cpu: 1, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        XCTAssertThrowsError(try spec.validateStatic())
+    }
+
+    func test_validateStatic_rejectsBadNameChars() {
+        let spec = VMSpec(name: "lin 1", kind: .linux, cpu: 1, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        XCTAssertThrowsError(try spec.validateStatic())
+    }
+
+    func test_validateStatic_rejectsCpuOutOfRange() {
+        let s1 = VMSpec(name: "x", kind: .linux, cpu: 0, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        let s2 = VMSpec(name: "x", kind: .linux, cpu: 65, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        XCTAssertThrowsError(try s1.validateStatic())
+        XCTAssertThrowsError(try s2.validateStatic())
+    }
+
+    func test_validateStatic_rejectsTinyMemory() {
+        let spec = VMSpec(name: "x", kind: .linux, cpu: 1, memorySize: 1024, diskSize: 1<<30, image: "alpine:3")
+        XCTAssertThrowsError(try spec.validateStatic())
+    }
+
+    func test_validateStatic_rejectsTinyDisk() {
+        let spec = VMSpec(name: "x", kind: .linux, cpu: 1, memorySize: 1<<30, diskSize: 1024, image: "alpine:3")
+        XCTAssertThrowsError(try spec.validateStatic())
+    }
+
+    func test_validateStatic_macosRequiresIpswOrLatest() {
+        let bad = VMSpec(name: "m", kind: .macos, cpu: 4, memorySize: 8<<30, diskSize: 32<<30, image: "alpine:3")
+        let okPath = VMSpec(name: "m", kind: .macos, cpu: 4, memorySize: 8<<30, diskSize: 32<<30, image: "/tmp/restore.ipsw")
+        let okLatest = VMSpec(name: "m", kind: .macos, cpu: 4, memorySize: 8<<30, diskSize: 32<<30, image: "latest")
+        XCTAssertThrowsError(try bad.validateStatic())
+        XCTAssertNoThrow(try okPath.validateStatic())
+        XCTAssertNoThrow(try okLatest.validateStatic())
+    }
+
+    func test_validateStatic_rosettaOnlyOnLinux() {
+        let s = VMSpec(name: "m", kind: .macos, cpu: 4, memorySize: 8<<30, diskSize: 32<<30, image: "latest", rosetta: true)
+        XCTAssertThrowsError(try s.validateStatic())
+    }
+}
+
+final class VMRegistryTests: XCTestCase {
+
+    private func makeTmpStateDir() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("interceptor-vm-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func test_resolveStateDir_precedence() {
+        let dir = "/tmp/explicit"
+        let resolved = VMRegistry.resolveStateDir(actionOverride: dir)
+        XCTAssertEqual(resolved.path, dir)
+    }
+
+    func test_resolveStateDir_envFallback() {
+        setenv("INTERCEPTOR_VM_STATE_DIR", "/tmp/from-env", 1)
+        defer { unsetenv("INTERCEPTOR_VM_STATE_DIR") }
+        let resolved = VMRegistry.resolveStateDir(actionOverride: nil)
+        XCTAssertEqual(resolved.path, "/tmp/from-env")
+    }
+
+    func test_resolveStateDir_cwdDefault() {
+        let resolved = VMRegistry.resolveStateDir(actionOverride: nil)
+        XCTAssertTrue(resolved.path.hasSuffix("/.interceptor"))
+    }
+
+    func test_create_then_get_roundtrip() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let reg = try VMRegistry(stateDir: stateDir)
+        let spec = VMSpec(name: "lin1", kind: .linux, cpu: 2, memorySize: 1<<30, diskSize: 1<<30, image: "docker.io/library/alpine:3")
+        _ = try await reg.create(spec)
+        let got = try await reg.get("lin1")
+        XCTAssertEqual(got.name, "lin1")
+        XCTAssertEqual(got.kind, .linux)
+        XCTAssertEqual(got.cpu, 2)
+    }
+
+    func test_create_duplicate_throws() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let reg = try VMRegistry(stateDir: stateDir)
+        let spec = VMSpec(name: "dup", kind: .linux, cpu: 2, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        _ = try await reg.create(spec)
+        await self.expectAsyncThrow(try await reg.create(spec))
+    }
+
+    func test_list_returns_all_created() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let reg = try VMRegistry(stateDir: stateDir)
+        for n in ["a", "b", "c"] {
+            let s = VMSpec(name: n, kind: .linux, cpu: 1, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+            _ = try await reg.create(s)
+        }
+        let all = try await reg.list()
+        XCTAssertEqual(all.map { $0.name }.sorted(), ["a", "b", "c"])
+    }
+
+    func test_delete_removes_from_index_and_bundle() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let reg = try VMRegistry(stateDir: stateDir)
+        let spec = VMSpec(name: "delme", kind: .linux, cpu: 1, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        let bundle = try await reg.create(spec)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundle.specPath.path))
+        try await reg.delete("delme")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bundle.bundlePath.path))
+        await self.expectAsyncThrow(try await reg.get("delme"))
+    }
+
+    func test_clone_rebrands_and_resets_id() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let reg = try VMRegistry(stateDir: stateDir)
+        let src = VMSpec(name: "gold", kind: .linux, cpu: 2, memorySize: 1<<30, diskSize: 1<<30, image: "alpine:3")
+        _ = try await reg.create(src)
+        let bundle = try await reg.clone(from: "gold", to: "test1")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundle.specPath.path))
+        let cloned = try await reg.get("test1")
+        XCTAssertEqual(cloned.name, "test1")
+        XCTAssertNotEqual(cloned.id, src.id)
+    }
+
+    // Helper: XCTest doesn't have an async-throws variant out of the box.
+    private func expectAsyncThrow<T>(_ expr: @autoclosure () async throws -> T, file: StaticString = #filePath, line: UInt = #line) async {
+        do {
+            _ = try await expr()
+            XCTFail("expected throw", file: file, line: line)
+        } catch {
+            // ok
+        }
+    }
+}
+
+final class VmDomainDispatchTests: XCTestCase {
+
+    func test_unknownVerb_returnsError() async {
+        let domain = VmDomain()
+        let action: [String: Any] = ["type": "macos_vm_xyzzy", "sub": "xyzzy"]
+        let result = await withCheckedContinuation { (cc: CheckedContinuation<TestDictBox, Never>) in
+            domain.handle("xyzzy", action: action) { result in
+                cc.resume(returning: TestDictBox(d: result))
+            }
+        }.d
+        XCTAssertEqual(result["success"] as? Bool, false)
+        XCTAssertTrue((result["error"] as? String ?? "").contains("unknown verb"))
+    }
+
+    func test_create_missingName_returnsError() async {
+        let domain = VmDomain()
+        let action: [String: Any] = ["type": "macos_vm_create", "sub": "create", "kind": "linux"]
+        let result = await withCheckedContinuation { (cc: CheckedContinuation<TestDictBox, Never>) in
+            domain.handle("create", action: action) { result in
+                cc.resume(returning: TestDictBox(d: result))
+            }
+        }.d
+        XCTAssertEqual(result["success"] as? Bool, false)
+    }
+
+    func test_pull_resolvesPathDeterministically() async throws {
+        let stateDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("interceptor-vm-pull-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let url1 = try await VMImage.resolveOCIImage(ref: "docker.io/library/alpine:3", stateDir: stateDir)
+        let url2 = try await VMImage.resolveOCIImage(ref: "docker.io/library/alpine:3", stateDir: stateDir)
+        XCTAssertEqual(url1.path, url2.path)
+    }
+}

--- a/scripts/build-bridge.sh
+++ b/scripts/build-bridge.sh
@@ -22,7 +22,10 @@ INTERCEPTOR_BRIDGE_IDENTIFIER="com.interceptor.bridge"
 INTERCEPTOR_BRIDGE_VERSION="${INTERCEPTOR_BRIDGE_VERSION:-1.0.0}"
 INTERCEPTOR_SPARKLE_FEED_URL="${INTERCEPTOR_SPARKLE_FEED_URL:-https://updates.hackervalley.media/appcast.xml}"
 INTERCEPTOR_SPARKLE_PUBLIC_KEY="${INTERCEPTOR_SPARKLE_PUBLIC_KEY:-dnUnuHGCO4obHb44Khlf2TZQFUMmFGGpm2c6j+EqmdU=}"
-ENTITLEMENTS="$SCRIPT_DIR/entitlements.plist"
+## Bridge carries Virtualization framework capabilities (VM lifecycle)
+## that the CLI and daemon don't need; entitlements-bridge.plist is the
+## superset, entitlements.plist is the slim CLI/daemon set.
+ENTITLEMENTS="$SCRIPT_DIR/entitlements-bridge.plist"
 APP_DIR="$DIST_DIR/interceptor-bridge.app"
 
 echo "==> Building interceptor-bridge (release)..."
@@ -109,7 +112,7 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
     <key>LSUIElement</key>
     <true/>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>interceptor-bridge dispatches Apple Events to apps you ask Interceptor to control via app_intent. macOS will prompt you to allow each target app the first time.</string>
     <key>NSAccessibilityUsageDescription</key>
@@ -119,7 +122,7 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
     <key>NSMicrophoneUsageDescription</key>
     <string>interceptor-bridge captures microphone input when you ask Interceptor to use listen / audio commands.</string>
 
-    <!-- PRD-66 — personal data and distribution surfaces.
+    <!-- personal data and distribution surfaces.
          Each TCC-gated framework gets a usage description string that surfaces
          in the system consent dialog. Strings follow Apple's recommended shape
          (verb + reason). Both modern (macOS 14+) and legacy keys are present

--- a/scripts/build-interceptord-pkg.sh
+++ b/scripts/build-interceptord-pkg.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BRIDGE_DIR="$ROOT/interceptor-bridge"
+OUT_DIR="${OUT_DIR:-$ROOT/dist}"
+IDENTIFIER="${IDENTIFIER:-com.interceptor.guest}"
+VERSION="${VERSION:-0.1.0}"
+PKG="$OUT_DIR/InterceptorD-${VERSION}.pkg"
+UNSIGNED_PKG="$OUT_DIR/InterceptorD-${VERSION}-unsigned.pkg"
+INTERCEPTOR_SIGNING_IDENTITY="${INTERCEPTOR_SIGNING_IDENTITY:-Developer ID Application: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)}"
+INTERCEPTOR_INSTALLER_IDENTITY="${INTERCEPTOR_INSTALLER_IDENTITY:-Developer ID Installer: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)}"
+
+mkdir -p "$OUT_DIR"
+
+cd "$BRIDGE_DIR"
+swift build -c release --product InterceptorD
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+install -d "$STAGE/Library/PrivilegedHelperTools"
+install -m 0755 ".build/release/InterceptorD" "$STAGE/Library/PrivilegedHelperTools/InterceptorD"
+
+if [[ "${INTERCEPTOR_SKIP_SIGNING:-0}" == "1" ]]; then
+  echo "==> INTERCEPTOR_SKIP_SIGNING=1 — skipping InterceptorD codesign and pkg signing"
+elif security find-identity -p codesigning -v 2>/dev/null | grep -q "$INTERCEPTOR_SIGNING_IDENTITY"; then
+  echo "==> Codesigning InterceptorD with: $INTERCEPTOR_SIGNING_IDENTITY"
+  codesign --force --options runtime --timestamp \
+    --sign "$INTERCEPTOR_SIGNING_IDENTITY" \
+    "$STAGE/Library/PrivilegedHelperTools/InterceptorD"
+  codesign --verify --strict --verbose=2 "$STAGE/Library/PrivilegedHelperTools/InterceptorD"
+else
+  echo "WARN: signing identity not found: $INTERCEPTOR_SIGNING_IDENTITY" >&2
+  echo "      Set INTERCEPTOR_SIGNING_IDENTITY or INTERCEPTOR_SKIP_SIGNING=1." >&2
+fi
+
+install -d "$STAGE/Library/LaunchAgents"
+cat > "$STAGE/Library/LaunchAgents/$IDENTIFIER.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$IDENTIFIER</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Library/PrivilegedHelperTools/InterceptorD</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/InterceptorD.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/InterceptorD.err.log</string>
+</dict>
+</plist>
+PLIST
+
+PKGBUILD_OUTPUT="$PKG"
+if [[ "${INTERCEPTOR_SKIP_SIGNING:-0}" != "1" ]] && security find-identity -v 2>/dev/null | grep -q "$INTERCEPTOR_INSTALLER_IDENTITY"; then
+  PKGBUILD_OUTPUT="$UNSIGNED_PKG"
+fi
+
+rm -f "$PKG" "$UNSIGNED_PKG"
+
+pkgbuild \
+  --root "$STAGE" \
+  --identifier "$IDENTIFIER" \
+  --version "$VERSION" \
+  --install-location / \
+  "$PKGBUILD_OUTPUT"
+
+if [[ "$PKGBUILD_OUTPUT" == "$UNSIGNED_PKG" ]]; then
+  echo "==> Signing pkg with: $INTERCEPTOR_INSTALLER_IDENTITY"
+  productsign \
+    --sign "$INTERCEPTOR_INSTALLER_IDENTITY" \
+    "$UNSIGNED_PKG" \
+    "$PKG"
+  rm -f "$UNSIGNED_PKG"
+  pkgutil --check-signature "$PKG"
+elif [[ "${INTERCEPTOR_SKIP_SIGNING:-0}" != "1" ]]; then
+  echo "WARN: installer identity not found: $INTERCEPTOR_INSTALLER_IDENTITY" >&2
+  echo "      Set INTERCEPTOR_INSTALLER_IDENTITY or INTERCEPTOR_SKIP_SIGNING=1." >&2
+fi
+
+echo "$PKG"

--- a/scripts/entitlements-bridge.plist
+++ b/scripts/entitlements-bridge.plist
@@ -37,10 +37,17 @@
     <true/>
     <key>com.apple.security.personal-information.location</key>
     <true/>
-    <!-- CLI + daemon entitlement set. Bridge-only capabilities (e.g.
-         com.apple.security.virtualization) live in entitlements-bridge.plist
-         to keep this surface minimal — AMFI rejects launchd-spawned
-         binaries that carry entitlements their bundle ID isn't allowlisted
-         for. -->
+    <!-- Bridge-only Virtualization framework requirement. Enables
+         VZVirtualMachine + VZVirtualMachineConfiguration + VZMacOSRestoreImage
+         (Virtualization.md:18). Apple does not restrict this entitlement —
+         any Developer ID-signed app may carry it
+         (BundleResources/Entitlements/com.apple.security.virtualization.md).
+         ships VM lifecycle with VZNATNetworkDeviceAttachment, which
+         requires only this entitlement. Bridged + vmnet attachment modes
+         (com.apple.vm.networking) are out of scope per 's scope
+         decision header — Apple restricts that entitlement via a private
+         allowlist Interceptor is not pursuing. -->
+    <key>com.apple.security.virtualization</key>
+    <true/>
 </dict>
 </plist>

--- a/test/macos-parser.test.ts
+++ b/test/macos-parser.test.ts
@@ -146,4 +146,26 @@ describe("macos parser", () => {
     expect(action.noPrompt).toBe(true)
     expect(action.prompt).toBe(false)
   })
+
+  test("tcc status parses target", () => {
+    const action = parseMacosCommand(["macos", "tcc", "status", "--target", "host"]) as Record<string, unknown>
+    expect(action.type).toBe("macos_tcc_status")
+    expect(action.sub).toBe("status")
+    expect(action.target).toBe("host")
+  })
+
+  test("tcc profile generate parses output and services", () => {
+    const action = parseMacosCommand([
+      "macos", "tcc", "profile", "generate",
+      "--target", "host",
+      "--out", "/tmp/interceptor.mobileconfig",
+      "--service", "Accessibility,PostEvent",
+      "--full-disk",
+    ]) as Record<string, unknown>
+    expect(action.type).toBe("macos_tcc_profile_generate")
+    expect(action.sub).toBe("profile_generate")
+    expect(action.out).toBe("/tmp/interceptor.mobileconfig")
+    expect(action.services).toEqual(["Accessibility", "PostEvent"])
+    expect(action.fullDisk).toBe(true)
+  })
 })

--- a/test/vm-lifecycle.test.ts
+++ b/test/vm-lifecycle.test.ts
@@ -1,0 +1,275 @@
+/**
+ * VM lifecycle smoke
+ *
+ * End-to-end exercise of the `interceptor macos vm *` CLI surface against
+ * a freshly-built bridge binary. Tests the parser layer + the daemon-to-
+ * bridge round trip + the registry on-disk shape.
+ *
+ * The actual guest boot is gated on:
+ *   - macOS 15+ host
+ *   - com.apple.security.virtualization entitlement on the bridge
+ *   - successful resolution of the apple/containerization Swift package
+ *
+ * When those aren't satisfied this test exercises the parser-level
+ * behaviour (CL24-CL28) and confirms the bridge returns a
+ * `setup_required` envelope per design notes.
+ */
+
+import { test, expect } from "bun:test"
+import { parseMacosCommand } from "../cli/commands/macos"
+import { existsSync, rmSync, mkdtempSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+function p(argv: string[]) {
+  return parseMacosCommand(argv) as any
+}
+
+test("vm create — parses required flags into macos_vm_create action", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "create",
+    "lin1",
+    "--kind",
+    "linux",
+    "--cpu",
+    "2",
+    "--memory",
+    "1073741824",
+    "--disk",
+    "4294967296",
+    "--image",
+    "docker.io/library/alpine:3",
+    "--network",
+    "nat",
+  ])
+  expect(action.type).toBe("macos_vm_create")
+  expect(action.sub).toBe("create")
+  expect(action.name).toBe("lin1")
+  expect(action.kind).toBe("linux")
+  expect(action.cpu).toBe(2)
+  expect(action.memorySize).toBe(1073741824)
+  expect(action.diskSize).toBe(4294967296)
+  expect(action.image).toBe("docker.io/library/alpine:3")
+  expect(action.network).toBe("nat")
+})
+
+test("vm clone — parses src and dst", () => {
+  const action = p(["macos", "vm", "clone", "gold", "test1"])
+  expect(action.type).toBe("macos_vm_clone")
+  expect(action.sub).toBe("clone")
+  expect(action.src).toBe("gold")
+  expect(action.dst).toBe("test1")
+})
+
+test("vm adopt — parses source, name, provider, and mode", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "adopt",
+    "/tmp/interceptor-vms/macos-gold",
+    "--name",
+    "macos-gold",
+    "--provider",
+    "auto",
+    "--mode",
+    "clone",
+    "--install-agent",
+  ])
+  expect(action.type).toBe("macos_vm_adopt")
+  expect(action.sub).toBe("adopt")
+  expect(action.sourcePath).toBe("/tmp/interceptor-vms/macos-gold")
+  expect(action.name).toBe("macos-gold")
+  expect(action.provider).toBe("auto")
+  expect(action.mode).toBe("clone")
+  expect(action.installAgent).toBe(true)
+})
+
+test("vm install — accepts --from-latest", () => {
+  const action = p(["macos", "vm", "install", "macgold", "--from-latest"])
+  expect(action.type).toBe("macos_vm_install")
+  expect(action.fromLatest).toBe(true)
+})
+
+test("vm install — accepts --ipsw <path>", () => {
+  const action = p(["macos", "vm", "install", "macgold", "--ipsw", "/tmp/restore.ipsw"])
+  expect(action.type).toBe("macos_vm_install")
+  expect(action.ipsw).toBe("/tmp/restore.ipsw")
+})
+
+test("vm start — flags wire into action correctly", () => {
+  const action = p(["macos", "vm", "start", "lin1", "--headless", "--wait-for-vsock"])
+  expect(action.type).toBe("macos_vm_start")
+  expect(action.headless).toBe(true)
+  expect(action.waitForVsock).toBe(true)
+})
+
+test("vm stop — --force flag", () => {
+  const action = p(["macos", "vm", "stop", "lin1", "--force"])
+  expect(action.type).toBe("macos_vm_stop")
+  expect(action.force).toBe(true)
+})
+
+test("vm exec — splits argv after --", () => {
+  const action = p(["macos", "vm", "exec", "lin1", "--", "sh", "-c", "uname -a"])
+  expect(action.type).toBe("macos_vm_exec")
+  expect(action.command).toEqual(["sh", "-c", "uname -a"])
+})
+
+test("vm exec — env vars carry through", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "exec",
+    "lin1",
+    "--env",
+    "FOO=bar",
+    "--env",
+    "BAZ=qux",
+    "--",
+    "env",
+  ])
+  expect(action.type).toBe("macos_vm_exec")
+  expect(action.env).toEqual({ FOO: "bar", BAZ: "qux" })
+})
+
+test("vm delete — keepDisk + force", () => {
+  const action = p(["macos", "vm", "delete", "lin1", "--force", "--keep-disk"])
+  expect(action.type).toBe("macos_vm_delete")
+  expect(action.force).toBe(true)
+  expect(action.keepDisk).toBe(true)
+})
+
+test("vm snapshot — defaults to op=create", () => {
+  const action = p(["macos", "vm", "snapshot", "lin1", "scratch"])
+  expect(action.type).toBe("macos_vm_snapshot")
+  expect(action.name).toBe("lin1")
+  expect(action.tag).toBe("scratch")
+  expect(action.snapshotOp).toBe("create")
+})
+
+test("vm list — minimal action with no flags", () => {
+  const action = p(["macos", "vm", "list"])
+  expect(action.type).toBe("macos_vm_list")
+  expect(action.sub).toBe("list")
+})
+
+test("vm get — requires name", () => {
+  const action = p(["macos", "vm", "get", "lin1"])
+  expect(action.type).toBe("macos_vm_get")
+  expect(action.name).toBe("lin1")
+})
+
+test("vm pull — captures image ref", () => {
+  const action = p(["macos", "vm", "pull", "docker.io/library/alpine:3"])
+  expect(action.type).toBe("macos_vm_pull")
+  expect(action.image).toBe("docker.io/library/alpine:3")
+})
+
+test("vm read-ax — renamed to read_ax in action type", () => {
+  const action = p(["macos", "vm", "read-ax", "mactest"])
+  expect(action.type).toBe("macos_vm_read_ax")
+  expect(action.sub).toBe("read-ax")
+})
+
+test("vm port-forward — renamed to port_forward in action type", () => {
+  const action = p(["macos", "vm", "port-forward", "lin1"])
+  expect(action.type).toBe("macos_vm_port_forward")
+})
+
+test("vm tcc profile generate — parses guest profile request", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "tcc",
+    "profile",
+    "generate",
+    "mactest",
+    "--out",
+    "/tmp/guest.mobileconfig",
+    "--service",
+    "Accessibility,PostEvent",
+  ])
+  expect(action.type).toBe("macos_vm_tcc_profile_generate")
+  expect(action.sub).toBe("tcc_profile_generate")
+  expect(action.name).toBe("mactest")
+  expect(action.out).toBe("/tmp/guest.mobileconfig")
+  expect(action.services).toEqual(["Accessibility", "PostEvent"])
+})
+
+test("vm cp — infers vm name from destination", () => {
+  const action = p(["macos", "vm", "cp", "./README.md", "mactest:/tmp/README.md"])
+  expect(action.type).toBe("macos_vm_cp")
+  expect(action.name).toBe("mactest")
+  expect(action.src).toBe("./README.md")
+  expect(action.dst).toBe("mactest:/tmp/README.md")
+})
+
+test("vm click — parses numeric coordinates", () => {
+  const action = p(["macos", "vm", "click", "mactest", "12,34", "--button", "right"])
+  expect(action.type).toBe("macos_vm_click")
+  expect(action.name).toBe("mactest")
+  expect(action.x).toBe(12)
+  expect(action.y).toBe(34)
+  expect(action.button).toBe("right")
+})
+
+test("vm type — captures text", () => {
+  const action = p(["macos", "vm", "type", "mactest", "hello"])
+  expect(action.type).toBe("macos_vm_type")
+  expect(action.name).toBe("mactest")
+  expect(action.text).toBe("hello")
+})
+
+test("vm create — share flag is parsed (repeatable)", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "create",
+    "lin1",
+    "--kind",
+    "linux",
+    "--image",
+    "alpine:3",
+    "--share",
+    "/host/foo:tagfoo:ro",
+    "--share",
+    "/host/bar:tagbar:rw",
+  ])
+  expect(action.shares).toEqual([
+    { hostPath: "/host/foo", tag: "tagfoo", readOnly: true },
+    { hostPath: "/host/bar", tag: "tagbar", readOnly: false },
+  ])
+})
+
+test("vm create — rosetta toggle", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "create",
+    "lin1",
+    "--kind",
+    "linux",
+    "--image",
+    "alpine:3",
+    "--rosetta",
+  ])
+  expect(action.rosetta).toBe(true)
+})
+
+test("vm create — stateDir override propagates", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "create",
+    "lin1",
+    "--kind",
+    "linux",
+    "--image",
+    "alpine:3",
+    "--state-dir",
+    "/tmp/explicit",
+  ])
+  expect(action.stateDir).toBe("/tmp/explicit")
+})


### PR DESCRIPTION
## Summary
- Add native VM lifecycle command parsing and bridge dispatch for Linux and macOS guests.
- Add the in-guest `interceptord` agent scaffold plus VM state, network, share, snapshot, adoption, and guest-control helpers.
- Add TCC profile generation support and VM lifecycle parser/bridge tests.

## Public-surface audit
- Rebuilt this branch from `origin/main` with only the implementation files needed for the public VM-control change.
- Excluded local VM state, research cache, broad research/report artifacts, and private docs from the branch.
- Scanned commit metadata, paths, and contents for private planning references, local filesystem paths, personal names/emails, project-specific names, and common secret patterns.

## Validation
- `bun run typecheck`
- `bun test test/vm-lifecycle.test.ts test/macos-parser.test.ts`
- `swift test` from `interceptor-bridge/`
- `bun run build`

Full `bun test` was also attempted: 270 passed, 6 skipped, and 4 Linux-container dry-run tests were blocked locally because the Apple container apiserver was not running and `container system start` could not register it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive VM management commands: create, clone, adopt, start, stop, pause, resume, and delete for Linux and macOS virtual machines
  * Added guest interaction capabilities: execute commands, transfer files, capture screenshots, inject keyboard/mouse input, and access accessibility tree
  * Added snapshot/restore functionality for VM state preservation and restoration
  * Added TCC profile generation and status reporting for privacy configuration
  * Added VM adoption to import existing VMs from external sources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->