### PR TITLE
Prepare Interceptor 0.16.1 release

### DIFF
--- a/.agents/skills/interceptor-browser/SKILL.md
+++ b/.agents/skills/interceptor-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interceptor-browser
-description: "Drive a real signed-in Chrome / Brave session via the `interceptor` CLI — read pages, click and type, navigate, observe network, automate rich editors (Canva / Google Docs / Slides), record and replay flows. Use compound commands (open, read, act, inspect) over low-level verbs. Structured reads over screenshots. Supports named contexts (--context <id>) for routing commands to a specific browser profile when multiple are connected. Workflows: VerifyDeploy (open URL and confirm rendering), ReadAndExtract (page + SPA state), DriveRichEditor (Canva/Docs/Slides scene workflow), OverrideXhr (request mutation), CapturePageCommunication (WebSocket/Beacon/BroadcastChannel), RecordAndReplay (monitor flow + export plan), ScreenshotForVlm (VLM-budgeted screenshot), MultiPageCompare (multi-page fact comparison). USE WHEN verify deploy, check page, read DOM, click, type, fill form, drive editor, override request, capture WebSocket, capture Beacon, capture BroadcastChannel, record flow, replay flow, screenshot for VLM, browser automation, SPA extraction, compare pages, multi-page comparison, designed by X vs Y, facts across N pages, cross-account testing, multi-profile routing. NOT FOR native macOS apps (use interceptor-macos), OS dialogs, browser chrome, or multi-page scraping at scale (use a crawler)."
+description: "Drive a signed-in Chrome / Brave session via the interceptor CLI: open/read pages, click, type, inspect DOM/text/network, automate rich browser editors and scene graphs, capture WebSocket/Beacon/BroadcastChannel traffic, record/replay flows, take VLM-budgeted screenshots, compare pages, and route to specific browser profiles with --context. Use for browser page content, tabs, forms, SPA extraction, request overrides, page communication capture, and deployment checks. Not for native macOS apps, OS dialogs, browser chrome, or large scraping."
 metadata:
   short-description: Drive a real signed-in Chrome / Brave session via the interceptor CLI
 ---
@@ -9,13 +9,23 @@ metadata:
 
 Agent-operator skill for the Browser surface of Interceptor. Use the `interceptor` CLI (no prefix) to drive a live Chrome / Brave session: pages, network, scene graph, monitor, screenshots. For native macOS apps load `interceptor-macos` instead.
 
-Constitutional rules (Input Layer Priority, Screenshot defaults, Surface Decision, `--json` discipline) live in [AGENTS.md](../../../AGENTS.md). This file is a dispatcher to the **Workflows** and **references** below — it does not restate the rules.
+This installed skill is self-contained. Source checkouts also have `AGENTS.md`, but packaged users may only have the skill directory below `/Library/Application Support/Interceptor/skills`.
+
+## Core Rules
+
+- Use compound commands (`open`, `read`, `act`, `inspect`) before low-level verbs.
+- Browser commands operate inside the cyan `interceptor` tab group. Do not use `--any-tab` unless the user explicitly authorizes acting outside that group.
+- `interceptor open <url>` and `interceptor tab new <url>` create background tabs by default. Only `open --activate`, `tab new --activate`, `tab switch <id>`, and `window focus <id>` intentionally move browser focus.
+- If multiple browser profiles are connected, run `interceptor contexts` and pass `--context <id>`.
+- Prefer structured reads (`read`, `tree`, `text`, `inspect`, `scene`) before screenshots. Open `references/screenshot-policy.md` before screenshot-heavy work.
+- Default to plain text output. Use `--json` only when piping into scripts or when a downstream tool needs a machine-readable contract.
+- If an already-loaded unpacked extension behaves stale after a package update, reload it from `chrome://extensions` or `brave://extensions`, or run `interceptor reload` once the extension is reachable.
 
 ## Fast Path
 
 ```bash
 interceptor status                        # 1. Confirm daemon + extension are alive
-interceptor open "https://example.com"    # 2. Compound open: tab + wait + tree + text
+interceptor open "https://example.com"    # 2. Background tab + wait + tree + text
 interceptor read                          # 3. Current state (re-read after any mutation)
 interceptor act e5                        # 4. Click ref e5 (refs come from `read`)
 interceptor act e7 "example user"         # 5. Type into ref e7
@@ -52,7 +62,7 @@ Each workflow is a complete self-contained "you are doing X" procedure. Open the
 
 ## When To Switch Surfaces
 
-If the target is **outside the page** — a native dialog, browser chrome (URL bar, profile picker), Save/Open file picker, OS notification, or any non-browser macOS app — load `interceptor-macos` instead. Decision table is in [AGENTS.md § Surface Decision](../../../AGENTS.md#surface-decision).
+If the target is **outside the page** - a native dialog, browser chrome (URL bar, profile picker), Save/Open file picker, OS notification, or any non-browser macOS app - load `interceptor-macos` instead.
 
 ## Do Not Default To Troubleshooting
 

--- a/.agents/skills/interceptor-browser/references/command-catalog.md
+++ b/.agents/skills/interceptor-browser/references/command-catalog.md
@@ -149,7 +149,8 @@ interceptor wait 1000
 interceptor wait-stable
 
 interceptor tabs
-interceptor tab new <url>
+interceptor tab new <url>             # Background tab in the interceptor group
+interceptor tab new <url> --activate  # Explicit foregrounding
 interceptor tab switch <tab-id>
 interceptor tab close <tab-id>
 interceptor window list

--- a/.agents/skills/interceptor-macos/SKILL.md
+++ b/.agents/skills/interceptor-macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interceptor-macos
-description: "Drive native macOS apps via `interceptor macos *` — read AX trees, click and type with OS-level trusted input, capture occluded / minimized / cross-Space windows, run on-device speech / vision / NLP, dispatch Apple Events, monitor and replay native flows, and run bridge-local JSC host utilities. Background-first by contract — only `app activate` and `open --activate` move focus. Workflows: CaptureBackgroundedApp (occluded window screenshot), DriveBackgroundedApp (click/type on non-frontmost app), DispatchAppleEvent (Apple Events to named app), ReadAxTree (AX tree with Electron wake-up), RecordAndReplayMacFlow (native monitor flow), TrustedInputGate (OS-level trusted input). USE WHEN macOS app, native app, AX tree, Apple Events, screenshot of app, drive Finder/Mail/Cursor, occluded window, browser chrome, URL bar, system dialog, trusted input, on-device vision, on-device speech, NLP, monitor mac flow, replay native, overlay, vibrate, intent dispatch, JSC host. NOT FOR content inside a browser tab (use interceptor-browser)."
+description: "Drive native macOS apps via interceptor macos *: AX trees, background click/type/keys/drag/scroll, occluded or minimized window capture, browser chrome, URL bars, OS dialogs, Apple Events, trusted OS input, monitor/replay, overlays, vision, speech, NLP, and JSC host utilities. Background-first by contract; only app activate and open --activate move focus. Use for native apps, named browser app routing, window control, cross-app work, and system UI. Not for content inside browser pages."
 metadata:
   short-description: Drive native macOS apps via the interceptor CLI; background-first
 ---
@@ -16,7 +16,7 @@ Agent-operator skill for the macOS surface of Interceptor. Use the `interceptor 
 
 The macOS bridge is a Swift daemon launched as a LaunchAgent / `.app` bundle. Links Apple frameworks only (Accessibility, ScreenCaptureKit, AVFoundation, Speech, Vision, NaturalLanguage, OSLogStore, NSAppleScript, container runtime). No private APIs.
 
