### PR TITLE
install: add --chrome-beta / --chrome-canary / --chrome-dev / --chrome-for-testing flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ bash scripts/build.sh
 bash scripts/install.sh --browser-only --brave --profile Default   # browser only, no TCC
 bash scripts/install.sh --full --brave --profile Default           # browser + macOS bridge
 bash scripts/install.sh --brave --profile Default                  # interactive prompt
+bash scripts/install.sh --chrome-beta --browser-only               # a Chrome channel (also --chrome-canary/--chrome-dev/--chrome-for-testing)
 bash scripts/install.sh --full --dry-run                           # print steps without running
 ```
 
@@ -248,14 +249,18 @@ mkdir -p ~/.local/bin
 ln -sf "$PWD/dist/interceptor" ~/.local/bin/interceptor
 ```
 
-#### Chrome Development Path
+#### Chrome channels & the Development Path
 
-Google Chrome ignores `--load-extension` in branded desktop builds. `scripts/install.sh --chrome` still writes the native messaging manifest, but load the extension manually:
+`scripts/install.sh` can target any Chrome channel: `--chrome` (stable), `--chrome-beta`, `--chrome-canary`, `--chrome-dev`, and `--chrome-for-testing` (macOS; Linux deferred, same as the Edge/Vivaldi gap).
+
+All **branded** Google Chrome builds — stable, Beta, Canary, and Dev — ignore `--load-extension` in desktop builds (Chrome 137+ removed the switch for branded builds). For those, `scripts/install.sh` still writes the native messaging manifest, but load the extension manually:
 
 1. Open Chrome and navigate to `chrome://extensions`
 2. Enable **Developer mode**
 3. Click **Load unpacked**
 4. Select `extension/dist/`
+
+**Chrome for Testing** is Google's unbranded automation build and *does* respect `--load-extension`, so `--chrome-for-testing` loads the extension automatically. Two caveats: its native-messaging host directory is `~/Library/Application Support/Google/ChromeForTesting/` as of Chrome 146 (the installer writes there), and it is typically installed as a standalone binary rather than into `/Applications`, so auto-detection may not find it — pass `--chrome-for-testing` explicitly.
 
 #### Uninstall
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,7 +48,12 @@ nm_dir_for() {
     Darwin:chrome-beta)        echo "$HOME/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts" ;;
     Darwin:chrome-canary)      echo "$HOME/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts" ;;
     Darwin:chrome-dev)         echo "$HOME/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts" ;;
-    Darwin:chrome-for-testing) echo "$HOME/Library/Application Support/Google/Chrome for Testing/NativeMessagingHosts" ;;
+    # Chrome for Testing separated its native-messaging host dir from its user-data
+    # dir as of Chrome 146: hosts now live under ~/.../Google/ChromeForTesting/
+    # (no spaces), NOT under the user-data dir "Google/Chrome for Testing". Verified
+    # against the Chrome native-messaging docs; the dispatch (Step 2) also writes the
+    # legacy profile-relative path as a hedge for older builds.
+    Darwin:chrome-for-testing) echo "$HOME/Library/Application Support/Google/ChromeForTesting/NativeMessagingHosts" ;;
     Darwin:edge)               echo "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts" ;;
     Darwin:vivaldi)            echo "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts" ;;
     Linux:brave)               echo "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
@@ -280,20 +285,25 @@ if [[ -z "$BROWSER" ]]; then
     exit 1
   fi
 
+  # First installed browser in priority order — the non-interactive default and the
+  # interactive prompt default, so we never default to a browser that isn't actually
+  # installed (e.g. stable Chrome on a Beta-only host).
+  if   [[ "$CHROME_INSTALLED"             == "1" ]]; then DEFAULT_BROWSER="chrome"
+  elif [[ "$CHROME_BETA_INSTALLED"        == "1" ]]; then DEFAULT_BROWSER="chrome-beta"
+  elif [[ "$CHROME_CANARY_INSTALLED"      == "1" ]]; then DEFAULT_BROWSER="chrome-canary"
+  elif [[ "$CHROME_DEV_INSTALLED"         == "1" ]]; then DEFAULT_BROWSER="chrome-dev"
+  elif [[ "$CHROME_FOR_TESTING_INSTALLED" == "1" ]]; then DEFAULT_BROWSER="chrome-for-testing"
+  elif [[ "$BRAVE_INSTALLED"              == "1" ]]; then DEFAULT_BROWSER="brave"
+  elif [[ "$EDGE_INSTALLED"               == "1" ]]; then DEFAULT_BROWSER="edge"
+  else                                                    DEFAULT_BROWSER="vivaldi"
+  fi
+
   if (( TOTAL_INSTALLED == 1 )); then
