### PR TITLE
build(windows): baseline target for the distributed installer

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -97,10 +97,13 @@ build_macos() {
 }
 
 build_windows() {
-  echo "Building CLI (Windows x64)..."
-  bun build cli/index.ts --compile --target=bun-windows-x64 --outfile=dist/interceptor.exe
-  echo "Building daemon (Windows x64)..."
-  bun build daemon/index.ts --compile --target=bun-windows-x64 --outfile=daemon/interceptor-daemon.exe
+  # Baseline target: no AVX2 requirement, so the distributed installer runs on
+  # any x64 Windows (incl. older/virtualized CPUs) instead of crashing with
+  # "Illegal instruction" at launch. Small speed cost; correct for a public .exe.
+  echo "Building CLI (Windows x64, baseline)..."
+  bun build cli/index.ts --compile --target=bun-windows-x64-baseline --outfile=dist/interceptor.exe
+  echo "Building daemon (Windows x64, baseline)..."
+  bun build daemon/index.ts --compile --target=bun-windows-x64-baseline --outfile=daemon/interceptor-daemon.exe
 }
 
 build_bridge() {


### PR DESCRIPTION
Switches `build_windows()` to `bun-windows-x64-baseline` so the public Windows installer runs on any x64 CPU (no AVX2 requirement) instead of crashing with 'Illegal instruction' on older/virtualized machines. Small speed cost. See PRD-90 F4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows x64 binary compatibility for older and virtualized CPUs to prevent crashes during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->