-Constitutional rules (Background-First, Surface Decision) live in [AGENTS.md](../../../AGENTS.md). This file is a dispatcher to the **Workflows** and **references** below.
+This installed skill is self-contained. Source checkouts also have `AGENTS.md`, but packaged users may only have the skill directory below `/Library/Application Support/Interceptor/skills`.
 
 ## Fast Path
 
@@ -65,7 +65,7 @@ Each workflow is a complete self-contained "you are doing X" procedure. Open the
 
 ## When To Switch Surfaces
 
-If the target is **inside a browser page** (DOM, network, SPA state, browser monitor, scene-graph of a Canva/Docs/Slides editor) — load `interceptor-browser` instead. Decision table is in [AGENTS.md § Surface Decision](../../../AGENTS.md#surface-decision).
+If the target is **inside a browser page** (DOM, network, SPA state, browser monitor, scene graph of a rich editor) - load `interceptor-browser` instead.
 
 ## Do Not Default To Troubleshooting
 

--- a/.agents/skills/interceptor-macos/references/accessibility-and-input.md
+++ b/.agents/skills/interceptor-macos/references/accessibility-and-input.md
@@ -51,7 +51,7 @@ interceptor macos resize e1 --width 672 --height 983
 ## Compound surface for AX
 
 ```bash
-interceptor macos open "Finder"                  # Activate + tree + windows in one call
+interceptor macos open "Finder"                  # Background open + tree + windows in one call
 interceptor macos read                           # Tree + frontmost app info
 interceptor macos act e5                         # Click + wait + updated tree
 interceptor macos act e3 "hello"                 # Type + wait + updated tree

--- a/.agents/skills/interceptor/SKILL.md
+++ b/.agents/skills/interceptor/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: interceptor
+description: "Choose the right Interceptor surface. Use interceptor-browser for page DOM, network, browser tabs, rich editors, screenshots, and browser automation. Use interceptor-macos for native apps, browser chrome, URL bars, OS dialogs, cross-app routing, AX trees, native screenshots, Apple Events, and trusted OS input. Background-first by default; focus changes require explicit opt-in."
+metadata:
+  short-description: Choose the right Interceptor surface
+---
+
+# Interceptor
+
+Use this as the routing skill before loading a surface-specific skill.
+
+## Surface Decision
+
+| Task | Skill |
+|---|---|
+| Page DOM, text, network, SPA state, browser monitor, screenshots of browser content | `interceptor-browser` |
+| Rich browser editors, canvas / scene graph reads, page-world request overrides | `interceptor-browser` |
+| Native macOS apps, OS dialogs, browser chrome, URL bars, app windows, menu bars | `interceptor-macos` |
+| Open or control a named app such as Brave, Mail, Finder, Signal, or Cursor | `interceptor-macos` |
+| Backgrounded, occluded, minimized, or cross-Space app capture | `interceptor-macos` |
+
+## Core Rules
+
+- Browser commands operate inside the cyan `interceptor` tab group. Do not use `--any-tab` unless the user explicitly authorizes acting outside that group.
+- `interceptor open <url>` and `interceptor tab new <url>` create background tabs by default. Only `open --activate`, `tab new --activate`, `tab switch <id>`, and `window focus <id>` intentionally move browser focus.
+- The macOS surface is background-first by default. Only `interceptor macos app activate <app>` and `interceptor macos open <app> --activate` intentionally move focus.
+- If multiple browser profiles are connected, run `interceptor contexts` and pass `--context <id>`.
+- Prefer compound commands (`open`, `read`, `act`, `inspect`) and structured reads before screenshots.
+- If an already-loaded unpacked extension behaves stale after a package update, reload it from `chrome://extensions` or `brave://extensions`, or run `interceptor reload` once the extension is reachable.
+
+## Load A Surface Skill
+
+- Load `interceptor-browser` for browser page content, network, tabs, scene graphs, and browser screenshots.
+- Load `interceptor-macos` for native apps, browser chrome, OS dialogs, window capture, AX trees, and Apple Events.

--- a/cli/daemon-spawn.ts
+++ b/cli/daemon-spawn.ts
@@ -5,22 +5,77 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { IS_WIN, SOCKET_PATH, PID_PATH } from "../shared/platform"
+export const MACOS_PKG_DAEMON_PATH = "/Library/Application Support/Interceptor/interceptor-daemon"
 
-const DAEMON_BINARY = IS_WIN ? "interceptor-daemon.exe" : "interceptor-daemon"
+export type DaemonBinaryCandidateOptions = {
+  platform?: string
+  execPath?: string
+  argv0?: string
+  cwd?: string
+}
 
-export function findDaemonBinary(): string | null {
-  const candidates: string[] = []
-  const exePath = resolve(process.execPath || process.argv[0] || "")
+export type FindDaemonBinaryOptions = DaemonBinaryCandidateOptions & {
+  candidates?: string[]
+  exists?: (path: string) => boolean
+}
+
+function daemonBinaryName(platform: string = process.platform): string {
+  return platform === "win32" ? "interceptor-daemon.exe" : "interceptor-daemon"
+}
+
+function resolveFrom(cwd: string, path: string): string {
+  return resolve(cwd, path)
+}
+
+export function daemonBinaryCandidates(options: DaemonBinaryCandidateOptions = {}): string[] {
+  const platform = options.platform ?? process.platform
+  const binary = daemonBinaryName(platform)
+  const cwd = options.cwd ?? process.cwd()
+  const exePath = resolveFrom(cwd, options.execPath || options.argv0 || process.execPath || process.argv[0] || "")
   const exeDir = dirname(exePath)
-  candidates.push(join(exeDir, "..", "daemon", DAEMON_BINARY))
-  candidates.push(join(exeDir, DAEMON_BINARY))
-  candidates.push(join(exeDir, "daemon", DAEMON_BINARY))
-  candidates.push(resolve("daemon", DAEMON_BINARY))
-  candidates.push(resolve("daemon", "interceptor-daemon"))
+  const candidates: string[] = []
+  candidates.push(join(exeDir, "..", "daemon", binary))
+  candidates.push(join(exeDir, binary))
+  candidates.push(join(exeDir, "daemon", binary))
+  candidates.push(resolveFrom(cwd, "daemon/" + binary))
+  candidates.push(resolveFrom(cwd, "daemon/interceptor-daemon"))
+  if (platform === "darwin") {
+    candidates.push(MACOS_PKG_DAEMON_PATH)
+  }
+  return [...new Set(candidates)]
+}
+
+export function findDaemonBinary(options: FindDaemonBinaryOptions = {}): string | null {
+  const candidates = options.candidates ?? daemonBinaryCandidates(options)
+  const pathExists = options.exists ?? existsSync
   for (const c of candidates) {
-    if (existsSync(c)) return c
+    if (pathExists(c)) return c
   }
   return null
+}
+
+export function formatMissingDaemonBinaryError(
+  candidates = daemonBinaryCandidates(),
+  platform = process.platform,
+): string {
+  const checked = candidates.map((candidate) => `  - ${candidate}`).join("\n")
+  const lines = [
+    "error: daemon not running and interceptor-daemon binary not found.",
+  ]
+
+  if (platform === "darwin") {
+    lines.push(`expected package daemon: ${MACOS_PKG_DAEMON_PATH}`)
+  }
+
+  lines.push("checked:", checked)
+
+  if (platform === "darwin") {
+    lines.push("This is the browser daemon binary, not the macOS bridge. Reinstall Interceptor or rebuild from source.")
+  } else {
+    lines.push("Reinstall Interceptor or rebuild from source.")
+  }
+
+  return lines.join("\n")
 }
 
 /**
@@ -44,7 +99,8 @@ export async function ensureDaemon(): Promise<void> {
     if (!IS_WIN) { try { unlinkSync(SOCKET_PATH) } catch {} }
     try { unlinkSync(PID_PATH) } catch {}
 
-    const resolvedDaemon = findDaemonBinary()
+    const candidates = daemonBinaryCandidates()
+    const resolvedDaemon = findDaemonBinary({ candidates })
 
     if (resolvedDaemon) {
       process.stderr.write("daemon not running — spawning...\n")
@@ -65,7 +121,7 @@ export async function ensureDaemon(): Promise<void> {
         process.exit(1)
       }
     } else {
-      console.error("error: daemon not running and interceptor-daemon binary not found. Open Chrome with the Interceptor extension loaded, or build the daemon.")
+      console.error(formatMissingDaemonBinaryError(candidates))
       process.exit(1)
     }
   }

--- a/daemon/index.ts
+++ b/daemon/index.ts
@@ -11,7 +11,7 @@ import {
   type MonitorSessionMeta,
   updateSessionMeta,
 } from "../shared/monitor-artifacts"
-import { chooseOutboundTransport } from "./outbound-routing"
+import { chooseOutboundTransport, validateContextRouting } from "./outbound-routing"
 import { formatBridgeUnavailableError, getBridgeRecoveryActions, getBridgeRecoveryLayout } from "./bridge-recovery"
 import { clearDaemonRuntimeFiles, decideDaemonStartupRole, defaultLifecycleDeps, readPidState, spawnDetachedStandaloneDaemon } from "./lifecycle"
 
@@ -973,24 +973,13 @@ try {
             continue
           }
 
-          if (request.contextId && !extensionWsMap.has(request.contextId)) {
-            const available = [...extensionWsMap.keys()]
-            const hint = available.length > 0
-              ? ` (connected: ${available.join(", ")})`
-              : " (no extensions connected)"
-            socketWriteFramed(socket, JSON.stringify({
-              id,
-              result: { success: false, error: `context '${request.contextId}' not found${hint}` },
-            }))
-            continue
-          }
-
-          if (!request.contextId && extensionWsMap.size !== 1) {
-            const available = [...extensionWsMap.keys()]
-            const error = available.length === 0
-              ? "no extensions connected"
-              : `multiple extensions connected, use --context <id> (connected: ${available.join(", ")})`
-            socketWriteFramed(socket, JSON.stringify({ id, result: { success: false, error } }))
+          const contextValidation = validateContextRouting({
+            contextId: request.contextId,
+            connectedContexts: [...extensionWsMap.keys()],
+            nativeRelayAvailable: !!nativeRelaySocket,
+          })
+          if (!contextValidation.ok) {
+            socketWriteFramed(socket, JSON.stringify({ id, result: { success: false, error: contextValidation.error } }))
             continue
           }
 
@@ -1105,21 +1094,13 @@ try {
 
         const actionType = (request.action as { type?: string })?.type || "unknown"
 
-        if (request.contextId && !extensionWsMap.has(request.contextId)) {
-          const available = [...extensionWsMap.keys()]
-          const hint = available.length > 0
-            ? ` (connected: ${available.join(", ")})`
-            : " (no extensions connected)"
-          ws.send(JSON.stringify({ id, result: { success: false, error: `context '${request.contextId}' not found${hint}` } }))
-          return
-        }
-
-        if (!request.contextId && extensionWsMap.size !== 1) {
-          const available = [...extensionWsMap.keys()]
-          const error = available.length === 0
-            ? "no extensions connected"
-            : `multiple extensions connected, use --context <id> (connected: ${available.join(", ")})`
-          ws.send(JSON.stringify({ id, result: { success: false, error } }))
+        const contextValidation = validateContextRouting({
+          contextId: request.contextId,
+          connectedContexts: [...extensionWsMap.keys()],
+          nativeRelayAvailable: !!nativeRelaySocket,
+        })
+        if (!contextValidation.ok) {
+          ws.send(JSON.stringify({ id, result: { success: false, error: contextValidation.error } }))
           return
         }
 

--- a/daemon/outbound-routing.ts
+++ b/daemon/outbound-routing.ts
@@ -1,4 +1,7 @@
 export type OutboundTransport = "relay" | "ws" | "native" | "queue"
+export type ContextRoutingValidation =
+  | { ok: true }
+  | { ok: false; error: string }
 
 export function isControlMessage(msg: unknown): boolean {
   const candidate = msg as { type?: unknown }
@@ -24,4 +27,29 @@ export function chooseOutboundTransport(
   if (state.nativeRelayAvailable) return "relay"
   if (!state.standalone && state.stdinAlive) return "native"
   return "queue"
+}
+
+export function validateContextRouting(input: {
+  contextId?: string
+  connectedContexts: string[]
+  nativeRelayAvailable: boolean
+}): ContextRoutingValidation {
+  const { contextId, connectedContexts, nativeRelayAvailable } = input
+
+  if (contextId) {
+    if (connectedContexts.includes(contextId)) return { ok: true }
+    const hint = connectedContexts.length > 0
+      ? ` (connected: ${connectedContexts.join(", ")})`
+      : " (no extensions connected)"
+    return { ok: false, error: `context '${contextId}' not found${hint}` }
+  }
+
+  if (connectedContexts.length === 1) return { ok: true }
+  if (connectedContexts.length === 0 && nativeRelayAvailable) return { ok: true }
+  if (connectedContexts.length === 0) return { ok: false, error: "no extensions connected" }
+
+  return {
+    ok: false,
+    error: `multiple extensions connected, use --context <id> (connected: ${connectedContexts.join(", ")})`,
+  }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.15.2",
+  "version": "0.16.1",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.15.2",
+  "version": "0.16.1",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/build-bridge.sh
+++ b/scripts/build-bridge.sh
@@ -27,6 +27,8 @@ INTERCEPTOR_SPARKLE_PUBLIC_KEY="${INTERCEPTOR_SPARKLE_PUBLIC_KEY:-dnUnuHGCO4obHb
 ## superset, entitlements.plist is the slim CLI/daemon set.
 ENTITLEMENTS="$SCRIPT_DIR/entitlements-bridge.plist"
 APP_DIR="$DIST_DIR/interceptor-bridge.app"
+APP_ICON_SOURCE="$PROJECT_DIR/Interceptor Logo Square.png"
+APP_ICON_NAME="interceptor"
 
 echo "==> Building interceptor-bridge (release)..."
 cd "$BRIDGE_DIR"
@@ -83,6 +85,33 @@ if [[ -d "$SOURCE_RESOURCES_DIR" ]]; then
   done
 fi
 
+# Sparkle's standard update reminder pulls the application icon from the host
+# bundle. The bridge is faceless in normal operation, but the update prompt is
+# user-facing and should show the Interceptor logo instead of a blank app icon.
+if [[ ! -f "$APP_ICON_SOURCE" ]]; then
+  echo "ERROR: App icon source not found at $APP_ICON_SOURCE" >&2
+  exit 1
+fi
+
+ICONSET_DIR="$APP_DIR/Contents/Resources/$APP_ICON_NAME.iconset"
+ICNS_PATH="$APP_DIR/Contents/Resources/$APP_ICON_NAME.icns"
+rm -rf "$ICONSET_DIR"
+mkdir -p "$ICONSET_DIR"
+
+sips -z 16 16 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+sips -z 32 32 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+sips -z 64 64 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+sips -z 128 128 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+sips -z 256 256 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+sips -z 512 512 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+sips -z 1024 1024 "$APP_ICON_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
+iconutil -c icns "$ICONSET_DIR" -o "$ICNS_PATH"
+rm -rf "$ICONSET_DIR"
+echo "==> Bundled app icon: $(basename "$ICNS_PATH")"
+
 # Synthesize Info.plist. LSUIElement=true makes it a faceless agent (no dock
 # icon, no menu bar) — same effect main.swift requests at runtime via
 # NSApplication.setActivationPolicy(.accessory).
@@ -103,6 +132,8 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
     <string>interceptor-bridge</string>
     <key>CFBundleDisplayName</key>
     <string>interceptor-bridge</string>
+    <key>CFBundleIconFile</key>
+    <string>$APP_ICON_NAME</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -308,9 +308,11 @@ run ditto "$REPO_ROOT/extension/dist" "$STAGING_DIR/extension/$DEST_EXTENSION_DI
 # Skill packs — shipped inside the daemon component payload at
 # /Library/Application Support/Interceptor/skills/<name>/. The conclusion
 # screen tells users to symlink these into the runtime skill dirs they use
-# (~/.claude/skills, ~/.agents/skills, etc.). Browser pkg gets the browser-
-# surface skills only; Full pkg also includes the macOS-surface skill.
+# (~/.claude/skills, ~/.agents/skills, etc.). Every pkg gets the top-level
+# router skill plus the browser-surface skill; Full pkg also includes the
+# macOS-surface skill.
 run mkdir -p "$STAGING_DIR/daemon/$DEST_SUPPORT_DIR/skills"
+run ditto "$REPO_ROOT/.agents/skills/interceptor" "$STAGING_DIR/daemon/$DEST_SUPPORT_DIR/skills/interceptor"
 run ditto "$REPO_ROOT/.agents/skills/interceptor-browser" "$STAGING_DIR/daemon/$DEST_SUPPORT_DIR/skills/interceptor-browser"
 
 # Bridge components only when building full mode. The Full daemon component

--- a/scripts/release/Resources/conclusion-browser.html
+++ b/scripts/release/Resources/conclusion-browser.html
@@ -77,8 +77,8 @@
 <body>
   <h2>Interceptor (Browser-Only) is installed.</h2>
 
-  <h3><span class="step-num">1</span>Load the browser extension</h3>
-  <p>Chrome and Brave do not allow installers to load extensions automatically &mdash; you have to do this once, by hand:</p>
+  <h3><span class="step-num">1</span>Load or reload the browser extension</h3>
+  <p>Chrome and Brave do not allow installers to load or refresh extensions automatically &mdash; do this once by hand, and after package updates:</p>
   <ol>
     <li>Open <code>chrome://extensions/</code> (or <code>brave://extensions/</code>)</li>
     <li>Toggle <strong>Developer mode</strong> on (top right)</li>
@@ -86,7 +86,9 @@
     <li>Select this folder:<br>
       <span class="path">/Library/Application Support/Interceptor/extension</span>
     </li>
+    <li>If Interceptor was already loaded from this folder, click its <strong>Reload</strong> button instead.</li>
   </ol>
+  <p>After the extension is connected, <code>interceptor reload</code> also refreshes the running extension service worker.</p>
 
   <h3><span class="step-num">2</span>Optional: register skill packs with your AI tooling</h3>
   <p>Interceptor ships skill packs that teach AI agents how to drive the browser surface. Find your runtime below and paste its block into a terminal. Skip the runtimes you don&rsquo;t use. Existing symlinks of the same name are replaced safely; nothing else is touched.</p>

--- a/scripts/release/Resources/conclusion-full.html
+++ b/scripts/release/Resources/conclusion-full.html
@@ -77,8 +77,8 @@
 <body>
   <h2>Interceptor (Full) is installed. Three quick steps left.</h2>
 
-  <h3><span class="step-num">1</span>Load the browser extension</h3>
-  <p>Chrome and Brave do not allow installers to load extensions automatically &mdash; you have to do this once, by hand:</p>
+  <h3><span class="step-num">1</span>Load or reload the browser extension</h3>
+  <p>Chrome and Brave do not allow installers to load or refresh extensions automatically &mdash; do this once by hand, and after package updates:</p>
   <ol>
     <li>Open <code>chrome://extensions/</code> (or <code>brave://extensions/</code>)</li>
     <li>Toggle <strong>Developer mode</strong> on (top right)</li>
@@ -86,7 +86,9 @@
     <li>Select this folder:<br>
       <span class="path">/Library/Application Support/Interceptor/extension</span>
     </li>
+    <li>If Interceptor was already loaded from this folder, click its <strong>Reload</strong> button instead.</li>
   </ol>
+  <p>After the extension is connected, <code>interceptor reload</code> also refreshes the running extension service worker.</p>
 
   <h3><span class="step-num">2</span>Allow Privacy &amp; Security prompts on first macOS command</h3>
   <p>The first time you run an <code>interceptor macos</code> command, macOS will prompt for <strong>Accessibility</strong>, <strong>Screen Recording</strong>, and <strong>Apple Events</strong> for <code>interceptor-bridge</code>. Allow each one in <strong>System Settings &rarr; Privacy &amp; Security</strong>.</p>

--- a/scripts/release/postinstall-browser
+++ b/scripts/release/postinstall-browser
@@ -12,6 +12,40 @@ set -euo pipefail
 
 INSTALL_ROOT="/Library/Application Support/Interceptor"
 RENDERED_MANIFEST="$INSTALL_ROOT/com.interceptor.host.json"
+DAEMON_PID_PATH="/tmp/interceptor.pid"
+DAEMON_SOCKET_PATH="/tmp/interceptor.sock"
+
+refresh_interceptor_daemon() {
+  local pid=""
+  local command_line=""
+
+  if [[ -f "$DAEMON_PID_PATH" ]]; then
+    pid="$(head -n 1 "$DAEMON_PID_PATH" 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+      if [[ "$command_line" == *"interceptor-daemon"* ]]; then
+        kill "$pid" 2>/dev/null || true
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+          kill -0 "$pid" 2>/dev/null || break
+          sleep 0.1
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+          command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+          if [[ "$command_line" == *"interceptor-daemon"* ]]; then
+            kill -KILL "$pid" 2>/dev/null || true
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  rm -f "$DAEMON_PID_PATH" "$DAEMON_SOCKET_PATH" 2>/dev/null || true
+}
+
+# The browser daemon is a long-lived user process. Stop only that daemon after
+# replacing pkg payloads so the next command cold-starts the newly installed
+# binary; do not touch the separate macOS bridge LaunchAgent.
+refresh_interceptor_daemon
 
 # ── Identify the installing user ──────────────────────────────────────────────
 # The installer sets $USER to root; we need the GUI user who initiated the

--- a/scripts/release/postinstall-full
+++ b/scripts/release/postinstall-full
@@ -19,6 +19,100 @@ set -euo pipefail
 INSTALL_ROOT="/Library/Application Support/Interceptor"
 RENDERED_MANIFEST="$INSTALL_ROOT/com.interceptor.host.json"
 LAUNCH_AGENT_PATH="/Library/LaunchAgents/com.interceptor.bridge.plist"
+DAEMON_PID_PATH="/tmp/interceptor.pid"
+DAEMON_SOCKET_PATH="/tmp/interceptor.sock"
+BRIDGE_PID_PATH="/tmp/interceptor-bridge.pid"
+BRIDGE_SOCKET_PATH="/tmp/interceptor-bridge.sock"
+INSTALL_LOG_PATH="/tmp/interceptor-install.log"
+
+log_install() {
+  printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >>"$INSTALL_LOG_PATH" 2>/dev/null || true
+}
+
+refresh_interceptor_daemon() {
+  local pid=""
+  local command_line=""
+
+  if [[ -f "$DAEMON_PID_PATH" ]]; then
+    pid="$(head -n 1 "$DAEMON_PID_PATH" 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+      if [[ "$command_line" == *"interceptor-daemon"* ]]; then
+        kill "$pid" 2>/dev/null || true
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+          kill -0 "$pid" 2>/dev/null || break
+          sleep 0.1
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+          command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+          if [[ "$command_line" == *"interceptor-daemon"* ]]; then
+            kill -KILL "$pid" 2>/dev/null || true
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  rm -f "$DAEMON_PID_PATH" "$DAEMON_SOCKET_PATH" 2>/dev/null || true
+}
+
+# The browser daemon is a long-lived user process. Stop only that daemon after
+# replacing pkg payloads so the next command cold-starts the newly installed
+# binary; do not touch the separate macOS bridge LaunchAgent.
+refresh_interceptor_daemon
+
+refresh_interceptor_bridge() {
+  local pid=""
+  local command_line=""
+
+  if [[ -f "$BRIDGE_PID_PATH" ]]; then
+    pid="$(head -n 1 "$BRIDGE_PID_PATH" 2>/dev/null | tr -d '[:space:]')"
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+      if [[ "$command_line" == *"interceptor-bridge"* ]]; then
+        log_install "stopping existing interceptor-bridge pid=$pid before LaunchAgent bootstrap"
+        kill "$pid" 2>/dev/null || true
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+          kill -0 "$pid" 2>/dev/null || break
+          sleep 0.1
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+          command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+          if [[ "$command_line" == *"interceptor-bridge"* ]]; then
+            kill -KILL "$pid" 2>/dev/null || true
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  rm -f "$BRIDGE_PID_PATH" "$BRIDGE_SOCKET_PATH" 2>/dev/null || true
+}
+
+bootstrap_bridge_launchagent() {
+  local uid="$1"
+  local domain="gui/$uid"
+  local service="$domain/com.interceptor.bridge"
+
+  log_install "bootstrapping bridge LaunchAgent for $service"
+  /bin/launchctl bootout "$service" >>"$INSTALL_LOG_PATH" 2>&1 || true
+
+  if /bin/launchctl bootstrap "$domain" "$LAUNCH_AGENT_PATH" >>"$INSTALL_LOG_PATH" 2>&1; then
+    /bin/launchctl kickstart -k "$service" >>"$INSTALL_LOG_PATH" 2>&1 || \
+      log_install "WARN: launchctl kickstart failed for $service"
+    return 0
+  fi
+
+  log_install "WARN: direct launchctl bootstrap failed for $service; trying asuser fallback"
+  if /bin/launchctl asuser "$uid" /bin/launchctl bootstrap "$domain" "$LAUNCH_AGENT_PATH" >>"$INSTALL_LOG_PATH" 2>&1; then
+    /bin/launchctl asuser "$uid" /bin/launchctl kickstart -k "$service" >>"$INSTALL_LOG_PATH" 2>&1 || \
+      log_install "WARN: launchctl asuser kickstart failed for $service"
+    return 0
+  fi
+
+  log_install "WARN: bridge LaunchAgent bootstrap failed for $service; it will retry at next login"
+  return 1
+}
 
 # ── Identify the installing user ──────────────────────────────────────────────
 # The installer sets $USER to root; we need the GUI user who initiated the
@@ -56,10 +150,10 @@ fi
 # come up next login even if bootstrap here fails. This block just makes the
 # bridge start immediately for the user who's installing right now.
 if [[ -n "$TARGET_UID" && -f "$LAUNCH_AGENT_PATH" ]]; then
-  # Bootout first for idempotency across re-installs.
-  launchctl asuser "$TARGET_UID" launchctl bootout "gui/$TARGET_UID/com.interceptor.bridge" 2>/dev/null || true
-  launchctl asuser "$TARGET_UID" launchctl bootstrap "gui/$TARGET_UID" "$LAUNCH_AGENT_PATH" 2>/dev/null || true
-  launchctl asuser "$TARGET_UID" launchctl kickstart -k "gui/$TARGET_UID/com.interceptor.bridge" 2>/dev/null || true
+  # Bootout first for idempotency across re-installs, stop any direct-launched
+  # bridge left by a prior install, then start the LaunchAgent-managed bridge.
+  refresh_interceptor_bridge
+  bootstrap_bridge_launchagent "$TARGET_UID" || true
 fi
 
 exit 0

--- a/test/daemon-spawn.test.ts
+++ b/test/daemon-spawn.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import {
+  daemonBinaryCandidates,
+  findDaemonBinary,
+  formatMissingDaemonBinaryError,
+  MACOS_PKG_DAEMON_PATH,
+} from "../cli/daemon-spawn"
+
+describe("daemon spawn binary resolution", () => {
+  test("finds the pkg-installed daemon for installed macOS CLI cold-starts", () => {
+    const found = findDaemonBinary({
+      platform: "darwin",
+      execPath: "/usr/local/bin/interceptor",
+      cwd: "/tmp/interceptor-user-home",
+      exists: (path) => path === MACOS_PKG_DAEMON_PATH,
+    })
+
+    expect(found).toBe(MACOS_PKG_DAEMON_PATH)
+  })
+
+  test("prefers repository daemon before macOS package fallback", () => {
+    const repoRoot = "/workspace/interceptor"
+    const repoDaemon = `${repoRoot}/daemon/interceptor-daemon`
+    const found = findDaemonBinary({
+      platform: "darwin",
+      execPath: `${repoRoot}/dist/interceptor`,
+      cwd: repoRoot,
+      exists: (path) => path === repoDaemon || path === MACOS_PKG_DAEMON_PATH,
+    })
+
+    expect(found).toBe(repoDaemon)
+  })
+
+  test("keeps Windows candidates on exe daemon names without macOS fallback", () => {
+    const candidates = daemonBinaryCandidates({
+      platform: "win32",
+      execPath: "/Program Files/Interceptor/interceptor.exe",
+      cwd: "/work/interceptor",
+    })
+
+    expect(candidates.some((path) => path.endsWith("interceptor-daemon.exe"))).toBe(true)
+    expect(candidates).not.toContain(MACOS_PKG_DAEMON_PATH)
+  })
+
+  test("missing-daemon message names package path without launchctl remediation", () => {
+    const message = formatMissingDaemonBinaryError([
+      "/usr/local/bin/interceptor-daemon",
+      MACOS_PKG_DAEMON_PATH,
+    ], "darwin")
+
+    expect(message).toContain(MACOS_PKG_DAEMON_PATH)
+    expect(message).toContain("browser daemon binary")
+    expect(message).not.toContain("launchctl")
+    expect(message).not.toContain("LaunchAgent")
+  })
+
+  test("missing-daemon message keeps macOS package guidance out of Windows output", () => {
+    const message = formatMissingDaemonBinaryError([
+      "C:\\Program Files\\Interceptor\\interceptor-daemon.exe",
+    ], "win32")
+
+    expect(message).not.toContain(MACOS_PKG_DAEMON_PATH)
+    expect(message).not.toContain("browser daemon binary")
+  })
+})

--- a/test/transport-routing.test.ts
+++ b/test/transport-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { chooseOutboundTransport, isControlMessage } from "../daemon/outbound-routing"
+import { chooseOutboundTransport, isControlMessage, validateContextRouting } from "../daemon/outbound-routing"
 
 describe("daemon outbound transport routing", () => {
   test("classifies ping/pong as control messages", () => {
@@ -30,5 +30,40 @@ describe("daemon outbound transport routing", () => {
       { nativeRelayAvailable: false, extensionWsAvailable: false, stdinAlive: true, standalone: false }
     )
     expect(chosen).toBe("native")
+  })
+
+  test("allows no-context routing through native relay when websocket context is absent", () => {
+    expect(validateContextRouting({
+      connectedContexts: [],
+      nativeRelayAvailable: true,
+    })).toEqual({ ok: true })
+  })
+
+  test("still fails no-context routing when no extension transport is attached", () => {
+    expect(validateContextRouting({
+      connectedContexts: [],
+      nativeRelayAvailable: false,
+    })).toEqual({ ok: false, error: "no extensions connected" })
+  })
+
+  test("requires explicit context when multiple websocket contexts are connected", () => {
+    expect(validateContextRouting({
+      connectedContexts: ["chrome-main", "brave-work"],
+      nativeRelayAvailable: true,
+    })).toEqual({
+      ok: false,
+      error: "multiple extensions connected, use --context <id> (connected: chrome-main, brave-work)",
+    })
+  })
+
+  test("rejects unknown explicit context even when native relay exists", () => {
+    expect(validateContextRouting({
+      contextId: "missing",
+      connectedContexts: ["chrome-main"],
+      nativeRelayAvailable: true,
+    })).toEqual({
+      ok: false,
+      error: "context 'missing' not found (connected: chrome-main)",
+    })
   })
 })


### PR DESCRIPTION
Summary
- bump Interceptor to 0.16.1 and ship the top-level Interceptor skill alongside the browser/macOS skill packs
- fix installed macOS CLI daemon cold-starts by resolving the package-installed daemon path and improving the missing-daemon diagnostic
- preserve native-relay browser routing when no WebSocket context is present, while keeping explicit-context and multi-context safeguards
- refresh stale daemon sockets during package updates and harden Full postinstall so the bridge is restarted under the LaunchAgent
- add the Interceptor app icon to the bridge bundle so Sparkle update prompts show the product logo
- update installer conclusion copy for extension reloads after package updates

Validation
- bash -n scripts/build-bridge.sh scripts/release.sh scripts/release/postinstall-browser scripts/release/postinstall-full scripts/publish-sparkle.sh
- bun test test/daemon-spawn.test.ts test/transport-routing.test.ts test/daemon-lifecycle.test.ts test/native-port-lifecycle.test.ts test/reconnect-lifecycle.test.ts
- bun run typecheck
- bash scripts/release.sh --dry-run

Public hygiene
- staged diff excludes internal planning docs and local runtime/generated artifacts
- staged diff scan found no PRD references, personal names/emails, local volume paths, or common token/key patterns
- release notes will follow the established GitHub Release format and include user-facing features from the latest merged monitor-task PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.16.1

* **New Features**
  * Added macOS application icon to installer interface.
  * Improved daemon startup error messages with platform-specific guidance.

* **Documentation**
  * Updated browser extension installation instructions with clearer reload guidance.
  * Enhanced skill documentation for improved routing behavior.

* **Improvements**
  * Strengthened daemon process lifecycle management during installation.
  * Enhanced extension context routing validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hacker-Valley-Media/Interceptor/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->