-    if   [[ "$CHROME_INSTALLED"             == "1" ]]; then BROWSER="chrome"
-    elif [[ "$CHROME_BETA_INSTALLED"        == "1" ]]; then BROWSER="chrome-beta"
-    elif [[ "$CHROME_CANARY_INSTALLED"      == "1" ]]; then BROWSER="chrome-canary"
-    elif [[ "$CHROME_DEV_INSTALLED"         == "1" ]]; then BROWSER="chrome-dev"
-    elif [[ "$CHROME_FOR_TESTING_INSTALLED" == "1" ]]; then BROWSER="chrome-for-testing"
-    elif [[ "$BRAVE_INSTALLED"              == "1" ]]; then BROWSER="brave"
-    elif [[ "$EDGE_INSTALLED"               == "1" ]]; then BROWSER="edge"
-    else                                                    BROWSER="vivaldi"
-    fi
+    BROWSER="$DEFAULT_BROWSER"
     echo "==> Browser: $BROWSER (only supported browser found)"
   elif [[ "$DRY_RUN" == "1" || ! -t 0 ]]; then
-    BROWSER="chrome"
-    echo "==> Browser not specified; defaulting to '$BROWSER' (non-interactive)."
+    BROWSER="$DEFAULT_BROWSER"
+    echo "==> Browser not specified; defaulting to '$BROWSER' (non-interactive, first installed)."
   else
     echo ""
     echo "Choose target browser:"
@@ -307,8 +317,8 @@ if [[ -z "$BROWSER" ]]; then
     [[ "$VIVALDI_INSTALLED"            == "1" ]] && echo "  vivaldi             Vivaldi"
     [[ "$CHROME_INSTALLED" == "1" && "$BRAVE_INSTALLED" == "1" ]] && echo "  both                Chrome (stable) and Brave"
     echo ""
-    read -r -p "Browser (default: chrome): " ANSWER
-    ANSWER="${ANSWER:-chrome}"
+    read -r -p "Browser (default: $DEFAULT_BROWSER): " ANSWER
+    ANSWER="${ANSWER:-$DEFAULT_BROWSER}"
     case "$ANSWER" in
       chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi|both) BROWSER="$ANSWER" ;;
       *)
@@ -348,7 +358,15 @@ case "$BROWSER" in
   chrome-beta)        NM_DIRS+=("$(nm_dir_for chrome-beta)") ;;
   chrome-canary)      NM_DIRS+=("$(nm_dir_for chrome-canary)") ;;
   chrome-dev)         NM_DIRS+=("$(nm_dir_for chrome-dev)") ;;
-  chrome-for-testing) NM_DIRS+=("$(nm_dir_for chrome-for-testing)") ;;
+  chrome-for-testing)
+    # Chrome 146 moved Chrome for Testing's native-messaging host lookup to a
+    # dedicated dir (Google/ChromeForTesting/). Write that (canonical for 146+) and
+    # ALSO the user-data-dir/NativeMessagingHosts path as a defensive hedge for older
+    # builds / alternate lookups — mirrors how other native-messaging tooling handles
+    # this boundary. The two targets are distinct dirs, so no double-write.
+    NM_DIRS+=("$(nm_dir_for chrome-for-testing)")
+    NM_DIRS+=("$HOME/Library/Application Support/Google/Chrome for Testing/NativeMessagingHosts")
+    ;;
   brave)              NM_DIRS+=("$(nm_dir_for brave)") ;;
   edge)               NM_DIRS+=("$(nm_dir_for edge)") ;;
   vivaldi)            NM_DIRS+=("$(nm_dir_for vivaldi)") ;;
@@ -372,7 +390,7 @@ for dir in "${NM_DIRS[@]}"; do
       *Google/Chrome\ Beta*)             echo "    Chrome Beta:        $dir/com.interceptor.host.json" ;;
       *Google/Chrome\ Canary*)           echo "    Chrome Canary:      $dir/com.interceptor.host.json" ;;
       *Google/Chrome\ Dev*)              echo "    Chrome Dev:         $dir/com.interceptor.host.json" ;;
-      *Google/Chrome\ for\ Testing*)     echo "    Chrome for Testing: $dir/com.interceptor.host.json" ;;
+      *Google/ChromeForTesting*|*Google/Chrome\ for\ Testing*) echo "    Chrome for Testing: $dir/com.interceptor.host.json" ;;
       *Google/Chrome*|*google-chrome*)   echo "    Chrome:             $dir/com.interceptor.host.json" ;;
       *Brave-Browser*|*BraveSoftware*)   echo "    Brave:              $dir/com.interceptor.host.json" ;;
       *Microsoft\ Edge*)                 echo "    Edge:               $dir/com.interceptor.host.json" ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,14 +16,26 @@ PLATFORM="$(uname -s)"   # Darwin | Linux
 # Edge and Vivaldi are Darwin-only in this revision (Linux support deferred to a
 # follow-up PRD; their User Data dirs on Linux are ~/.config/microsoft-edge and
 # ~/.config/vivaldi but install-detection across distros isn't covered yet).
