### PR TITLE
Release 0.16.2 — fast-fail screenshot on minimized windows

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background/capabilities/screenshot.ts
+++ b/extension/src/background/capabilities/screenshot.ts
@@ -191,6 +191,19 @@ async function handleDomRenderScreenshot(
     return { success: false, error: `tab ${tabId} not found` }
   }
 
+  // Preflight: a minimized window has no live compositor frame to render, so
+  // the DOM-render path would inject screenshot-runner.js and then hang until
+  // the CLI WebSocket client times out at 15s (cli/transport.ts). Match the
+  // --pixel path's fast, honest failure instead.
+  const renderWindow = await chrome.windows.get(targetTab.windowId, { populate: false }).catch(() => null)
+  if (renderWindow && renderWindow.state === "minimized") {
+    return {
+      success: false,
+      error: `window ${targetTab.windowId} is minimized — DOM-render requires the window to be non-minimized`,
+      data: { hint: VISIBILITY_HINT, layer: "preflight", windowState: renderWindow.state }
+    }
+  }
+
   await installScreenshotCorsRule(tabId)
   try {
     const inject = await injectScreenshotRunner(tabId)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/test/screenshot-minimized-preflight.test.ts
+++ b/test/screenshot-minimized-preflight.test.ts
@@ -1,0 +1,90 @@
+/// <reference lib="dom" />
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+// Minimized-window preflight for the DOM-render screenshot path (issue #94).
+//
+// A minimized window has no live compositor frame to render, so the default
+// DOM-render screenshot path used to inject screenshot-runner.js and then hang
+// until the CLI WebSocket client timed out at 15s (cli/transport.ts). The fix
+// adds a `chrome.windows.get(...).state === "minimized"` preflight in
+// handleDomRenderScreenshot that returns the same fast, honest error shape the
+// legacy --pixel path already returns.
+//
+// These tests stub chrome.tabs.get + chrome.windows.get and assert that:
+//   (1) a minimized window short-circuits with the preflight error + data shape
+//       and never touches the content-script / CORS / inject machinery, and
+//   (2) a non-minimized window passes the preflight (proven here by the call
+//       advancing past windows.get to the inject stage).
+
+interface FakeTab { id: number; windowId: number }
+interface FakeWindow { id: number; state: chrome.windows.windowStateEnum }
+
+let windowGetCalls: number[]
+let scriptingInjectCalls: number
+let originalChrome: unknown
+
+function installFakeChrome(tab: FakeTab, win: FakeWindow) {
+  windowGetCalls = []
+  scriptingInjectCalls = 0
+  originalChrome = (globalThis as { chrome?: unknown }).chrome
+  ;(globalThis as { chrome: unknown }).chrome = {
+    tabs: {
+      get: async (tabId: number) => (tabId === tab.id ? tab : null),
+    },
+    windows: {
+      get: async (windowId: number) => {
+        windowGetCalls.push(windowId)
+        return win.id === windowId ? win : null
+      },
+    },
+    // If the preflight fails to short-circuit, the next thing the path does is
+    // install a DNR CORS rule then inject the runner. Stub both so a leak is
+    // observable (scriptingInjectCalls > 0) rather than throwing.
+    declarativeNetRequest: {
+      updateSessionRules: async () => undefined,
+      getSessionRules: async () => [],
+    },
+    scripting: {
+      executeScript: async () => { scriptingInjectCalls++; return [] },
+    },
+  }
+}
+
+function restoreChrome() {
+  ;(globalThis as { chrome?: unknown }).chrome = originalChrome
+}
+
+afterEach(() => {
+  restoreChrome()
+})
+
+describe("DOM-render screenshot — minimized-window preflight", () => {
+  test("minimized window returns the preflight error and never injects the runner", async () => {
+    installFakeChrome({ id: 200, windowId: 1 }, { id: 1, state: "minimized" })
+    const { handleScreenshotActions } = await import("../extension/src/background/capabilities/screenshot")
+    const result = await handleScreenshotActions({ type: "screenshot", save: true }, 200)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("window 1 is minimized")
+    expect(result.error).toContain("DOM-render requires the window to be non-minimized")
+    const data = result.data as { layer?: string; windowState?: string }
+    expect(data.layer).toBe("preflight")
+    expect(data.windowState).toBe("minimized")
+    // Proves the fast-fail: the window state was checked and the runner was
+    // never injected (no 15s hang path).
+    expect(windowGetCalls).toEqual([1])
+    expect(scriptingInjectCalls).toBe(0)
+  })
+
+  test("non-minimized window passes the preflight and proceeds toward injection", async () => {
+    installFakeChrome({ id: 200, windowId: 1 }, { id: 1, state: "normal" })
+    const { handleScreenshotActions } = await import("../extension/src/background/capabilities/screenshot")
+    // We don't drive a full render here (no content script / OffscreenCanvas in
+    // bun's env); we only assert the preflight did NOT short-circuit, i.e. the
+    // path advanced past windows.get to the inject stage.
+    await handleScreenshotActions({ type: "screenshot", save: true }, 200).catch(() => undefined)
+    expect(windowGetCalls).toEqual([1])
+    expect(scriptingInjectCalls).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

DOM-render `screenshot` on a minimized window injected the screenshot runner and then hung until the CLI WebSocket client timed out at 15s, surfacing a generic timeout that looked like a broken daemon/extension/install.

This adds a `chrome.windows.get()` preflight in `handleDomRenderScreenshot` that returns the same fast, honest error the `--pixel` path already returns when the window is minimized — ~0.08s instead of a 15s hang.

Fixes #94.

## Changes
- Minimized-window preflight in the DOM-render screenshot path
- Regression test (`test/screenshot-minimized-preflight.test.ts`)
- Version bump 0.16.1 -> 0.16.2 (package.json, extension/manifest.json)

## Verification
- Live: minimized `screenshot` now returns in ~0.08s with `window <id> is minimized — DOM-render requires the window to be non-minimized`
- No regression: `tree`/`state`/`find`/`tabs` and `--pixel` unchanged; recovery after restore confirmed
- Tests: screenshot suite 13 pass / 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screenshot functionality to fail immediately when windows are minimized, providing clear error feedback instead of indefinite timeouts.

* **Chores**
  * Bumped version to 0.16.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->