+#
+# Google Chrome ships four sibling channels alongside stable — Beta, Canary, Dev,
+# and "Chrome for Testing" — each with its own User Data dir under
+# ~/Library/Application Support/Google/. Treated here as distinct browser targets
+# so a single host can register Interceptor against any combination of them
+# without manual symlink fiddling. Darwin-only for now (Linux google-chrome-beta /
+# google-chrome-unstable detection across distros isn't covered yet — same
+# rationale as Edge/Vivaldi).
 profile_root_for() {
   case "$PLATFORM:$1" in
-    Darwin:brave)   echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
-    Darwin:chrome)  echo "$HOME/Library/Application Support/Google/Chrome" ;;
-    Darwin:edge)    echo "$HOME/Library/Application Support/Microsoft Edge" ;;
-    Darwin:vivaldi) echo "$HOME/Library/Application Support/Vivaldi" ;;
-    Linux:brave)    echo "$HOME/.config/BraveSoftware/Brave-Browser" ;;
-    Linux:chrome)   echo "$HOME/.config/google-chrome" ;;
+    Darwin:brave)              echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser" ;;
+    Darwin:chrome)             echo "$HOME/Library/Application Support/Google/Chrome" ;;
+    Darwin:chrome-beta)        echo "$HOME/Library/Application Support/Google/Chrome Beta" ;;
+    Darwin:chrome-canary)      echo "$HOME/Library/Application Support/Google/Chrome Canary" ;;
+    Darwin:chrome-dev)         echo "$HOME/Library/Application Support/Google/Chrome Dev" ;;
+    Darwin:chrome-for-testing) echo "$HOME/Library/Application Support/Google/Chrome for Testing" ;;
+    Darwin:edge)               echo "$HOME/Library/Application Support/Microsoft Edge" ;;
+    Darwin:vivaldi)            echo "$HOME/Library/Application Support/Vivaldi" ;;
+    Linux:brave)               echo "$HOME/.config/BraveSoftware/Brave-Browser" ;;
+    Linux:chrome)              echo "$HOME/.config/google-chrome" ;;
     *) return 1 ;;
   esac
 }
@@ -31,12 +43,16 @@ profile_root_for() {
 # Native messaging hosts dir for a browser target on this platform.
 nm_dir_for() {
   case "$PLATFORM:$1" in
-    Darwin:brave)   echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
-    Darwin:chrome)  echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts" ;;
-    Darwin:edge)    echo "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts" ;;
-    Darwin:vivaldi) echo "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts" ;;
-    Linux:brave)    echo "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
-    Linux:chrome)   echo "$HOME/.config/google-chrome/NativeMessagingHosts" ;;
+    Darwin:brave)              echo "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
+    Darwin:chrome)             echo "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts" ;;
+    Darwin:chrome-beta)        echo "$HOME/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts" ;;
+    Darwin:chrome-canary)      echo "$HOME/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts" ;;
+    Darwin:chrome-dev)         echo "$HOME/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts" ;;
+    Darwin:chrome-for-testing) echo "$HOME/Library/Application Support/Google/Chrome for Testing/NativeMessagingHosts" ;;
+    Darwin:edge)               echo "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts" ;;
+    Darwin:vivaldi)            echo "$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts" ;;
+    Linux:brave)               echo "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts" ;;
+    Linux:chrome)              echo "$HOME/.config/google-chrome/NativeMessagingHosts" ;;
     *) return 1 ;;
   esac
 }
@@ -44,10 +60,14 @@ nm_dir_for() {
 # Detect whether a browser is installed on this platform. Echoes 1/0.
 browser_installed() {
   case "$PLATFORM:$1" in
-    Darwin:brave)   [[ -d "/Applications/Brave Browser.app" ]]  && echo 1 || echo 0 ;;
-    Darwin:chrome)  [[ -d "/Applications/Google Chrome.app" ]]  && echo 1 || echo 0 ;;
-    Darwin:edge)    [[ -d "/Applications/Microsoft Edge.app" ]] && echo 1 || echo 0 ;;
-    Darwin:vivaldi) [[ -d "/Applications/Vivaldi.app" ]]        && echo 1 || echo 0 ;;
+    Darwin:brave)              [[ -d "/Applications/Brave Browser.app" ]]              && echo 1 || echo 0 ;;
+    Darwin:chrome)             [[ -d "/Applications/Google Chrome.app" ]]              && echo 1 || echo 0 ;;
+    Darwin:chrome-beta)        [[ -d "/Applications/Google Chrome Beta.app" ]]         && echo 1 || echo 0 ;;
+    Darwin:chrome-canary)      [[ -d "/Applications/Google Chrome Canary.app" ]]       && echo 1 || echo 0 ;;
+    Darwin:chrome-dev)         [[ -d "/Applications/Google Chrome Dev.app" ]]          && echo 1 || echo 0 ;;
+    Darwin:chrome-for-testing) [[ -d "/Applications/Google Chrome for Testing.app" ]]  && echo 1 || echo 0 ;;
+    Darwin:edge)               [[ -d "/Applications/Microsoft Edge.app" ]]             && echo 1 || echo 0 ;;
+    Darwin:vivaldi)            [[ -d "/Applications/Vivaldi.app" ]]                    && echo 1 || echo 0 ;;
     Linux:brave)    command -v brave-browser >/dev/null 2>&1 && echo 1 || echo 0 ;;
     Linux:chrome)   ( command -v google-chrome >/dev/null 2>&1 \
                   || command -v google-chrome-stable >/dev/null 2>&1 ) && echo 1 || echo 0 ;;
@@ -61,10 +81,14 @@ browser_installed() {
 # pgrep + direct exec).
 browser_bin_for() {
   case "$PLATFORM:$1" in
-    Darwin:brave)   echo "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" ;;
-    Darwin:chrome)  echo "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ;;
-    Darwin:edge)    echo "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" ;;
-    Darwin:vivaldi) echo "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi" ;;
+    Darwin:brave)              echo "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" ;;
+    Darwin:chrome)             echo "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ;;
+    Darwin:chrome-beta)        echo "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta" ;;
+    Darwin:chrome-canary)      echo "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" ;;
+    Darwin:chrome-dev)         echo "/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev" ;;
+    Darwin:chrome-for-testing) echo "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" ;;
+    Darwin:edge)               echo "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" ;;
+    Darwin:vivaldi)            echo "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi" ;;
     Linux:brave)
       if command -v brave-browser >/dev/null 2>&1; then echo brave-browser
       else return 1; fi
@@ -90,10 +114,14 @@ while [[ $i -le $# ]]; do
   arg="${!i}"
   case "$arg" in
     --skip-extension) SKIP_EXTENSION=1 ;;
-    --brave)   BROWSER="brave" ;;
-    --chrome)  BROWSER="chrome" ;;
-    --edge)    BROWSER="edge" ;;
-    --vivaldi) BROWSER="vivaldi" ;;
+    --brave)              BROWSER="brave" ;;
+    --chrome)             BROWSER="chrome" ;;
+    --chrome-beta)        BROWSER="chrome-beta" ;;
+    --chrome-canary)      BROWSER="chrome-canary" ;;
+    --chrome-dev)         BROWSER="chrome-dev" ;;
+    --chrome-for-testing) BROWSER="chrome-for-testing" ;;
+    --edge)               BROWSER="edge" ;;
+    --vivaldi)            BROWSER="vivaldi" ;;
     --profile)
       i=$((i + 1))
       PROFILE="${!i}"
@@ -124,12 +152,16 @@ while [[ $i -le $# ]]; do
        echo "                    ScreenCaptureKit + Apple Events). macOS only."
        echo ""
        echo "Browser:"
-       echo "  --brave           Target Brave Browser"
-       echo "  --chrome          Target Google Chrome"
-       echo "  --edge            Target Microsoft Edge (macOS only in this revision)"
-       echo "  --vivaldi         Target Vivaldi (macOS only in this revision)"
-       echo "  --profile <name>  Profile directory name (e.g. \"Default\", \"Profile 2\")"
-       echo "  --profiles        List available profiles and exit"
+       echo "  --brave                Target Brave Browser"
+       echo "  --chrome               Target Google Chrome (stable)"
+       echo "  --chrome-beta          Target Google Chrome Beta (macOS only in this revision)"
+       echo "  --chrome-canary        Target Google Chrome Canary (macOS only in this revision)"
+       echo "  --chrome-dev           Target Google Chrome Dev (macOS only in this revision)"
+       echo "  --chrome-for-testing   Target Google Chrome for Testing (macOS only in this revision)"
+       echo "  --edge                 Target Microsoft Edge (macOS only in this revision)"
+       echo "  --vivaldi              Target Vivaldi (macOS only in this revision)"
+       echo "  --profile <name>       Profile directory name (e.g. \"Default\", \"Profile 2\")"
+       echo "  --profiles             List available profiles and exit"
        echo ""
        echo "Options:"
        echo "  --skip-extension  Only install native messaging (skip extension load)"
@@ -142,10 +174,14 @@ done
 # ── List profiles ──────────────────────────────────────────────────────────────
 if [[ "$LIST_PROFILES" == "1" ]]; then
   if [[ -z "$BROWSER" ]]; then
-    if   [[ "$(browser_installed brave)"   == "1" ]]; then BROWSER="brave"
-    elif [[ "$(browser_installed chrome)"  == "1" ]]; then BROWSER="chrome"
-    elif [[ "$(browser_installed edge)"    == "1" ]]; then BROWSER="edge"
-    elif [[ "$(browser_installed vivaldi)" == "1" ]]; then BROWSER="vivaldi"
+    if   [[ "$(browser_installed brave)"              == "1" ]]; then BROWSER="brave"
+    elif [[ "$(browser_installed chrome)"             == "1" ]]; then BROWSER="chrome"
+    elif [[ "$(browser_installed chrome-beta)"        == "1" ]]; then BROWSER="chrome-beta"
+    elif [[ "$(browser_installed chrome-canary)"      == "1" ]]; then BROWSER="chrome-canary"
+    elif [[ "$(browser_installed chrome-dev)"         == "1" ]]; then BROWSER="chrome-dev"
+    elif [[ "$(browser_installed chrome-for-testing)" == "1" ]]; then BROWSER="chrome-for-testing"
+    elif [[ "$(browser_installed edge)"               == "1" ]]; then BROWSER="edge"
+    elif [[ "$(browser_installed vivaldi)"            == "1" ]]; then BROWSER="vivaldi"
     fi
   fi
   PROFILE_ROOT="$(profile_root_for "$BROWSER" || true)"
@@ -170,6 +206,7 @@ if [[ "$LIST_PROFILES" == "1" ]]; then
   echo "Usage: bash scripts/install.sh --brave --profile \"Profile 2\""
   echo "       bash scripts/install.sh --edge --profiles"
   echo "       bash scripts/install.sh --vivaldi --profiles"
+  echo "       bash scripts/install.sh --chrome-beta --profiles"
   exit 0
 fi
 
@@ -226,22 +263,32 @@ fi
 # only — preserved from the upstream contract).
 if [[ -z "$BROWSER" ]]; then
   CHROME_INSTALLED=$(browser_installed chrome)
+  CHROME_BETA_INSTALLED=$(browser_installed chrome-beta)
+  CHROME_CANARY_INSTALLED=$(browser_installed chrome-canary)
+  CHROME_DEV_INSTALLED=$(browser_installed chrome-dev)
+  CHROME_FOR_TESTING_INSTALLED=$(browser_installed chrome-for-testing)
   BRAVE_INSTALLED=$(browser_installed brave)
   EDGE_INSTALLED=$(browser_installed edge)
   VIVALDI_INSTALLED=$(browser_installed vivaldi)
-  TOTAL_INSTALLED=$(( CHROME_INSTALLED + BRAVE_INSTALLED + EDGE_INSTALLED + VIVALDI_INSTALLED ))
+  TOTAL_INSTALLED=$(( CHROME_INSTALLED + CHROME_BETA_INSTALLED + CHROME_CANARY_INSTALLED \
+                    + CHROME_DEV_INSTALLED + CHROME_FOR_TESTING_INSTALLED \
+                    + BRAVE_INSTALLED + EDGE_INSTALLED + VIVALDI_INSTALLED ))
 
   if (( TOTAL_INSTALLED == 0 )); then
     echo "ERROR: No supported browser found." >&2
-    echo "       Install Chrome, Brave, Edge, or Vivaldi, then re-run." >&2
+    echo "       Install Chrome (stable/Beta/Canary/Dev/for-Testing), Brave, Edge, or Vivaldi, then re-run." >&2
     exit 1
   fi
 
   if (( TOTAL_INSTALLED == 1 )); then
-    if   [[ "$CHROME_INSTALLED"  == "1" ]]; then BROWSER="chrome"
-    elif [[ "$BRAVE_INSTALLED"   == "1" ]]; then BROWSER="brave"
-    elif [[ "$EDGE_INSTALLED"    == "1" ]]; then BROWSER="edge"
-    else                                          BROWSER="vivaldi"
+    if   [[ "$CHROME_INSTALLED"             == "1" ]]; then BROWSER="chrome"
+    elif [[ "$CHROME_BETA_INSTALLED"        == "1" ]]; then BROWSER="chrome-beta"
+    elif [[ "$CHROME_CANARY_INSTALLED"      == "1" ]]; then BROWSER="chrome-canary"
+    elif [[ "$CHROME_DEV_INSTALLED"         == "1" ]]; then BROWSER="chrome-dev"
+    elif [[ "$CHROME_FOR_TESTING_INSTALLED" == "1" ]]; then BROWSER="chrome-for-testing"
+    elif [[ "$BRAVE_INSTALLED"              == "1" ]]; then BROWSER="brave"
+    elif [[ "$EDGE_INSTALLED"               == "1" ]]; then BROWSER="edge"
+    else                                                    BROWSER="vivaldi"
     fi
     echo "==> Browser: $BROWSER (only supported browser found)"
   elif [[ "$DRY_RUN" == "1" || ! -t 0 ]]; then
@@ -250,16 +297,20 @@ if [[ -z "$BROWSER" ]]; then
   else
     echo ""
     echo "Choose target browser:"
-    [[ "$CHROME_INSTALLED"  == "1" ]] && echo "  chrome     Google Chrome"
-    [[ "$BRAVE_INSTALLED"   == "1" ]] && echo "  brave      Brave Browser"
-    [[ "$EDGE_INSTALLED"    == "1" ]] && echo "  edge       Microsoft Edge"
-    [[ "$VIVALDI_INSTALLED" == "1" ]] && echo "  vivaldi    Vivaldi"
-    [[ "$CHROME_INSTALLED" == "1" && "$BRAVE_INSTALLED" == "1" ]] && echo "  both       Chrome and Brave"
+    [[ "$CHROME_INSTALLED"             == "1" ]] && echo "  chrome              Google Chrome (stable)"
+    [[ "$CHROME_BETA_INSTALLED"        == "1" ]] && echo "  chrome-beta         Google Chrome Beta"
+    [[ "$CHROME_CANARY_INSTALLED"      == "1" ]] && echo "  chrome-canary       Google Chrome Canary"
+    [[ "$CHROME_DEV_INSTALLED"         == "1" ]] && echo "  chrome-dev          Google Chrome Dev"
+    [[ "$CHROME_FOR_TESTING_INSTALLED" == "1" ]] && echo "  chrome-for-testing  Google Chrome for Testing"
+    [[ "$BRAVE_INSTALLED"              == "1" ]] && echo "  brave               Brave Browser"
+    [[ "$EDGE_INSTALLED"               == "1" ]] && echo "  edge                Microsoft Edge"
+    [[ "$VIVALDI_INSTALLED"            == "1" ]] && echo "  vivaldi             Vivaldi"
+    [[ "$CHROME_INSTALLED" == "1" && "$BRAVE_INSTALLED" == "1" ]] && echo "  both                Chrome (stable) and Brave"
     echo ""
     read -r -p "Browser (default: chrome): " ANSWER
     ANSWER="${ANSWER:-chrome}"
     case "$ANSWER" in
-      chrome|brave|edge|vivaldi|both) BROWSER="$ANSWER" ;;
+      chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi|both) BROWSER="$ANSWER" ;;
       *)
         echo "Unrecognized browser '$ANSWER'." >&2
         exit 1 ;;
@@ -293,10 +344,14 @@ fi
 echo "==> [browser] Installing native messaging symlink(s)..."
 NM_DIRS=()
 case "$BROWSER" in
-  chrome)  NM_DIRS+=("$(nm_dir_for chrome)") ;;
-  brave)   NM_DIRS+=("$(nm_dir_for brave)") ;;
-  edge)    NM_DIRS+=("$(nm_dir_for edge)") ;;
-  vivaldi) NM_DIRS+=("$(nm_dir_for vivaldi)") ;;
+  chrome)             NM_DIRS+=("$(nm_dir_for chrome)") ;;
+  chrome-beta)        NM_DIRS+=("$(nm_dir_for chrome-beta)") ;;
+  chrome-canary)      NM_DIRS+=("$(nm_dir_for chrome-canary)") ;;
+  chrome-dev)         NM_DIRS+=("$(nm_dir_for chrome-dev)") ;;
+  chrome-for-testing) NM_DIRS+=("$(nm_dir_for chrome-for-testing)") ;;
+  brave)              NM_DIRS+=("$(nm_dir_for brave)") ;;
+  edge)               NM_DIRS+=("$(nm_dir_for edge)") ;;
+  vivaldi)            NM_DIRS+=("$(nm_dir_for vivaldi)") ;;
   both)
     NM_DIRS+=("$(nm_dir_for chrome)")
     NM_DIRS+=("$(nm_dir_for brave)")
@@ -310,11 +365,18 @@ for dir in "${NM_DIRS[@]}"; do
   else
     mkdir -p "$dir"
     ln -sfn "$GENERATED_MANIFEST" "$dir/com.interceptor.host.json"
+    # Order matters: the specific Chrome-branch patterns must precede the generic
+    # *Google/Chrome* glob, otherwise Beta/Canary/Dev/for-Testing get labelled
+    # "Chrome" and the user can't tell which branch was wired.
     case "$dir" in
-      *Google/Chrome*|*google-chrome*)   echo "    Chrome:  $dir/com.interceptor.host.json" ;;
-      *Brave-Browser*|*BraveSoftware*)   echo "    Brave:   $dir/com.interceptor.host.json" ;;
-      *Microsoft\ Edge*)                 echo "    Edge:    $dir/com.interceptor.host.json" ;;
-      *Vivaldi*)                         echo "    Vivaldi: $dir/com.interceptor.host.json" ;;
+      *Google/Chrome\ Beta*)             echo "    Chrome Beta:        $dir/com.interceptor.host.json" ;;
+      *Google/Chrome\ Canary*)           echo "    Chrome Canary:      $dir/com.interceptor.host.json" ;;
+      *Google/Chrome\ Dev*)              echo "    Chrome Dev:         $dir/com.interceptor.host.json" ;;
+      *Google/Chrome\ for\ Testing*)     echo "    Chrome for Testing: $dir/com.interceptor.host.json" ;;
+      *Google/Chrome*|*google-chrome*)   echo "    Chrome:             $dir/com.interceptor.host.json" ;;
+      *Brave-Browser*|*BraveSoftware*)   echo "    Brave:              $dir/com.interceptor.host.json" ;;
+      *Microsoft\ Edge*)                 echo "    Edge:               $dir/com.interceptor.host.json" ;;
+      *Vivaldi*)                         echo "    Vivaldi:            $dir/com.interceptor.host.json" ;;
     esac
   fi
 done
@@ -388,10 +450,14 @@ load_extension() {
 
   local BROWSER_APP BROWSER_BIN BROWSER_NAME
   case "$target" in
-    brave)   BROWSER_NAME="Brave" ;;
-    chrome)  BROWSER_NAME="Chrome" ;;
-    edge)    BROWSER_NAME="Edge" ;;
-    vivaldi) BROWSER_NAME="Vivaldi" ;;
+    brave)              BROWSER_NAME="Brave" ;;
+    chrome)             BROWSER_NAME="Chrome" ;;
+    chrome-beta)        BROWSER_NAME="Chrome Beta" ;;
+    chrome-canary)      BROWSER_NAME="Chrome Canary" ;;
+    chrome-dev)         BROWSER_NAME="Chrome Dev" ;;
+    chrome-for-testing) BROWSER_NAME="Chrome for Testing" ;;
+    edge)               BROWSER_NAME="Edge" ;;
+    vivaldi)            BROWSER_NAME="Vivaldi" ;;
     *)
       echo "ERROR: load_extension called with unknown browser '$target'." >&2
       return 1 ;;
@@ -405,6 +471,22 @@ load_extension() {
       chrome)
         BROWSER_APP="/Applications/Google Chrome.app"
         BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome"
+        ;;
+      chrome-beta)
+        BROWSER_APP="/Applications/Google Chrome Beta.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome Beta"
+        ;;
+      chrome-canary)
+        BROWSER_APP="/Applications/Google Chrome Canary.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome Canary"
+        ;;
+      chrome-dev)
+        BROWSER_APP="/Applications/Google Chrome Dev.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome Dev"
+        ;;
+      chrome-for-testing)
+        BROWSER_APP="/Applications/Google Chrome for Testing.app"
+        BROWSER_BIN="$BROWSER_APP/Contents/MacOS/Google Chrome for Testing"
         ;;
       edge)
         BROWSER_APP="/Applications/Microsoft Edge.app"
@@ -453,7 +535,7 @@ load_extension() {
     echo ""
     echo "    Manual remediation:"
     echo "      1. Quit $BROWSER_NAME entirely."
-    echo "      2. Re-launch $BROWSER_NAME, open $(case "$target" in brave) echo brave://extensions/ ;; chrome) echo chrome://extensions/ ;; edge) echo edge://extensions/ ;; vivaldi) echo vivaldi://extensions/ ;; esac), toggle Developer mode ON."
+    echo "      2. Re-launch $BROWSER_NAME, open $(case "$target" in brave) echo brave://extensions/ ;; chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing) echo chrome://extensions/ ;; edge) echo edge://extensions/ ;; vivaldi) echo vivaldi://extensions/ ;; esac), toggle Developer mode ON."
     echo "      3. Quit $BROWSER_NAME again."
     echo "      4. Re-run: bash scripts/install.sh ${MODE:+--$MODE} --$target${PROFILE:+ --profile \"$PROFILE\"}"
 
@@ -530,14 +612,18 @@ load_extension() {
     fi
   fi
 
-  # Chrome and Edge (both branded Chromium builds) ignore --load-extension on
-  # macOS and Windows desktop. Surface the developer-flow remediation rather
-  # than launch a no-op. Brave and Vivaldi respect --load-extension.
-  if [[ "$target" == "chrome" || "$target" == "edge" ]]; then
+  # Chrome stable / Beta / Canary / Dev and Edge (all branded Chromium builds)
+  # ignore --load-extension on macOS and Windows desktop. Surface the
+  # developer-flow remediation rather than launch a no-op. Brave, Vivaldi, and
+  # Chrome for Testing (an unbranded Google-built testing variant) respect
+  # --load-extension and fall through to the launch path below.
+  if [[ "$target" == "chrome" || "$target" == "chrome-beta" \
+     || "$target" == "chrome-canary" || "$target" == "chrome-dev" \
+     || "$target" == "edge" ]]; then
     local SCHEMA
     case "$target" in
-      chrome) SCHEMA="chrome" ;;
-      edge)   SCHEMA="edge" ;;
+      chrome|chrome-beta|chrome-canary|chrome-dev) SCHEMA="chrome" ;;
+      edge)                                        SCHEMA="edge" ;;
     esac
     echo ""
     echo "==> $BROWSER_NAME ignores --load-extension in branded desktop builds."
@@ -594,10 +680,10 @@ load_extension() {
     echo ""
     echo "    Verify in $BROWSER_NAME:"
     case "$target" in
-      brave)   echo "      1. Open brave://extensions/" ;;
-      chrome)  echo "      1. Open chrome://extensions/" ;;
-      edge)    echo "      1. Open edge://extensions/" ;;
-      vivaldi) echo "      1. Open vivaldi://extensions/" ;;
+      brave)                                                                 echo "      1. Open brave://extensions/" ;;
+      chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing)        echo "      1. Open chrome://extensions/" ;;
+      edge)                                                                  echo "      1. Open edge://extensions/" ;;
+      vivaldi)                                                               echo "      1. Open vivaldi://extensions/" ;;
     esac
     echo "      2. Confirm Developer mode is ON (top-right toggle)."
     echo "      3. Confirm 'Interceptor' appears with ID hkjbaciefhhgekldhncknbjkofbpenng."
@@ -611,7 +697,8 @@ load_extension() {
 }
 
 case "$BROWSER" in
-  chrome|brave|edge|vivaldi) load_extension "$BROWSER" ;;
+  chrome|chrome-beta|chrome-canary|chrome-dev|chrome-for-testing|brave|edge|vivaldi)
+    load_extension "$BROWSER" ;;
   both)
     load_extension chrome
     load_extension brave


### PR DESCRIPTION
## Why

Google Chrome ships four sibling channels alongside stable — Beta, Canary, Dev, and "Chrome for Testing" — each with its own User Data dir under `~/Library/Application Support/Google/`. Today `install.sh` hardcodes stable Chrome, so anyone wanting Interceptor in (say) Chrome Beta has to hand-symlink the generated native messaging manifest into `Google/Chrome Beta/NativeMessagingHosts/com.interceptor.host.json` themselves.

The concrete use case that motivated this: running Interceptor in two browsers side by side (one stable Chrome session, one Beta session) and routing commands to them via `--context <id>`. The extension and daemon already support that; only `install.sh` was in the way.

## What

Four new first-class browser targets:

```
--chrome-beta          Google Chrome Beta
--chrome-canary        Google Chrome Canary
--chrome-dev           Google Chrome Dev
--chrome-for-testing   Google Chrome for Testing
```

Each plugs into the existing helper-and-dispatch shape of the script:

- `profile_root_for` / `nm_dir_for` / `browser_installed` / `browser_bin_for` extended on Darwin. Linux deferred (same rationale as the existing Edge / Vivaldi Linux gaps — the per-distro detection isn't a wedge this PR wants to drive).
- Flag parsing, `--help`, the interactive browser prompt, the `--profiles` auto-detect chain, the `NM_DIRS` dispatch case, the per-dir label print, and the `load_extension` internal cases (`BROWSER_NAME`, Darwin `BROWSER_APP` / `BROWSER_BIN`, dev-mode remediation `chrome://` scheme echo, reachability-probe URL) all extended.
- Chrome stable / Beta / Canary / Dev join Edge in the "branded Chromium build that ignores `--load-extension`" branch — the developer-flow remediation is surfaced rather than launching a no-op. **Chrome for Testing is Google's unbranded testing variant and respects `--load-extension`,** so it falls through to the launch path.

`scripts/build.sh`, the daemon, the extension, and the bridge are all untouched — this is install-time wiring only.

## Validation

```
# bash -n
$ bash -n scripts/install.sh && echo OK
OK

# Routes to the right NativeMessagingHosts dir
$ bash scripts/install.sh --chrome-beta --skip-extension --browser-only --dry-run
==> Browser: chrome-beta
…
    DRY: ln -sfn …/com.interceptor.host.json \
         "$HOME/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/com.interceptor.host.json"

# Falls through to --load-extension launch (unbranded variant)
$ bash scripts/install.sh --chrome-for-testing --browser-only --dry-run
==> Browser: chrome-for-testing
…
==> [browser] DRY: would launch Chrome for Testing --load-extension=…/extension/dist
```

Help text and unknown-flag rejection both updated.

## Out of scope

- Linux detection for the new branches (parallel to existing Edge / Vivaldi Linux gap).
- Extending `both` to a multi-Chrome combination (kept as the historical chrome+brave shortcut to avoid widening the contract in this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install support added for Chrome Beta, Chrome Canary, Chrome Dev, and Chrome for Testing alongside existing browsers.
  * Browser auto-detection, interactive selection, and extension loading now present per-channel Chrome variants across platforms, with macOS app/binary detection.
  * Native-messaging installation and post-install reporting target and label per-channel host directories.

* **Documentation**
  * CLI flags, help text, developer-mode guidance, and post-launch verification links updated for the new Chrome channel options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->