### PR TITLE
Release 0.16.6 — native macOS VM control plane + Spotlight fs_search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ notary-log-*.json
 release-notes-*.md
 staging/
 /release/
-
+.interceptor/
+reports/
 # Apple container runtime data dir (symlinked from ~/Library/Application Support/com.apple.container/)
 # Holds Linux container images + per-container VM disk state; never tracked.
 .container-data/

--- a/README.md
+++ b/README.md
@@ -495,20 +495,27 @@ A session follows your focus across the interceptor tab group. Switch to another
 ```bash
 interceptor monitor start                              # Begin recording on the active interceptor tab
 interceptor monitor start --instruction "..."          # Annotate with task intent
+interceptor monitor start --task "Teach 9 AM batch" --mode human-teach
 interceptor monitor stop                               # End recording, print summary
+interceptor monitor stop --task <taskId>               # Stop the task envelope only
 interceptor monitor status                             # Show active session(s)
+interceptor monitor status --task <taskId>             # Show task envelope status
 interceptor monitor pause                              # Stop emitting events without ending
 interceptor monitor resume                             # Resume a paused session
+interceptor monitor task attach <taskId> <sessionId>   # Attach an existing source session
 interceptor monitor list                               # All sessions in the event log
 interceptor monitor tail                               # Live tail current session (pretty)
 interceptor monitor tail --raw                         # Live tail (raw JSONL)
 interceptor monitor export <sessionId>                 # Aligned text rendering
+interceptor monitor export --task <taskId> --format transcript
 interceptor monitor export <sessionId> --json          # Raw JSONL for that session
 interceptor monitor export <sessionId> --plan          # Emit interceptor ... replay script
 interceptor monitor export <sessionId> --with-bodies   # Include persisted net-body context when available
 ```
 
 Each event line is sparse JSON (short keys: `t`, `s`, `k`, `sid`, `ref`, `r`, `n`, `cause`) so an agent can read a 30-minute session in a few KB. User actions get a session-monotonic `seq`; mutations and network calls fired within 500ms of an action carry `cause: <action_seq>`. Real user events have `tr: true`; interceptor's own synthetic clicks have `tr: false`. The replay-plan generator automatically includes synthetic clicks when no real user events exist in the session (common when an agent drove the browser). Use `--include-synthetic` to force inclusion regardless.
+
+Tasks are task-scoped; monitor sessions are source-scoped. `--task` creates or attaches a durable task envelope under `${INTERCEPTOR_TASKS_DIR:-<platform app support>}/<taskId>/` while preserving the existing browser/macOS source artifacts. `interceptor monitor export <sessionId>` remains a source-session export. `interceptor monitor export --task <taskId> --format timeline|transcript|json` builds a task-level view by deterministically merging attached source logs, then validating semantic transcript entries against source references.
 
 The rolling live event stream lives in `/tmp/interceptor-events.jsonl`. Export prefers per-session artifacts under `/tmp/interceptor-monitor-sessions/<sessionId>/` (one directory per session containing `events.jsonl`, `session.json`, and `net.jsonl`) and falls back to the rolling event log for legacy sessions. `--with-bodies` uses persisted correlated net-body artifacts when present (body previews are capped at 64 KiB, redact `Authorization` / `Cookie` / token-shaped strings, and only persist JSON / text content types) and otherwise leaves `interceptor net log` hints in the replay output.
 
@@ -904,6 +911,7 @@ Same pattern as the browser monitor. Record what the user does across native app
 # Phase 1 — core monitor (Accessibility TCC required)
 interceptor macos monitor start                  # frontmost-app default scope
 interceptor macos monitor start --instruction "Show me how you file expenses"
+interceptor macos monitor start --task "Teach Slack triage" --mode human-teach --app Slack
 interceptor macos monitor start --app Slack      # scope to a single app
 interceptor macos monitor start --apps Slack,Mail
 interceptor macos monitor start --all-apps       # every running PID + new launches

--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -1065,7 +1065,10 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           if (!name) { console.error("error: interceptor macos vm start requires a name"); process.exit(1) }
           base.name = name
           if (boolArg("--headless")) base.headless = true
-          if (boolArg("--wait-for-vsock")) base.waitForVsock = true
+          if (boolArg("--wait-for-agent") || boolArg("--wait-for-vsock")) {
+            base.waitForAgent = true
+            base.waitForVsock = true
+          }
           if (boolArg("--detach")) base.detach = true
           return base
         }
@@ -1097,6 +1100,13 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           const name = filtered[3]
           if (!name) { console.error("error: interceptor macos vm trust requires a name"); process.exit(1) }
           base.name = name
+          const noPrompt = boolArg("--no-prompt")
+          base.noPrompt = noPrompt
+          base.prompt = !noPrompt && (boolArg("--prompt") || boolArg("--walkthrough"))
+          base.walkthrough = !noPrompt && boolArg("--walkthrough")
+          base.accessibilityPrompt = !noPrompt && boolArg("--accessibility-prompt")
+          base.screenPrompt = !noPrompt && boolArg("--screen-prompt")
+          base.resetDenied = !noPrompt && boolArg("--reset-denied")
           if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
           return base
         }
@@ -1166,6 +1176,9 @@ export function parseMacosCommand(filtered: string[]): Action | null {
           const tag = filtered[4]
           if (!name || !tag) { console.error("error: interceptor macos vm restore requires <name> <tag>"); process.exit(1) }
           base.name = name; base.tag = tag
+          if (boolArg("--disk-only")) base.diskOnly = true
+          if (boolArg("--paused-state")) base.pausedStateOnly = true
+          if (boolArg("--headless")) base.headless = true
           return base
         }
         case "cp": {
@@ -1277,6 +1290,11 @@ export function parseMacosCommand(filtered: string[]): Action | null {
               base.hostPort = Number(parts[1])
               base.guestPort = Number(parts[2])
             }
+          }
+          if (vmSub === "console") {
+            if (strArg("--write")) base.write = strArg("--write")
+            if (intArg("--max-bytes") !== undefined) base.maxBytes = intArg("--max-bytes")
+            if (intArg("--timeout") !== undefined) base.timeout = intArg("--timeout")
           }
           return base
         }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.16.2",
+  "version": "0.16.6",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/interceptor-bridge/InterceptorD/main.swift
+++ b/interceptor-bridge/InterceptorD/main.swift
@@ -1,8 +1,11 @@
 // InterceptorD (in-guest agent)
 //
-// Listens on vsock port 3294 inside a Linux or macOS guest. Speaks the
-// same length-prefixed JSON framing as the host bridge (`WireFormat`
-// pattern). Each inbound request looks like:
+// Guests listen on AF_VSOCK port 3294 by default. Apple documents
+// VZVirtioSocketDevice as a host-to-guest port connection, and the macOS SDK
+// exposes AF_VSOCK / sockaddr_vm for the guest-side listener. A normal TCP
+// listener is available only as an explicit diagnostic fallback.
+// Both paths speak the same length-prefixed JSON framing as the host bridge
+// (`WireFormat` pattern). Each inbound request looks like:
 //
 //   { "id": "<uuid>", "action": { "verb": "exec", ... } }
 //
@@ -23,12 +26,8 @@
 //   cp_in       — receive bytes into a guest path (host pushes)
 //   cp_out      — read a guest path and return bytes (host pulls)
 //
-// vsock semantics on Linux: AF_VSOCK + SOCK_STREAM, family-specific
-// address. On macOS: Darwin doesn't expose AF_VSOCK to user-space; the
-// macOS guest agent therefore binds on a localhost loopback when run
-// under VZ, and the host's VsockGuestAgent connects via
-// VZVirtioSocketDevice.connect(toPort:) — the connection inside the
-// guest is a normal SOCK_STREAM that lands here.
+// vsock semantics: AF_VSOCK + SOCK_STREAM, family-specific address bound to
+// VMADDR_CID_ANY and the Interceptor agent port.
 
 import Foundation
 import Darwin
@@ -76,6 +75,20 @@ func handleExec(_ action: [String: Any]) -> [String: Any] {
     }
     let workdir = action["workdir"] as? String
     let env = action["env"] as? [String: String] ?? [:]
+    let timeout: TimeInterval = {
+        switch action["timeout"] {
+        case let number as NSNumber:
+            return max(0, number.doubleValue)
+        case let double as Double:
+            return max(0, double)
+        case let int as Int:
+            return max(0, TimeInterval(int))
+        case let string as String:
+            return max(0, TimeInterval(string) ?? 0)
+        default:
+            return 0
+        }
+    }()
 
     let task = Process()
     task.executableURL = URL(fileURLWithPath: argv[0])
@@ -97,7 +110,21 @@ func handleExec(_ action: [String: Any]) -> [String: Any] {
     } catch {
         return ["success": false, "error": "exec: spawn failed: \(error.localizedDescription)"]
     }
-    task.waitUntilExit()
+    let sem = DispatchSemaphore(value: 0)
+    task.terminationHandler = { _ in sem.signal() }
+    var timedOut = false
+    if timeout > 0 {
+        timedOut = sem.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            task.terminate()
+            if sem.wait(timeout: .now() + 2) == .timedOut {
+                kill(task.processIdentifier, SIGKILL)
+                _ = sem.wait(timeout: .now() + 2)
+            }
+        }
+    } else {
+        task.waitUntilExit()
+    }
     let durationMs = Int(Date().timeIntervalSince(started) * 1000)
 
     let stdoutData = outPipe.fileHandleForReading.readDataToEndOfFile()
@@ -111,7 +138,8 @@ func handleExec(_ action: [String: Any]) -> [String: Any] {
             "exitCode": task.terminationStatus,
             "stdout": stdout,
             "stderr": stderr,
-            "durationMs": durationMs
+            "durationMs": durationMs,
+            "timedOut": timedOut
         ] as [String: Any]
     ]
 }
@@ -230,11 +258,47 @@ func handleScreenshot(_ action: [String: Any]) -> [String: Any] {
     return ["success": true, "data": ["path": out, "width": cgImage.width, "height": cgImage.height, "bytes": png.count]]
 }
 
+func appMatches(_ app: NSRunningApplication, query: String) -> Bool {
+    let q = query.lowercased()
+    let candidates = [
+        app.localizedName,
+        app.bundleIdentifier,
+        app.bundleURL?.deletingPathExtension().lastPathComponent,
+        app.executableURL?.lastPathComponent,
+    ].compactMap { $0?.lowercased() }
+    return candidates.contains(q) || candidates.contains { $0.contains(q) }
+}
+
+func resolveRunningApp(_ query: String?) -> NSRunningApplication? {
+    let trimmed = query?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let trimmed, !trimmed.isEmpty {
+        return NSWorkspace.shared.runningApplications.first { appMatches($0, query: trimmed) }
+    }
+    return NSWorkspace.shared.frontmostApplication
+}
+
+func eventTargetPID(_ action: [String: Any]) -> pid_t? {
+    guard let app = action["app"] as? String, !app.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return nil
+    }
+    return resolveRunningApp(app)?.processIdentifier
+}
+
+func postEvent(_ event: CGEvent?, targetPID: pid_t?) {
+    guard let event else { return }
+    if let targetPID {
+        event.postToPid(targetPID)
+    } else {
+        event.post(tap: .cghidEventTap)
+    }
+}
+
 func handleType(_ action: [String: Any]) -> [String: Any] {
     guard let text = action["text"] as? String else {
         return ["success": false, "error": "type: missing 'text'"]
     }
     let source = CGEventSource(stateID: .hidSystemState)
+    let pid = eventTargetPID(action)
     for char in text.unicodeScalars {
         // Use the unicode-string path so we don't need to map every key.
         let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
@@ -242,11 +306,11 @@ func handleType(_ action: [String: Any]) -> [String: Any] {
         var u = UniChar(char.value)
         down?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &u)
         up?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &u)
-        down?.post(tap: .cghidEventTap)
-        up?.post(tap: .cghidEventTap)
+        postEvent(down, targetPID: pid)
+        postEvent(up, targetPID: pid)
         usleep(10_000)
     }
-    return ["success": true, "data": ["typed": text.count]]
+    return ["success": true, "data": ["typed": text.count, "targetPID": pid as Any? ?? NSNull()]]
 }
 
 func handleClick(_ action: [String: Any]) -> [String: Any] {
@@ -263,9 +327,10 @@ func handleClick(_ action: [String: Any]) -> [String: Any] {
     default: mb = .left; down = .leftMouseDown; up = .leftMouseUp
     }
     let pt = CGPoint(x: x, y: y)
-    CGEvent(mouseEventSource: source, mouseType: down, mouseCursorPosition: pt, mouseButton: mb)?.post(tap: .cghidEventTap)
-    CGEvent(mouseEventSource: source, mouseType: up, mouseCursorPosition: pt, mouseButton: mb)?.post(tap: .cghidEventTap)
-    return ["success": true, "data": ["x": x, "y": y, "button": button]]
+    let pid = eventTargetPID(action)
+    postEvent(CGEvent(mouseEventSource: source, mouseType: down, mouseCursorPosition: pt, mouseButton: mb), targetPID: pid)
+    postEvent(CGEvent(mouseEventSource: source, mouseType: up, mouseCursorPosition: pt, mouseButton: mb), targetPID: pid)
+    return ["success": true, "data": ["x": x, "y": y, "button": button, "targetPID": pid as Any? ?? NSNull()]]
 }
 
 func handleKeys(_ action: [String: Any]) -> [String: Any] {
@@ -280,10 +345,24 @@ func handleKeys(_ action: [String: Any]) -> [String: Any] {
 func handleReadAX(_ action: [String: Any]) -> [String: Any] {
     let depth = (action["max_depth"] as? Int) ?? 4
     let maxNodes = (action["max_nodes"] as? Int) ?? 500
-    let systemElement = AXUIElementCreateSystemWide()
+    guard let app = resolveRunningApp(action["app"] as? String) else {
+        return ["success": false, "error": "read_ax: no target app found"]
+    }
+
+    let appElement = AXUIElementCreateApplication(app.processIdentifier)
     var visited = 0
-    let tree = axNode(systemElement, depth: 0, maxDepth: depth, maxNodes: maxNodes, visited: &visited)
-    return ["success": true, "data": ["tree": tree, "visited": visited, "maxDepth": depth]]
+    let tree = axNode(appElement, depth: 0, maxDepth: depth, maxNodes: maxNodes, visited: &visited)
+    return [
+        "success": true,
+        "data": [
+            "app": app.localizedName ?? "",
+            "bundleIdentifier": app.bundleIdentifier ?? "",
+            "pid": app.processIdentifier,
+            "tree": tree,
+            "visited": visited,
+            "maxDepth": depth
+        ] as [String: Any]
+    ]
 }
 
 func axString(_ el: AXUIElement, _ attr: CFString) -> String? {
@@ -337,8 +416,18 @@ func axNode(_ el: AXUIElement, depth: Int, maxDepth: Int, maxNodes: Int, visited
 
     guard depth < maxDepth, visited < maxNodes else { return node }
     var childrenRef: CFTypeRef?
+    var children: [AXUIElement] = []
     let result = AXUIElementCopyAttributeValue(el, kAXChildrenAttribute as CFString, &childrenRef)
-    if result == .success, let children = childrenRef as? [AXUIElement], !children.isEmpty {
+    if result == .success, let axChildren = childrenRef as? [AXUIElement], !axChildren.isEmpty {
+        children = axChildren
+    } else {
+        var windowsRef: CFTypeRef?
+        let windowsResult = AXUIElementCopyAttributeValue(el, kAXWindowsAttribute as CFString, &windowsRef)
+        if windowsResult == .success, let windows = windowsRef as? [AXUIElement], !windows.isEmpty {
+            children = windows
+        }
+    }
+    if !children.isEmpty {
         var childNodes: [[String: Any]] = []
         for child in children.prefix(50) {
             if visited >= maxNodes { break }
@@ -446,23 +535,144 @@ func handleLogs(_ action: [String: Any]) -> [String: Any] {
     return ["success": true, "data": ["logs": entries]]
 }
 
+func boolFlag(_ action: [String: Any], _ key: String) -> Bool {
+    return action[key] as? Bool ?? false
+}
+
+#if os(macOS)
+func resetTCC(service: String) -> [String: Any] {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+    task.arguments = ["reset", service]
+    let stdout = Pipe()
+    let stderr = Pipe()
+    task.standardOutput = stdout
+    task.standardError = stderr
+    do {
+        try task.run()
+    } catch {
+        return [
+            "service": service,
+            "ok": false,
+            "error": error.localizedDescription,
+        ]
+    }
+    task.waitUntilExit()
+    let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    return [
+        "service": service,
+        "ok": task.terminationStatus == 0,
+        "exitCode": task.terminationStatus,
+        "stdout": stdoutText,
+        "stderr": stderrText,
+    ]
+}
+
+func checkAccessibility(prompt: Bool) -> Bool {
+    if prompt {
+        let key = "AXTrustedCheckOptionPrompt" as CFString
+        let options = [key: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+    return AXIsProcessTrusted()
+}
+
+func checkScreenRecording(prompt: Bool) -> Bool {
+    if !prompt {
+        return CGPreflightScreenCaptureAccess()
+    }
+    if CGPreflightScreenCaptureAccess() {
+        return true
+    }
+    return CGRequestScreenCaptureAccess()
+}
+
+func openPrivacyPane(_ anchor: String) -> Bool {
+    guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(anchor)") else {
+        return false
+    }
+    return NSWorkspace.shared.open(url)
+}
+#endif
+
 func handleTrust(_ action: [String: Any]) -> [String: Any] {
 #if os(macOS)
-    let accessibility = AXIsProcessTrusted()
-    let screenRecording = CGPreflightScreenCaptureAccess()
+    let noPrompt = boolFlag(action, "noPrompt")
+    let prompt = !noPrompt && boolFlag(action, "prompt")
+    let walkthrough = !noPrompt && boolFlag(action, "walkthrough")
+    let accessibilityPrompt = !noPrompt && boolFlag(action, "accessibilityPrompt")
+    let screenPrompt = !noPrompt && boolFlag(action, "screenPrompt")
+    let resetDenied = !noPrompt && boolFlag(action, "resetDenied")
+
+    let shouldPromptAccessibility = prompt || walkthrough || accessibilityPrompt
+    let shouldPromptScreen = prompt || walkthrough || screenPrompt
+
+    var resetResults: [[String: Any]] = []
+    if resetDenied {
+        if shouldPromptAccessibility {
+            resetResults.append(resetTCC(service: "Accessibility"))
+        }
+        if shouldPromptScreen {
+            resetResults.append(resetTCC(service: "ScreenCapture"))
+        }
+    }
+
+    let accessibility = checkAccessibility(prompt: shouldPromptAccessibility)
+    let screenRecording = checkScreenRecording(prompt: shouldPromptScreen)
+
+    var opened: [String] = []
+    if walkthrough {
+        if !accessibility {
+            if openPrivacyPane("Privacy_Accessibility") {
+                opened.append("Accessibility")
+            }
+        } else if !screenRecording {
+            if openPrivacyPane("Privacy_ScreenCapture") {
+                opened.append("Screen Recording")
+            }
+        }
+    }
+
+    var prompted: [String] = []
+    if shouldPromptAccessibility { prompted.append("Accessibility") }
+    if shouldPromptScreen { prompted.append("Screen Recording") }
+
+    var actionRequired: [String] = []
+    if !accessibility {
+        actionRequired.append("System Settings -> Privacy & Security -> Accessibility -> Enable InterceptorD")
+    }
+    if !screenRecording {
+        actionRequired.append("System Settings -> Privacy & Security -> Screen Recording -> Enable InterceptorD")
+    }
+
+    var data: [String: Any] = [
+        "platform": "macos",
+        "accessibility": accessibility ? "granted" : "denied",
+        "screenRecording": screenRecording ? "granted" : "denied",
+        "postEvent": "unknown",
+        "inputMonitoring": "unknown",
+        "notes": [
+            "Accessibility and Screen Recording expose only boolean preflight state through public APIs here.",
+            "PostEvent/Input Monitoring should be validated by attempting the requested verb and checking failure diagnostics.",
+            "On unmanaged macOS guests, prompts still require user approval in the guest UI; SSH cannot silently grant TCC.",
+        ],
+    ]
+    if !prompted.isEmpty {
+        data["prompted"] = prompted
+    }
+    if !opened.isEmpty {
+        data["opened"] = opened
+    }
+    if !resetResults.isEmpty {
+        data["reset"] = resetResults
+    }
+    if !actionRequired.isEmpty {
+        data["action_required"] = actionRequired
+    }
     return [
         "success": true,
-        "data": [
-            "platform": "macos",
-            "accessibility": accessibility ? "granted" : "denied",
-            "screenRecording": screenRecording ? "granted" : "denied",
-            "postEvent": "unknown",
-            "inputMonitoring": "unknown",
-            "notes": [
-                "Accessibility and Screen Recording expose only boolean preflight state through public APIs here.",
-                "PostEvent/Input Monitoring should be validated by attempting the requested verb and checking failure diagnostics.",
-            ],
-        ],
+        "data": data,
     ]
 #else
     return [
@@ -476,7 +686,14 @@ func handleTrust(_ action: [String: Any]) -> [String: Any] {
 #endif
 }
 
-func isMutatingVerb(_ verb: String) -> Bool {
+func isMutatingVerb(_ verb: String, action: [String: Any]) -> Bool {
+    if verb == "trust" {
+        return boolFlag(action, "prompt")
+            || boolFlag(action, "walkthrough")
+            || boolFlag(action, "accessibilityPrompt")
+            || boolFlag(action, "screenPrompt")
+            || boolFlag(action, "resetDenied")
+    }
     switch verb {
     case "ping", "get_ip", "trust", "read_ax", "screenshot", "logs":
         return false
@@ -495,7 +712,7 @@ func dispatch(request: [String: Any]) -> [String: Any] {
     guard let verb = action["verb"] as? String else {
         return errorResult(id, "missing action.verb")
     }
-    if let requiredAuthToken, isMutatingVerb(verb) {
+    if let requiredAuthToken, isMutatingVerb(verb, action: action) {
         guard action["authToken"] as? String == requiredAuthToken else {
             return errorResult(id, "auth: invalid or missing authToken")
         }
@@ -520,27 +737,42 @@ func dispatch(request: [String: Any]) -> [String: Any] {
     return ["id": id, "result": result]
 }
 
-// MARK: - Loopback server (works on both Linux & macOS guests)
+// MARK: - Guest-agent server
 //
-// In the macOS guest variant we bind on 127.0.0.1:<port> and rely on
-// VZVirtioSocketDevice's port-mapping inside VZ to route the host
-// connection. On Linux a real AF_VSOCK socket is available via the
-// kernel virtio_vsock driver; we open AF_VSOCK in that case.
+// macOS exposes AF_VSOCK and sockaddr_vm in sys/socket.h and sys/vsock.h.
+// Use literal fallbacks so the source remains clear if Swift's imported
+// constants vary by SDK.
 
-func serve() {
-#if os(Linux)
-    let AF_VSOCK_C: Int32 = 40  // Linux AF_VSOCK
-    let VMADDR_CID_ANY: UInt32 = 0xFFFFFFFF
-    let server = socket(AF_VSOCK_C, Int32(SOCK_STREAM.rawValue), 0)
-    if server < 0 {
-        fputs("InterceptorD: AF_VSOCK socket() failed\n", stderr)
-        exit(1)
+let AF_VSOCK_C: Int32 = 40
+let VMADDR_CID_ANY_C: UInt32 = 0xFFFFFFFF
+
+func serveAcceptedClients(server: Int32) -> Never {
+    Darwin.listen(server, 5)
+    while true {
+        let client = Darwin.accept(server, nil, nil)
+        if client < 0 { continue }
+        Thread.detachNewThread { handleClient(fd: client) }
     }
-    // sockaddr_vm layout: u16 family, u16 reserved, u32 port, u32 cid, ...
+}
+
+func openVsockServer() -> Int32? {
+#if os(Linux)
+    let streamType = Int32(SOCK_STREAM.rawValue)
+#else
+    let streamType = SOCK_STREAM
+#endif
+    let server = socket(AF_VSOCK_C, streamType, 0)
+    if server < 0 {
+        fputs("InterceptorD: AF_VSOCK socket() failed: \(String(cString: strerror(errno)))\n", stderr)
+        return nil
+    }
     var addr = sockaddr_vm()
+#if os(macOS)
+    addr.svm_len = UInt8(MemoryLayout<sockaddr_vm>.size)
+#endif
     addr.svm_family = sa_family_t(AF_VSOCK_C)
     addr.svm_port = kAgentPort
-    addr.svm_cid = VMADDR_CID_ANY
+    addr.svm_cid = VMADDR_CID_ANY_C
     let sz = socklen_t(MemoryLayout<sockaddr_vm>.size)
     let bindRes = withUnsafePointer(to: &addr) { ptr -> Int32 in
         ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
@@ -549,18 +781,23 @@ func serve() {
     }
     if bindRes != 0 {
         fputs("InterceptorD: bind() failed: \(String(cString: strerror(errno)))\n", stderr)
-        exit(1)
+        Darwin.close(server)
+        return nil
     }
-    Darwin.listen(server, 5)
+    return server
+}
+
+func serveVsock() -> Never {
     while true {
-        let client = Darwin.accept(server, nil, nil)
-        if client < 0 { continue }
-        Thread.detachNewThread { handleClient(fd: client) }
+        if let server = openVsockServer() {
+            serveAcceptedClients(server: server)
+        }
+        fputs("InterceptorD: waiting for VSOCK device on port \(kAgentPort)\n", stderr)
+        Darwin.sleep(5)
     }
-#else
-    // macOS guest path — bind on all guest interfaces. Virtualization's
-    // macOS guest socket path is not reliable for every host/guest pairing,
-    // so the host bridge can fall back to the guest's NAT IP.
+}
+
+func serveTcpDiagnosticFallback() -> Never {
     let server = socket(AF_INET, SOCK_STREAM, 0)
     if server < 0 {
         fputs("InterceptorD: socket() failed\n", stderr)
@@ -582,13 +819,14 @@ func serve() {
         fputs("InterceptorD: bind() failed: \(String(cString: strerror(errno)))\n", stderr)
         exit(1)
     }
-    Darwin.listen(server, 5)
-    while true {
-        let client = Darwin.accept(server, nil, nil)
-        if client < 0 { continue }
-        Thread.detachNewThread { handleClient(fd: client) }
+    serveAcceptedClients(server: server)
+}
+
+func serve() -> Never {
+    if ProcessInfo.processInfo.environment["INTERCEPTOR_GUEST_TCP_LISTEN"] == "1" {
+        serveTcpDiagnosticFallback()
     }
-#endif
+    serveVsock()
 }
 
 func handleClient(fd: Int32) {
@@ -617,5 +855,6 @@ func handleClient(fd: Int32) {
 
 // MARK: - Entry point
 
-fputs("InterceptorD starting on port \(kAgentPort)\n", stderr)
+let transport = ProcessInfo.processInfo.environment["INTERCEPTOR_GUEST_TCP_LISTEN"] == "1" ? "tcp-diagnostic" : "vsock"
+fputs("InterceptorD starting on \(transport) port \(kAgentPort)\n", stderr)
 serve()

--- a/interceptor-bridge/Sources/Domains/FsDomain.swift
+++ b/interceptor-bridge/Sources/Domains/FsDomain.swift
@@ -276,108 +276,157 @@ final class FsDomain: DomainHandler, @unchecked Sendable {
             return
         }
 
-        // Try Spotlight (NSMetadataQuery) first. For machine-wide
-        // ("everywhere") scope, only match filenames — kMDItemTextContent
-        // across LocalComputerScope is unbounded and routinely blows past
-        // the gather window. Narrower scopes can still use the compound
-        // name+content predicate.
-        let mq = NSMetadataQuery()
-        mq.searchScopes = mqScopes
-        if scope == "everywhere" {
-            mq.predicate = NSPredicate(
-                format: "(kMDItemDisplayName LIKE[cd] %@) OR (kMDItemFSName LIKE[cd] %@)",
-                "*\(query)*", "*\(query)*"
-            )
-        } else {
-            mq.predicate = NSPredicate(
-                format: "(kMDItemDisplayName LIKE[cd] %@) OR (kMDItemFSName LIKE[cd] %@) OR (kMDItemTextContent LIKE[cd] %@)",
-                "*\(query)*", "*\(query)*", "*\(query)*"
-            )
-        }
-        mq.sortDescriptors = [NSSortDescriptor(key: NSMetadataItemFSContentChangeDateKey, ascending: false)]
-
-        let lock = NSLock()
-        var captured = false
-        var observer: NSObjectProtocol?
-
-        @Sendable func extractMatches(from query: NSMetadataQuery, max: Int) -> [[String: Any]] {
-            var rows: [[String: Any]] = []
-            for i in 0..<min(query.resultCount, max) {
-                guard let item = query.result(at: i) as? NSMetadataItem,
-                      let path = item.value(forAttribute: NSMetadataItemPathKey) as? String else { continue }
-                let pathUrl = URL(fileURLWithPath: path)
-                let kindLabel = item.value(forAttribute: NSMetadataItemKindKey) as? String
-                if !self.matchesKinds(requestedKinds, at: pathUrl, kindLabel: kindLabel) {
-                    continue
-                }
-                var entry: [String: Any] = ["path": path]
-                if let name = item.value(forAttribute: NSMetadataItemDisplayNameKey) as? String ??
-                              item.value(forAttribute: NSMetadataItemFSNameKey) as? String {
-                    entry["name"] = name
-                }
-                if let kindLabel { entry["kind"] = kindLabel }
-                if let size = item.value(forAttribute: NSMetadataItemFSSizeKey) as? Int { entry["size"] = size }
-                if let modified = item.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date {
-                    entry["modified"] = ISO8601DateFormatter().string(from: modified)
-                }
-                rows.append(entry)
-            }
-            return rows
-        }
-
-        func finish(_ matches: [[String: Any]], indexed: Bool) {
-            lock.lock(); if captured { lock.unlock(); return }; captured = true; lock.unlock()
-            if let obs = observer { NotificationCenter.default.removeObserver(obs); observer = nil }
-            mq.stop()
+        // Spotlight via `mdfind` (synchronous). NSMetadataQuery's async
+        // DidFinishGathering delivery does NOT fire in the faceless launchd-agent
+        // context — the query times out and falls back even with an
+        // operationQueue set: a deployed faceless bridge was measured timing out
+        // at ~2.18s and falling back, while `mdfind` from the same process
+        // returned results instantly. `mdfind` is a fresh process that connects
+        // to the metadata server directly and returns results synchronously
+        // regardless of run-loop context. `mqScopes` is retained above for the
+        // scope-resolution/validation it performs; the actual Spotlight scoping
+        // now flows through `bfsRoots` as `mdfind -onlyin` roots.
+        _ = mqScopes
+        let spotlight = self.spotlightSearchViaMdfind(
+            query: query,
+            scopePaths: bfsRoots,                 // [] for "everywhere" → no -onlyin
+            nameOnly: scope == "everywhere",      // content across the whole machine is unbounded
+            limit: limit,
+            requestedKinds: requestedKinds
+        )
+        if !spotlight.isEmpty {
             completion(WireFormat.success([
-                "matches": matches,
-                "indexed": indexed,
-                "source": indexed ? "spotlight" : "fallback",
+                "matches": spotlight,
+                "indexed": true,
+                "source": "spotlight",
                 "scope": scopeLabel,
                 "query": query,
-                "count": matches.count
+                "count": spotlight.count
             ]))
-        }
-
-        observer = NotificationCenter.default.addObserver(
-            forName: .NSMetadataQueryDidFinishGathering,
-            object: mq,
-            queue: nil
-        ) { _ in
-            mq.disableUpdates()
-            let rows = extractMatches(from: mq, max: limit)
-            finish(rows, indexed: true)
-        }
-
-        if !mq.start() {
-            finish([], indexed: false)
             return
         }
 
-        // Bound the wait — Spotlight should respond in <2s for indexed scopes.
-        // If empty after 2s, also kick off the fallback breadth-first scan;
-        // whichever produces a non-empty result first wins.
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) { [self] in
-            if captured { return }
-            // Snapshot whatever Spotlight has so far; if non-empty, take it.
-            mq.disableUpdates()
-            let snap = extractMatches(from: mq, max: limit)
-            if !snap.isEmpty {
-                finish(snap, indexed: true)
-                return
-            }
-            // Spotlight had nothing. Run the breadth-first enumerator fallback
-            // across every BFS root (skip when scope is "everywhere" since
-            // walking / unbounded would block this thread for minutes).
-            var allMatches: [[String: Any]] = []
-            for root in bfsRoots {
-                if allMatches.count >= limit { break }
-                let remaining = limit - allMatches.count
-                let chunk = self.fallbackBfsSearch(query: query, root: root, limit: remaining, requestedKinds: requestedKinds)
-                allMatches.append(contentsOf: chunk)
-            }
-            finish(allMatches, indexed: false)
+        // Spotlight returned nothing (or mdfind unavailable) → breadth-first
+        // fallback across the path roots (empty for "everywhere", so that scope
+        // simply yields no matches rather than an unbounded walk).
+        var allMatches: [[String: Any]] = []
+        for root in bfsRoots {
+            if allMatches.count >= limit { break }
+            let remaining = limit - allMatches.count
+            let chunk = self.fallbackBfsSearch(query: query, root: root, limit: remaining, requestedKinds: requestedKinds)
+            allMatches.append(contentsOf: chunk)
         }
+        completion(WireFormat.success([
+            "matches": allMatches,
+            "indexed": false,
+            "source": "fallback",
+            "scope": scopeLabel,
+            "query": query,
+            "count": allMatches.count
+        ]))
+    }
+
+    /// Synchronous Spotlight search via `mdfind`. Returns enriched matches, or
+    /// `[]` on no result / mdfind-unavailable (caller then runs the BFS
+    /// fallback). Mirrors the old NSMetadataQuery predicate: name-only for
+    /// machine-wide scope, name+content for rooted scopes. Runs one `mdfind` per
+    /// scope root (mdfind takes a single `-onlyin`), or one global run when
+    /// unscoped. Results are enriched with kind/size/modified in-process via
+    /// URLResourceValues — no per-result subprocess.
+    private func spotlightSearchViaMdfind(
+        query: String,
+        scopePaths: [String],
+        nameOnly: Bool,
+        limit: Int,
+        requestedKinds: Set<String>
+    ) -> [[String: Any]] {
+        let esc = query
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let pat = "*\(esc)*"
+        let expr: String
+        if nameOnly {
+            expr = "(kMDItemFSName = \"\(pat)\"cd) || (kMDItemDisplayName = \"\(pat)\"cd)"
+        } else {
+            expr = "(kMDItemFSName = \"\(pat)\"cd) || (kMDItemDisplayName = \"\(pat)\"cd) || (kMDItemTextContent = \"\(pat)\"cd)"
+        }
+
+        // Gather candidate paths (dedupe; a few extra to survive kinds-filtering).
+        let gatherCap = max(limit * 4, limit)
+        var seen = Set<String>()
+        var paths: [String] = []
+        let runs: [String?] = scopePaths.isEmpty ? [nil] : scopePaths
+        outer: for sp in runs {
+            for p in runMdfind(onlyIn: sp, queryExpr: expr, maxResults: gatherCap) {
+                if seen.insert(p).inserted {
+                    paths.append(p)
+                    if paths.count >= gatherCap { break outer }
+                }
+            }
+        }
+
+        let iso = ISO8601DateFormatter()
+        var matches: [[String: Any]] = []
+        for path in paths {
+            if matches.count >= limit { break }
+            let url = URL(fileURLWithPath: path)
+            let vals = try? url.resourceValues(forKeys: [.contentTypeKey, .fileSizeKey, .contentModificationDateKey])
+            let kindLabel = vals?.contentType?.localizedDescription
+            if !self.matchesKinds(requestedKinds, at: url, kindLabel: kindLabel) { continue }
+            var entry: [String: Any] = ["path": path, "name": url.lastPathComponent]
+            if let kindLabel { entry["kind"] = kindLabel }
+            if let size = vals?.fileSize { entry["size"] = size }
+            if let modified = vals?.contentModificationDate {
+                entry["modified"] = iso.string(from: modified)
+            }
+            matches.append(entry)
+        }
+        return matches
+    }
+
+    /// Run `/usr/bin/mdfind` synchronously and return result paths (one absolute
+    /// path per stdout line, capped at `maxResults`). stderr is discarded
+    /// (mdfind logs locale-parser chatter there). Reads incrementally and
+    /// terminates mdfind once it has `maxResults` lines, so a query that matches
+    /// a huge set (e.g. 11k files for "media kit") still returns the first page
+    /// near-instantly instead of paying to enumerate every match. Returns `[]`
+    /// if mdfind cannot be launched.
+    private func runMdfind(onlyIn: String?, queryExpr: String, maxResults: Int) -> [String] {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/mdfind")
+        var args: [String] = []
+        if let dir = onlyIn { args += ["-onlyin", dir] }
+        args.append(queryExpr)
+        proc.arguments = args
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+        } catch {
+            return []
+        }
+        let handle = out.fileHandleForReading
+        let cap = max(maxResults, 1)
+        var buffer = Data()
+        var lines: [String] = []
+        while lines.count < cap {
+            let chunk = handle.availableData          // blocks until data or EOF
+            if chunk.isEmpty { break }                // EOF — mdfind finished
+            buffer.append(chunk)
+            while let nl = buffer.firstIndex(of: 0x0A) {
+                let lineData = buffer.subdata(in: buffer.startIndex..<nl)
+                buffer.removeSubrange(buffer.startIndex...nl)
+                if let line = String(data: lineData, encoding: .utf8), !line.isEmpty {
+                    lines.append(line)
+                    if lines.count >= cap { break }
+                }
+            }
+        }
+        // Stop mdfind once we have enough — don't enumerate the whole match set.
+        proc.terminate()
+        proc.waitUntilExit()
+        return lines
     }
 
     /// Breadth-first fallback that visits the workspace root's top-level

--- a/interceptor-bridge/Sources/Domains/MonitorSession.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorSession.swift
@@ -45,7 +45,7 @@ final class MonitorSession: @unchecked Sendable {
 
     init(
         id: String,
-        taskId: String?,
+        taskId: String? = nil,
         instruction: String?,
         startTime: Date,
         scope: MonitorScope,

--- a/interceptor-bridge/Sources/Domains/VmDomain.swift
+++ b/interceptor-bridge/Sources/Domains/VmDomain.swift
@@ -79,8 +79,8 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
             case "cp":         try await handleCp(action, completion: completion)
             case "share":      try await handleShare(action, completion: completion)
             case "tcc_profile_generate": try await handleTccProfileGenerate(action, completion: completion)
-            case "console", "port_forward":
-                completion(WireFormat.error("vm \(sub): pending v2 — console/port-forward require VM runtime device wiring"))
+            case "console":    try await handleConsole(action, completion: completion)
+            case "port_forward": try await handlePortForward(action, completion: completion)
             default:
                 completion(WireFormat.error("vm: unknown verb '\(sub)'"))
             }
@@ -112,6 +112,21 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
             return TimeInterval(string) ?? defaultValue
         default:
             return defaultValue
+        }
+    }
+
+    private func intValue(from value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber:
+            return number.intValue
+        case let int as Int:
+            return int
+        case let double as Double:
+            return Int(double)
+        case let string as String:
+            return Int(string)
+        default:
+            return nil
         }
     }
 
@@ -173,7 +188,13 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
         let spec = VMSpec(
             name: name, kind: kind, cpu: cpu, memorySize: memory, diskSize: disk,
             image: image, network: network,
-            shares: shares, rosetta: rosetta
+            shares: shares, rosetta: rosetta,
+            agent: VMGuestAgentSpec(
+                enabled: true,
+                transport: .vsock,
+                port: kInterceptorGuestAgentPort,
+                trustStatus: kind == .macos ? "transport_unverified" : "unknown"
+            )
         )
         let reg = try registry(from: action)
         let bundle = try await reg.create(spec)
@@ -200,6 +221,20 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
         let modeStr = (action["mode"] as? String) ?? "clone"
         guard let mode = VMAdoptMode(rawValue: modeStr) else {
             completion(WireFormat.error("vm adopt: --mode must be clone, move, or reference")); return
+        }
+        let installAgent = (action["installAgent"] as? Bool) ?? false
+        let waitForAgent = (action["waitForAgent"] as? Bool) ?? false
+        if installAgent || waitForAgent {
+            completion([
+                "success": false,
+                "error": "vm adopt: unsupported-transport: --install-agent/--wait-for-agent require a configured macOS guest bootstrap transport; current VZ adoption cannot install or trust-probe InterceptorD safely",
+                "setup_required": [
+                    "reason": "adopt-time guest-agent install/readiness is fail-closed until macOS guest transport is explicitly configured",
+                    "command": "adopt without --install-agent/--wait-for-agent, install InterceptorD inside the guest image, then run `interceptor macos vm start \(name) --wait-for-agent`",
+                    "docs": "reports/macos-vm-agent-transport-background-2026-05-27.md",
+                ],
+            ])
+            return
         }
         let source = URL(fileURLWithPath: (sourcePath as NSString).expandingTildeInPath)
         let reg = try registry(from: action)
@@ -283,7 +318,7 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
             completion(WireFormat.error("vm start: missing 'name'")); return
         }
         let headless = (action["headless"] as? Bool) ?? false
-        let waitForVsock = (action["waitForVsock"] as? Bool) ?? false
+        let waitForAgent = (action["waitForAgent"] as? Bool) ?? (action["waitForVsock"] as? Bool) ?? false
         let reg = try registry(from: action)
         let spec = try await reg.get(name)
         let bundle = await reg.bundle(for: name)
@@ -297,7 +332,7 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
         let inst = VMInstance(spec: spec, bundle: bundle, status: .ready)
         putInstance(inst, name: name)
         do {
-            let r = try await inst.start(headless: headless, waitForVsock: waitForVsock)
+            let r = try await inst.start(headless: headless, waitForAgent: waitForAgent)
             // Persist startedAt
             var updated = spec
             updated.startedAt = Date()
@@ -733,29 +768,83 @@ final class VmDomain: DomainHandler, @unchecked Sendable {
         }
         let reg = try registry(from: action)
         let bundle = await reg.bundle(for: name)
-        let snapDir = bundle.snapshotDir(tag: tag)
-        let snapDisk = snapDir.appendingPathComponent("Disk.img")
-        guard FileManager.default.fileExists(atPath: snapDisk.path) else {
-            completion(WireFormat.error("vm restore: snapshot '\(tag)' has no Disk.img"))
-            return
-        }
+        let spec = try await reg.get(name)
+        let diskOnly = action["diskOnly"] as? Bool ?? false
+        let pausedStateOnly = action["pausedStateOnly"] as? Bool ?? false
+        let headless = action["headless"] as? Bool ?? true
         // Stop the VM first if running.
         if let inst = instance(for: name) {
             try? await inst.stop(force: true, timeout: 10)
             dropInstance(name: name)
         }
-        let parked = bundle.bundlePath.appendingPathComponent("Disk.img.pre-restore-\(Int(Date().timeIntervalSince1970))")
+        let inst = VMInstance(spec: spec, bundle: bundle, status: .stopped)
         do {
-            if FileManager.default.fileExists(atPath: bundle.diskPath.path) {
-                try FileManager.default.moveItem(at: bundle.diskPath, to: parked)
+            let manifest = try await inst.restoreSnapshot(
+                tag: tag,
+                diskOnly: diskOnly,
+                pausedStateOnly: pausedStateOnly,
+                headless: headless
+            )
+            let status = await inst.status
+            if status == .paused || status == .running {
+                putInstance(inst, name: name)
             }
-            try FileManager.default.copyItem(at: snapDisk, to: bundle.diskPath)
-            try? FileManager.default.removeItem(at: parked)
-            completion(WireFormat.success(["tag": tag, "restored": "disk"]))
+            completion(WireFormat.success([
+                "tag": manifest.tag,
+                "state": status.rawValue,
+                "kind": manifest.kind,
+                "hasPausedState": manifest.hasPausedState,
+                "hasDiskClone": manifest.hasDiskClone,
+                "restored": status == .paused ? "paused-state" : "disk",
+            ]))
         } catch {
-            // best-effort rollback
-            try? FileManager.default.moveItem(at: parked, to: bundle.diskPath)
             completion(WireFormat.error("vm restore: \(error)"))
+        }
+    }
+
+    private func handleConsole(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let resolved = guestInstance(from: action, verb: "console", completion: completion) else { return }
+        let timeout = timeInterval(from: action["timeout"], default: 1)
+        do {
+            if let text = action["write"] as? String {
+                let bytes = try await resolved.inst.consoleWrite(text)
+                completion(WireFormat.success(["bytesWritten": bytes]))
+                return
+            }
+            let maxBytes = intValue(from: action["maxBytes"]) ?? 4096
+            let data = try await resolved.inst.consoleRead(maxBytes: maxBytes, timeout: timeout)
+            completion(WireFormat.success([
+                "bytes": data.count,
+                "text": String(data: data, encoding: .utf8) ?? "",
+                "dataBase64": data.base64EncodedString(),
+            ]))
+        } catch {
+            completion(WireFormat.error("vm console: \(error)"))
+        }
+    }
+
+    private func handlePortForward(_ action: [String: Any], completion: @escaping @Sendable ([String: Any]) -> Void) async throws {
+        guard let resolved = guestInstance(from: action, verb: "port-forward", completion: completion) else { return }
+        let hostAddress = action["hostAddress"] as? String ?? "127.0.0.1"
+        let hostPort = intValue(from: action["hostPort"]) ?? 0
+        guard let guestPort = intValue(from: action["guestPort"]) else {
+            completion(WireFormat.error("vm port-forward: missing guest port; use <hostPort>:<guestPort> or <hostAddress>:<hostPort>:<guestPort>"))
+            return
+        }
+        guard (0...65535).contains(hostPort), (1...65535).contains(guestPort) else {
+            completion(WireFormat.error("vm port-forward: ports must be in range"))
+            return
+        }
+        do {
+            let result = try await resolved.inst.portForward(hostAddress: hostAddress, hostPort: hostPort, guestPort: guestPort)
+            completion(WireFormat.success([
+                "hostAddress": result.hostAddress,
+                "hostPort": result.hostPort,
+                "guestAddress": result.guestAddress,
+                "guestPort": result.guestPort,
+            ]))
+        } catch {
+            completion(WireFormat.error("vm port-forward: \(error)"))
         }
     }
 }

--- a/interceptor-bridge/Sources/VM/GuestAgent.swift
+++ b/interceptor-bridge/Sources/VM/GuestAgent.swift
@@ -1,13 +1,16 @@
 // GuestAgent
 //
-// vsock client used by the host bridge to dispatch verbs INTO a running
-// guest. The guest agent (InterceptorD, CL29-CL32) listens on
-// VSOCK port 3294. We connect via
+// Guest-agent client used by the host bridge to dispatch verbs INTO a
+// running guest. The preferred VZ path requires the guest to expose a
+// Virtio socket endpoint on port 3294. We connect via
 // `VZVirtioSocketDevice.connect(toPort:completionHandler:)` per
 // `apple-developer-docs/Virtualization/VZVirtioSocketDevice.md:25-30`,
 // take the resulting `VZVirtioSocketConnection.fileDescriptor`, and
 // speak the same length-prefixed JSON framing the host bridge already
 // uses (`WireFormat`).
+//
+// A normal macOS guest TCP listener is not the same as a Virtio socket
+// endpoint. TCP is only attempted when a VM spec explicitly configures it.
 //
 // Wire framing (host ↔ guest):
 //   [4 bytes little-endian length][JSON payload]
@@ -108,9 +111,10 @@ public extension GuestAgent {
     }
 
     func exec(_ argv: [String], env: [String: String] = [:], workdir: String? = nil, tty: Bool = false, timeout: TimeInterval = 60) async throws -> (exitCode: Int32, stdout: String, stderr: String, durationMs: Int) {
-        var action: [String: Any] = ["verb": "exec", "argv": argv, "env": env, "tty": tty]
+        var action: [String: Any] = ["verb": "exec", "argv": argv, "env": env, "tty": tty, "timeout": timeout]
         if let w = workdir { action["workdir"] = w }
-        let r = try await request(GuestAgentDict(action), timeout: timeout).dict
+        let responseTimeout = timeout > 0 ? timeout + 5 : timeout
+        let r = try await request(GuestAgentDict(action), timeout: responseTimeout).dict
         let success = r["success"] as? Bool ?? false
         if !success {
             throw GuestAgentError.remote(r["error"] as? String ?? "exec failed")
@@ -184,6 +188,30 @@ public extension GuestAgent {
 /// serialized through a dedicated dispatch queue, which is async-safe
 /// under Swift 6 strict concurrency where NSLock.lock() is not.
 @available(macOS 11.0, *)
+private actor GuestAgentRequestLock {
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func lock() async {
+        if !locked {
+            locked = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func unlock() {
+        if waiters.isEmpty {
+            locked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+@available(macOS 11.0, *)
 public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
     private let socketDevice: VZVirtioSocketDevice
     private let connectQueue: DispatchQueue?
@@ -191,8 +219,10 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
     private let stateQueue = DispatchQueue(label: "interceptor.bridge.vsockAgent")
     private var fd: Int32 = -1
     private var tcpFallbackHost: String?
+    private var retainedConnection: AnyObject?
     private var pending: [String: CheckedContinuation<GuestAgentDict, Error>] = [:]
     private var reader: Task<Void, Never>?
+    private let requestLock = GuestAgentRequestLock()
 
     private func withState<R>(_ body: (inout Int32, inout [String: CheckedContinuation<GuestAgentDict, Error>]) -> R) -> R {
         stateQueue.sync { body(&fd, &pending) }
@@ -219,11 +249,72 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
         }
     }
 
+    private func retainConnection(_ connection: AnyObject, fd connectionFd: Int32) {
+        stateQueue.sync {
+            retainedConnection = connection
+            fd = connectionFd
+        }
+    }
+
     public func connect(timeout: TimeInterval = 30) async throws {
         let existingFd: Int32 = withState { (f, _) in f }
         if existingFd >= 0 {
             return
         }
+        let deadline = timeout > 0 ? Date().addingTimeInterval(timeout) : nil
+        var lastError: Error?
+
+        while true {
+            if withState({ (f, _) in f }) >= 0 {
+                return
+            }
+
+            let remaining: TimeInterval
+            if let deadline {
+                remaining = deadline.timeIntervalSinceNow
+                if remaining <= 0 {
+                    break
+                }
+            } else {
+                remaining = 0
+            }
+
+            let attemptTimeout = deadline == nil ? timeout : min(5, max(0.5, remaining))
+            let connectedFd: Int32
+            if let host = tcpFallbackHostSnapshot(), !host.isEmpty {
+                do {
+                    connectedFd = try Self.connectTCP(host: host, port: port, timeout: attemptTimeout)
+                    withState { (f, _) in f = connectedFd }
+                    return
+                } catch {
+                    lastError = error
+                    if deadline == nil {
+                        throw GuestAgentError.notConnected("tcp connect \(host):\(port): \(error)")
+                    }
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    continue
+                }
+            }
+            do {
+                connectedFd = try await connectVsockAttempt(timeout: attemptTimeout)
+            } catch {
+                lastError = error
+                if deadline == nil {
+                    throw GuestAgentError.notConnected("\(error); tcp fallback not attempted because no explicit tcp guest-agent transport is configured")
+                } else {
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    continue
+                }
+            }
+            withState { (f, _) in f = connectedFd }
+            return
+        }
+
+        let errorText = lastError.map { "\($0)" } ?? "timeout"
+        throw GuestAgentError.notConnected("\(errorText); tcp fallback not attempted because no explicit tcp guest-agent transport is configured")
+    }
+
+    private func connectVsockAttempt(timeout: TimeInterval) async throws -> Int32 {
         // VZVirtioSocketDevice.connect(toPort:completionHandler:) returns a
         // VZVirtioSocketConnection whose fileDescriptor is a real socket
         // file descriptor (apple-developer-docs/.../VZVirtioSocketDevice.md:30).
@@ -232,48 +323,36 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
         let connectQueue = self.connectQueue
         let port = self.port
         // VZVirtioSocketConnection isn't Sendable; extract the fileDescriptor
-        // (Int32, Sendable) inside the completion closure and hand only that
-        // primitive across the continuation.
-        let connectedFd: Int32
-        do {
-            connectedFd = try await withCheckedThrowingContinuation { cc in
-                let gate = GuestAgentConnectContinuation(cc)
-                let startConnect = {
-                    device.connect(toPort: port) { result in
-                        switch result {
-                        case .success(let conn):
-                            gate.resume(returning: conn.fileDescriptor)
-                        case .failure(let err):
-                            gate.resume(throwing: GuestAgentError.notConnected("vsock connect port \(port): \(err.localizedDescription)"))
+        // (Int32, Sendable) inside the completion closure and retain the
+        // connection object on this agent so the fd remains valid.
+        return try await withCheckedThrowingContinuation { cc in
+            let gate = GuestAgentConnectContinuation(cc)
+            let startConnect = {
+                device.connect(toPort: port) { result in
+                    switch result {
+                    case .success(let conn):
+                        let connectionFd = conn.fileDescriptor
+                        guard connectionFd >= 0 else {
+                            gate.resume(throwing: GuestAgentError.notConnected("vsock connect port \(port): connection closed before fileDescriptor was usable"))
+                            return
                         }
-                    }
-                }
-                if let connectQueue {
-                    connectQueue.async(execute: startConnect)
-                } else {
-                    startConnect()
-                }
-                if timeout > 0 {
-                    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
-                        gate.resume(throwing: GuestAgentError.timeout("vsock connect port \(port) after \(Int(timeout))s"))
+                        self.retainConnection(conn, fd: connectionFd)
+                        gate.resume(returning: connectionFd)
+                    case .failure(let err):
+                        gate.resume(throwing: GuestAgentError.notConnected("vsock connect port \(port): \(err.localizedDescription)"))
                     }
                 }
             }
-        } catch {
-            guard let host = tcpFallbackHostSnapshot(), !host.isEmpty else {
-                throw error
+            if let connectQueue {
+                connectQueue.async(execute: startConnect)
+            } else {
+                startConnect()
             }
-            do {
-                connectedFd = try Self.connectTCP(host: host, port: port, timeout: timeout)
-            } catch {
-                throw GuestAgentError.notConnected("vsock failed and tcp fallback \(host):\(port) failed: \(error)")
+            if timeout > 0 {
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                    gate.resume(throwing: GuestAgentError.timeout("vsock connect port \(port) after \(Int(timeout))s"))
+                }
             }
-        }
-        withState { (f, _) in f = connectedFd }
-
-        // Spawn a reader task that demuxes inbound frames to pending continuations.
-        self.reader = Task.detached(priority: .utility) { [weak self] in
-            await self?.readLoop()
         }
     }
 
@@ -358,6 +437,18 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
     }
 
     public func request(_ action: GuestAgentDict, timeout: TimeInterval = 60) async throws -> GuestAgentDict {
+        await requestLock.lock()
+        do {
+            let result = try await requestUnlocked(action, timeout: timeout)
+            await requestLock.unlock()
+            return result
+        } catch {
+            await requestLock.unlock()
+            throw error
+        }
+    }
+
+    private func requestUnlocked(_ action: GuestAgentDict, timeout: TimeInterval = 60) async throws -> GuestAgentDict {
         let id = UUID().uuidString
         var payload: [String: Any] = ["id": id, "action": action.dict]
         if payload["action"] == nil { payload["action"] = action.dict }
@@ -369,28 +460,108 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
             throw GuestAgentError.framing("encode request: \(error.localizedDescription)")
         }
 
-        let fdSnapshot: Int32 = withState { (f, _) in f }
-        guard fdSnapshot >= 0 else { throw GuestAgentError.notConnected("no fd") }
+        var length = UInt32(data.count).littleEndian
+        var frame = Data(bytes: &length, count: 4)
+        frame.append(data)
 
-        let wrapped = try await withCheckedThrowingContinuation { (cc: CheckedContinuation<GuestAgentDict, Error>) in
-            self.withState { (_, p) in p[id] = cc }
-
-            var length = UInt32(data.count).littleEndian
-            var header = Data(bytes: &length, count: 4)
-            header.append(data)
-            header.withUnsafeBytes { ptr in
-                _ = Darwin.write(fdSnapshot, ptr.baseAddress!, header.count)
+        func sendAndRead() throws -> GuestAgentDict {
+            let fdSnapshot: Int32 = withState { (f, _) in f }
+            guard fdSnapshot >= 0 else { throw GuestAgentError.notConnected("no fd") }
+            try Self.writeAll(fd: fdSnapshot, data: frame)
+            let response = try Self.readFrame(fd: fdSnapshot, timeout: timeout)
+            guard let obj = try JSONSerialization.jsonObject(with: response, options: []) as? [String: Any] else {
+                throw GuestAgentError.framing("decode response: expected object")
             }
+            let result = (obj["result"] as? [String: Any]) ?? [:]
+            return GuestAgentDict(result)
+        }
 
-            if timeout > 0 {
-                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) { [weak self] in
-                    guard let self = self else { return }
-                    let pendingCC: CheckedContinuation<GuestAgentDict, Error>? = self.withState { (_, p) in p.removeValue(forKey: id) }
-                    pendingCC?.resume(throwing: GuestAgentError.timeout("no response for \(id.prefix(8)) after \(Int(timeout))s"))
-                }
+        do {
+            return try sendAndRead()
+        } catch {
+            await disconnect()
+            try await connect(timeout: min(max(timeout, 1), 10))
+            do {
+                return try sendAndRead()
+            } catch {
+                await disconnect()
+                throw error
             }
         }
-        return wrapped
+    }
+
+    private static func writeAll(fd: Int32, data: Data) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < data.count {
+                let n = Darwin.write(fd, base.advanced(by: written), data.count - written)
+                if n > 0 {
+                    written += n
+                    continue
+                }
+                if n < 0 && errno == EINTR {
+                    continue
+                }
+                let message = n == 0 ? "zero-byte write" : String(cString: strerror(errno))
+                throw GuestAgentError.ioFailure("write: \(message)")
+            }
+        }
+    }
+
+    private static func readFrame(fd: Int32, timeout: TimeInterval) throws -> Data {
+        let header = try readExact(fd: fd, count: 4, timeout: timeout)
+        let length = header.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+        guard length > 0 && length <= 50_000_000 else {
+            throw GuestAgentError.framing("invalid response length \(length)")
+        }
+        return try readExact(fd: fd, count: Int(length), timeout: timeout)
+    }
+
+    private static func readExact(fd: Int32, count: Int, timeout: TimeInterval) throws -> Data {
+        let deadline = timeout > 0 ? Date().addingTimeInterval(timeout) : nil
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: min(64 * 1024, max(1, count)))
+        while data.count < count {
+            let timeoutMs: Int32
+            if let deadline {
+                let remaining = deadline.timeIntervalSinceNow
+                guard remaining > 0 else {
+                    throw GuestAgentError.timeout("read \(count) bytes after \(Int(timeout))s")
+                }
+                timeoutMs = Int32(min(Double(Int32.max), ceil(remaining * 1000)))
+            } else {
+                timeoutMs = -1
+            }
+            var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+            let pollResult = Darwin.poll(&pfd, 1, timeoutMs)
+            if pollResult == 0 {
+                throw GuestAgentError.timeout("read \(count) bytes after \(Int(timeout))s")
+            }
+            if pollResult < 0 {
+                if errno == EINTR { continue }
+                throw GuestAgentError.ioFailure("poll: \(String(cString: strerror(errno)))")
+            }
+            if (pfd.revents & Int16(POLLHUP | POLLERR | POLLNVAL)) != 0 {
+                throw GuestAgentError.notConnected("disconnected")
+            }
+            let wanted = min(buffer.count, count - data.count)
+            let n = buffer.withUnsafeMutableBufferPointer {
+                Darwin.read(fd, $0.baseAddress, wanted)
+            }
+            if n > 0 {
+                data.append(buffer, count: n)
+                continue
+            }
+            if n == 0 {
+                throw GuestAgentError.notConnected("disconnected")
+            }
+            if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK {
+                continue
+            }
+            throw GuestAgentError.ioFailure("read: \(String(cString: strerror(errno)))")
+        }
+        return data
     }
 
     public func disconnect() async {
@@ -400,6 +571,7 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
             let snapshotPending = pending
             let snapshotFd = fd
             fd = -1
+            retainedConnection = nil
             pending.removeAll()
             return (snapshotFd, snapshotPending)
         }
@@ -418,7 +590,24 @@ public final class VsockGuestAgent: GuestAgent, @unchecked Sendable {
             let fdSnapshot: Int32 = withState { (f, _) in f }
             if fdSnapshot < 0 { return }
             let n = buf.withUnsafeMutableBufferPointer { Darwin.read(fdSnapshot, $0.baseAddress, $0.count) }
-            if n <= 0 {
+            if n == 0 {
+                await self.disconnect()
+                return
+            }
+            if n < 0 {
+                let readErrno = errno
+                if readErrno == EINTR {
+                    continue
+                }
+                if readErrno == EAGAIN || readErrno == EWOULDBLOCK {
+                    var pfd = pollfd(fd: fdSnapshot, events: Int16(POLLIN), revents: 0)
+                    let pollResult = Darwin.poll(&pfd, 1, 250)
+                    if pollResult < 0 && errno != EINTR {
+                        await self.disconnect()
+                        return
+                    }
+                    continue
+                }
                 await self.disconnect()
                 return
             }

--- a/interceptor-bridge/Sources/VM/MacRuntime.swift
+++ b/interceptor-bridge/Sources/VM/MacRuntime.swift
@@ -49,12 +49,14 @@ public final class MacRunningVM: @unchecked Sendable {
     public let queue: DispatchQueue
     public let delegate: MacVMDelegate
     public let macAddress: String?
+    public let consoleHandles: VMConsoleHandles?
 
-    init(vm: VZVirtualMachine, queue: DispatchQueue, delegate: MacVMDelegate, macAddress: String?) {
+    init(vm: VZVirtualMachine, queue: DispatchQueue, delegate: MacVMDelegate, macAddress: String?, consoleHandles: VMConsoleHandles?) {
         self.vm = vm
         self.queue = queue
         self.delegate = delegate
         self.macAddress = macAddress
+        self.consoleHandles = consoleHandles
     }
 }
 
@@ -240,6 +242,8 @@ public struct MacRuntime: Sendable {
         config.networkDevices = networkDevices
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]  // for guest agent
+        let console = VMConsole.buildSerialPort()
+        config.serialPorts = [console.config]
         if let shares = try? VMShare.buildDirectorySharingDevices(for: spec) {
             config.directorySharingDevices = shares
         }
@@ -260,7 +264,13 @@ public struct MacRuntime: Sendable {
         let delegate = MacVMDelegate()
         vm.delegate = delegate
 
-        return MacRunningVM(vm: vm, queue: queue, delegate: delegate, macAddress: networkDevices.first?.macAddress.string)
+        return MacRunningVM(
+            vm: vm,
+            queue: queue,
+            delegate: delegate,
+            macAddress: networkDevices.first?.macAddress.string,
+            consoleHandles: console.handles
+        )
     }
 
     /// Create a sparse-file-backed disk image of the given size. The

--- a/interceptor-bridge/Sources/VM/VMAdoption.swift
+++ b/interceptor-bridge/Sources/VM/VMAdoption.swift
@@ -133,7 +133,13 @@ public struct VMAdoption: Sendable {
             provider: .lume,
             sourcePath: source.path,
             adoptMode: mode,
-            macAddress: config.macAddress
+            macAddress: config.macAddress,
+            agent: VMGuestAgentSpec(
+                enabled: true,
+                transport: .vsock,
+                port: kInterceptorGuestAgentPort,
+                trustStatus: "transport_unverified"
+            )
         )
         let bundle = try await registry.create(spec)
         var copied: [String] = []
@@ -168,7 +174,13 @@ public struct VMAdoption: Sendable {
             image: "latest",
             provider: .appleVZ,
             sourcePath: source.path,
-            adoptMode: mode
+            adoptMode: mode,
+            agent: VMGuestAgentSpec(
+                enabled: true,
+                transport: .vsock,
+                port: kInterceptorGuestAgentPort,
+                trustStatus: "transport_unverified"
+            )
         )
         let bundle = try await registry.create(spec)
         let pairs: [(String, URL)] = [

--- a/interceptor-bridge/Sources/VM/VMConsole.swift
+++ b/interceptor-bridge/Sources/VM/VMConsole.swift
@@ -23,6 +23,31 @@ public struct VMConsoleHandles: Sendable {
     public let outputPipeReadEnd: FileHandle  // host end of the guest-output pipe
 }
 
+final class VMConsoleReadContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Data, Error>?
+
+    init(_ continuation: CheckedContinuation<Data, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning data: Data) {
+        lock.lock()
+        let cc = continuation
+        continuation = nil
+        lock.unlock()
+        cc?.resume(returning: data)
+    }
+
+    func resume(throwing error: Error) {
+        lock.lock()
+        let cc = continuation
+        continuation = nil
+        lock.unlock()
+        cc?.resume(throwing: error)
+    }
+}
+
 public struct VMConsole: Sendable {
 #if canImport(Virtualization)
     @available(macOS 11.0, *)
@@ -46,4 +71,36 @@ public struct VMConsole: Sendable {
         return (serial, handles)
     }
 #endif
+
+    public static func read(
+        from handle: FileHandle,
+        maxBytes: Int,
+        timeout: TimeInterval
+    ) async throws -> Data {
+        let bytes = max(1, maxBytes)
+        return try await withCheckedThrowingContinuation { cc in
+            let gate = VMConsoleReadContinuation(cc)
+            let source = DispatchSource.makeReadSource(fileDescriptor: handle.fileDescriptor, queue: .global(qos: .utility))
+            source.setEventHandler {
+                let available = Int(source.data)
+                let count = min(bytes, max(1, available))
+                let data = handle.readData(ofLength: count)
+                source.cancel()
+                gate.resume(returning: data)
+            }
+            source.setCancelHandler {}
+            source.resume()
+            if timeout > 0 {
+                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) {
+                    source.cancel()
+                    gate.resume(returning: Data())
+                }
+            }
+        }
+    }
+
+    public static func write(_ data: Data, to handle: FileHandle) throws -> Int {
+        try handle.write(contentsOf: data)
+        return data.count
+    }
 }

--- a/interceptor-bridge/Sources/VM/VMInstance.swift
+++ b/interceptor-bridge/Sources/VM/VMInstance.swift
@@ -50,6 +50,7 @@ public actor VMInstance {
     // Held only when running. Cleared on stop.
     private var linuxRuntime: LinuxRuntimeHandle?
     private var guestAgent: (any GuestAgent)?
+    private var portForwarders: [String: VMPortForwarder] = [:]
 
 #if canImport(Virtualization)
     private var macVM: MacRunningVM?
@@ -62,8 +63,8 @@ public actor VMInstance {
     }
 
     /// `vm start` — boot the guest. Transitions ready → starting → running.
-    /// `waitForVsock` blocks the start call until the guest agent connects.
-    public func start(headless: Bool, waitForVsock: Bool) async throws -> VMStartResult {
+    /// `waitForAgent` blocks the start call until the guest agent connects.
+    public func start(headless: Bool, waitForAgent: Bool) async throws -> VMStartResult {
         let begin = Date()
         switch status {
         case .running, .paused, .starting, .stopping, .savingSnapshot, .restoringSnapshot:
@@ -98,32 +99,44 @@ public actor VMInstance {
                         }
                     }
                     macVM = mvm
-                    ipAddress = await Self.waitForBridge100IPAddress(macAddress: mvm.macAddress, timeout: waitForVsock ? 30 : 3)
+                    ipAddress = await Self.waitForBridge100IPAddress(macAddress: mvm.macAddress, timeout: waitForAgent ? 30 : 3)
                     let fallbackIPAddress = ipAddress
+                    let agentSpec = spec.agent
+                    let agentEnabled = agentSpec?.enabled ?? true
+                    let agentPort = agentSpec?.port ?? kInterceptorGuestAgentPort
+                    let tcpFallbackHost = agentSpec?.transport == .tcp ? (agentSpec?.host ?? fallbackIPAddress) : nil
                     // GuestAgent (vsock) attach. The first socketDevice is
-                    // the one we configured in MacRuntime.run.
+                    // the one we configured in MacRuntime.run. TCP fallback is
+                    // only enabled when VMSpec.agent explicitly requests TCP.
                     let agent: VsockGuestAgent? = await withCheckedContinuation { cc in
                         mvm.queue.async {
                             let socketDevice = mvm.vm.socketDevices.first as? VZVirtioSocketDevice
-                            cc.resume(returning: socketDevice.map { VsockGuestAgent(socketDevice: $0, connectQueue: mvm.queue, tcpFallbackHost: fallbackIPAddress) })
+                            cc.resume(returning: socketDevice.map {
+                                VsockGuestAgent(
+                                    socketDevice: $0,
+                                    connectQueue: mvm.queue,
+                                    port: agentPort,
+                                    tcpFallbackHost: tcpFallbackHost
+                                )
+                            })
                         }
                     }
-                    if let agent {
-                        if waitForVsock {
+                    if agentEnabled, let agent {
+                        if waitForAgent {
                             do {
                                 try await agent.connect(timeout: 60)
                                 self.guestAgent = agent
                             } catch {
-                                // boot succeeded; agent not up — still
-                                // a running VM. Keep the agent handle so
-                                // later guest verbs can retry after login
-                                // items / LaunchAgents finish starting.
                                 self.guestAgent = agent
-                                self.lastError = "vsock connect: \(error.localizedDescription)"
+                                self.lastError = "guest agent connect: \(error)"
+                                throw VMInstanceError.runtimeUnavailable("guest agent readiness failed: \(error)")
                             }
                         } else {
                             self.guestAgent = agent  // lazy connect on first use
                         }
+                    } else if waitForAgent {
+                        let transport = agentSpec?.transport.rawValue ?? "vsock"
+                        throw VMInstanceError.runtimeUnavailable("guest agent transport '\(transport)' is not available for VM '\(spec.name)'")
                     }
                 } else {
                     throw VMInstanceError.runtimeUnavailable("macOS guests require macOS 13+ host")
@@ -161,6 +174,10 @@ public actor VMInstance {
         // tear down agent
         await guestAgent?.disconnect()
         guestAgent = nil
+        for forwarder in portForwarders.values {
+            forwarder.stop()
+        }
+        portForwarders.removeAll()
         linuxRuntime = nil
         #if canImport(Virtualization)
         macVM = nil
@@ -243,7 +260,11 @@ public actor VMInstance {
             if ipAddress == nil {
                 ipAddress = await Self.waitForBridge100IPAddress(macAddress: macVM?.macAddress, timeout: 5)
             }
-            vsockAgent.setTCPFallbackHost(ipAddress)
+            if spec.agent?.transport == .tcp {
+                vsockAgent.setTCPFallbackHost(spec.agent?.host ?? ipAddress)
+            } else {
+                vsockAgent.setTCPFallbackHost(nil)
+            }
         }
         #endif
         try await agent.connect(timeout: min(timeout, 30))
@@ -260,6 +281,97 @@ public actor VMInstance {
         }
         #endif
         throw VMInstanceError.runtimeUnavailable("paused-state snapshots require macOS 14+ and a running macOS VM")
+    }
+
+    public func restoreSnapshot(tag: String, diskOnly: Bool, pausedStateOnly: Bool, headless: Bool) async throws -> VMSnapshotManifest {
+        guard status != .running && status != .paused && status != .starting && status != .stopping else {
+            throw VMInstanceError.invalidTransition("restore requires VM '\(spec.name)' to be stopped")
+        }
+        status = .restoringSnapshot
+        do {
+            let manifest = try VMSnapshot.manifest(bundle: bundle, tag: tag)
+            if diskOnly && !manifest.hasDiskClone {
+                throw VMSnapshotError.missing("snapshot '\(tag)' has no Disk.img")
+            }
+            if pausedStateOnly && !manifest.hasPausedState {
+                throw VMSnapshotError.missing("snapshot '\(tag)' has no paused machine state")
+            }
+            if !pausedStateOnly && manifest.hasDiskClone {
+                _ = try VMSnapshot.restoreDisk(bundle: bundle, tag: tag)
+            }
+            if diskOnly || !manifest.hasPausedState {
+                status = .stopped
+                return manifest
+            }
+
+            guard spec.kind == .macos else {
+                throw VMInstanceError.runtimeUnavailable("paused-state restore is only wired for macOS VZ guests")
+            }
+            #if canImport(Virtualization)
+            if #available(macOS 14.0, *) {
+                let mvm = try await MacRuntime.run(spec: spec, bundle: bundle, headless: headless)
+                _ = try await VMSnapshot.restorePausedState(vm: mvm.vm, bundle: bundle, tag: tag)
+                macVM = mvm
+                status = .paused
+                return manifest
+            }
+            #endif
+            throw VMInstanceError.runtimeUnavailable("paused-state restore requires macOS 14+ host with Virtualization.framework")
+        } catch {
+            status = .error
+            lastError = "\(error)"
+            throw error
+        }
+    }
+
+    public func consoleRead(maxBytes: Int, timeout: TimeInterval) async throws -> Data {
+        guard status == .running || status == .paused else {
+            throw VMInstanceError.notStarted("vm '\(spec.name)' is .\(status.rawValue)")
+        }
+        #if canImport(Virtualization)
+        if let handle = macVM?.consoleHandles?.outputPipeReadEnd {
+            return try await VMConsole.read(from: handle, maxBytes: maxBytes, timeout: timeout)
+        }
+        #endif
+        throw VMInstanceError.runtimeUnavailable("console is only available for VZ guests with a serial attachment")
+    }
+
+    public func consoleWrite(_ text: String) async throws -> Int {
+        guard status == .running || status == .paused else {
+            throw VMInstanceError.notStarted("vm '\(spec.name)' is .\(status.rawValue)")
+        }
+        #if canImport(Virtualization)
+        if let handle = macVM?.consoleHandles?.inputPipeWriteEnd {
+            return try VMConsole.write(Data(text.utf8), to: handle)
+        }
+        #endif
+        throw VMInstanceError.runtimeUnavailable("console is only available for VZ guests with a serial attachment")
+    }
+
+    public func portForward(hostAddress: String, hostPort: Int, guestPort: Int) async throws -> (hostAddress: String, hostPort: Int, guestAddress: String, guestPort: Int) {
+        guard status == .running else {
+            throw VMInstanceError.notStarted("vm '\(spec.name)' is .\(status.rawValue)")
+        }
+        if ipAddress == nil {
+            #if canImport(Virtualization)
+            if #available(macOS 13.0, *) {
+                ipAddress = await Self.waitForBridge100IPAddress(macAddress: macVM?.macAddress, timeout: 5)
+            }
+            #endif
+        }
+        guard let guestAddress = ipAddress, !guestAddress.isEmpty else {
+            throw VMInstanceError.runtimeUnavailable("cannot start port-forward without a known guest IPv4 address")
+        }
+        let forwarder = VMPortForwarder(
+            hostAddress: hostAddress,
+            hostPort: hostPort,
+            guestAddress: guestAddress,
+            guestPort: guestPort
+        )
+        let actualHostPort = try forwarder.start()
+        let key = "\(hostAddress):\(actualHostPort)->\(guestAddress):\(guestPort)"
+        portForwarders[key] = forwarder
+        return (hostAddress, actualHostPort, guestAddress, guestPort)
     }
 
     public func current() -> VMSpec { spec }

--- a/interceptor-bridge/Sources/VM/VMPortForwarder.swift
+++ b/interceptor-bridge/Sources/VM/VMPortForwarder.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Darwin
+
+public enum VMPortForwarderError: Error, CustomStringConvertible, Sendable {
+    case invalidAddress(String)
+    case socket(String)
+    case bind(String)
+    case listen(String)
+
+    public var description: String {
+        switch self {
+        case .invalidAddress(let m): return "portForward.invalidAddress: \(m)"
+        case .socket(let m): return "portForward.socket: \(m)"
+        case .bind(let m): return "portForward.bind: \(m)"
+        case .listen(let m): return "portForward.listen: \(m)"
+        }
+    }
+}
+
+public final class VMPortForwarder: @unchecked Sendable {
+    public let hostAddress: String
+    public private(set) var hostPort: Int
+    public let guestAddress: String
+    public let guestPort: Int
+
+    private let queue: DispatchQueue
+    private var serverFd: Int32 = -1
+    private var listener: DispatchSourceRead?
+    private var sockets: Set<Int32> = []
+
+    public init(hostAddress: String, hostPort: Int, guestAddress: String, guestPort: Int) {
+        self.hostAddress = hostAddress
+        self.hostPort = hostPort
+        self.guestAddress = guestAddress
+        self.guestPort = guestPort
+        self.queue = DispatchQueue(label: "interceptor.vm.portForward.\(hostAddress).\(hostPort).\(guestAddress).\(guestPort)")
+    }
+
+    public func start() throws -> Int {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw VMPortForwarderError.socket(String(cString: strerror(errno)))
+        }
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+        let flags = Darwin.fcntl(fd, F_GETFL, 0)
+        if flags >= 0 {
+            _ = Darwin.fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(hostPort).bigEndian
+        guard hostAddress.withCString({ inet_pton(AF_INET, $0, &addr.sin_addr) }) == 1 else {
+            Darwin.close(fd)
+            throw VMPortForwarderError.invalidAddress(hostAddress)
+        }
+
+        let addrSize = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                Darwin.bind(fd, sptr, addrSize)
+            }
+        }
+        guard bindResult == 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(fd)
+            throw VMPortForwarderError.bind(message)
+        }
+        guard Darwin.listen(fd, SOMAXCONN) == 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(fd)
+            throw VMPortForwarderError.listen(message)
+        }
+
+        if hostPort == 0 {
+            var bound = sockaddr_in()
+            var boundSize = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let got = withUnsafeMutablePointer(to: &bound) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                    Darwin.getsockname(fd, sptr, &boundSize)
+                }
+            }
+            if got == 0 {
+                hostPort = Int(UInt16(bigEndian: bound.sin_port))
+            }
+        }
+
+        serverFd = fd
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+        source.setEventHandler { [weak self] in
+            self?.acceptReady()
+        }
+        source.setCancelHandler {}
+        listener = source
+        source.resume()
+        return hostPort
+    }
+
+    public func stop() {
+        queue.sync {
+            listener?.cancel()
+            listener = nil
+            if serverFd >= 0 {
+                Darwin.close(serverFd)
+                serverFd = -1
+            }
+            for fd in sockets {
+                Darwin.shutdown(fd, SHUT_RDWR)
+                Darwin.close(fd)
+            }
+            sockets.removeAll()
+        }
+    }
+
+    private func acceptReady() {
+        while true {
+            let client = Darwin.accept(serverFd, nil, nil)
+            if client < 0 {
+                let e = errno
+                if e == EWOULDBLOCK || e == EAGAIN { return }
+                return
+            }
+            sockets.insert(client)
+            Task.detached(priority: .utility) { [weak self] in
+                await self?.handle(client: client)
+            }
+        }
+    }
+
+    private func handle(client: Int32) async {
+        let guest: Int32
+        do {
+            guest = try Self.connect(host: guestAddress, port: guestPort)
+        } catch {
+            closeTracked(client)
+            return
+        }
+        queue.async { self.sockets.insert(guest) }
+
+        Task.detached(priority: .utility) { [weak self] in
+            Self.pipe(from: client, to: guest)
+            self?.closeTracked(client)
+            self?.closeTracked(guest)
+        }
+        Task.detached(priority: .utility) { [weak self] in
+            Self.pipe(from: guest, to: client)
+            self?.closeTracked(client)
+            self?.closeTracked(guest)
+        }
+    }
+
+    private func closeTracked(_ fd: Int32) {
+        queue.async {
+            guard self.sockets.remove(fd) != nil else { return }
+            Darwin.shutdown(fd, SHUT_RDWR)
+            Darwin.close(fd)
+        }
+    }
+
+    private static func connect(host: String, port: Int) throws -> Int32 {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw VMPortForwarderError.socket(String(cString: strerror(errno)))
+        }
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        guard host.withCString({ inet_pton(AF_INET, $0, &addr.sin_addr) }) == 1 else {
+            Darwin.close(fd)
+            throw VMPortForwarderError.invalidAddress(host)
+        }
+        let size = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let result = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                Darwin.connect(fd, sptr, size)
+            }
+        }
+        guard result == 0 else {
+            let message = String(cString: strerror(errno))
+            Darwin.close(fd)
+            throw VMPortForwarderError.socket("connect \(host):\(port): \(message)")
+        }
+        return fd
+    }
+
+    private static func pipe(from src: Int32, to dst: Int32) {
+        var buf = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = buf.withUnsafeMutableBufferPointer { Darwin.read(src, $0.baseAddress, $0.count) }
+            if n <= 0 { return }
+            var written = 0
+            while written < n {
+                let w = buf.withUnsafeBufferPointer { ptr -> Int in
+                    guard let base = ptr.baseAddress else { return -1 }
+                    return Darwin.write(dst, base.advanced(by: written), n - written)
+                }
+                if w <= 0 { return }
+                written += w
+            }
+        }
+    }
+}

--- a/interceptor-bridge/Sources/VM/VMRegistry.swift
+++ b/interceptor-bridge/Sources/VM/VMRegistry.swift
@@ -7,8 +7,11 @@
 // State directory resolution order (first hit wins):
 //   1. action["stateDir"] passed by the CLI (per-invocation override).
 //   2. $INTERCEPTOR_VM_STATE_DIR environment variable.
-//   3. $CWD/.interceptor/vms/   (default, matches the existing
-//      .container-data/ pattern at the project root for Apple's container.)
+//   3. ~/Library/Application Support/Interceptor/   (default — a stable,
+//      writable, per-user location independent of the process CWD. The bridge
+//      runs as a launchd LaunchAgent whose CWD is "/", so the old
+//      $CWD/.interceptor default resolved to "/.interceptor" on the read-only
+//      root volume and every registry write failed with errno 30.)
 //
 // Bundle layout matches Apple's `VM.bundle` format from
 // `apple-developer-docs/Virtualization/running-macos-in-a-virtual-machine-on-apple-silicon.md:21-32`:
@@ -96,8 +99,16 @@ public actor VMRegistry {
         if let envS = ProcessInfo.processInfo.environment["INTERCEPTOR_VM_STATE_DIR"], !envS.isEmpty {
             return URL(fileURLWithPath: (envS as NSString).expandingTildeInPath)
         }
-        let cwd = FileManager.default.currentDirectoryPath
-        return URL(fileURLWithPath: cwd).appendingPathComponent(".interceptor", isDirectory: true)
+        // No override: use a stable, writable, per-user location independent of
+        // the process CWD. The bridge runs as a launchd LaunchAgent whose CWD is
+        // "/", so a $CWD-relative default resolved to "/.interceptor" on the
+        // read-only root volume. Application Support is the canonical per-user
+        // app-state directory and is writable in the agent's GUI session.
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return appSupport.appendingPathComponent("Interceptor", isDirectory: true)
     }
 
     /// Create the directory if missing; no-op if it exists.

--- a/interceptor-bridge/Sources/VM/VMSnapshot.swift
+++ b/interceptor-bridge/Sources/VM/VMSnapshot.swift
@@ -157,7 +157,55 @@ public struct VMSnapshot: Sendable {
 
         return manifest
     }
+
+    @available(macOS 14.0, *)
+    public static func restorePausedState(
+        vm: VZVirtualMachine,
+        bundle: VMBundle,
+        tag: String
+    ) async throws -> VMSnapshotManifest {
+        let manifest = try manifest(bundle: bundle, tag: tag)
+        guard manifest.hasPausedState else {
+            throw VMSnapshotError.missing("snapshot '\(tag)' has no paused machine state")
+        }
+        let saveURL = bundle.snapshotFile(tag: tag)
+        do {
+            try await vm.restoreMachineStateFrom(url: saveURL)
+        } catch {
+            throw VMSnapshotError.ioFailure("restoreMachineStateFrom: \(error.localizedDescription)")
+        }
+        return manifest
+    }
 #endif
+
+    public static func manifest(bundle: VMBundle, tag: String) throws -> VMSnapshotManifest {
+        let manifestURL = bundle.snapshotManifest(tag: tag)
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            throw VMSnapshotError.missing("snapshot '\(tag)' not found at \(manifestURL.path)")
+        }
+        return try readManifest(at: manifestURL)
+    }
+
+    public static func restoreDisk(bundle: VMBundle, tag: String) throws -> VMSnapshotManifest {
+        let manifest = try manifest(bundle: bundle, tag: tag)
+        guard manifest.hasDiskClone else {
+            throw VMSnapshotError.missing("snapshot '\(tag)' has no Disk.img")
+        }
+        let snapDisk = bundle.snapshotDir(tag: tag).appendingPathComponent("Disk.img")
+        let liveDisk = bundle.diskPath
+        let parked = bundle.bundlePath.appendingPathComponent("Disk.img.pre-restore-\(Int(Date().timeIntervalSince1970))")
+        if FileManager.default.fileExists(atPath: liveDisk.path) {
+            try? FileManager.default.moveItem(at: liveDisk, to: parked)
+        }
+        do {
+            try FileManager.default.copyItem(at: snapDisk, to: liveDisk)
+            try? FileManager.default.removeItem(at: parked)
+        } catch {
+            try? FileManager.default.moveItem(at: parked, to: liveDisk)
+            throw VMSnapshotError.ioFailure("restore Disk.img: \(error.localizedDescription)")
+        }
+        return manifest
+    }
 
     public static func list(bundle: VMBundle) -> [String] {
         let snapsDir = bundle.snapshotsDir

--- a/interceptor-bridge/Sources/VM/VMSpec.swift
+++ b/interceptor-bridge/Sources/VM/VMSpec.swift
@@ -64,6 +64,41 @@ public enum VMAdoptMode: String, Codable, Sendable, Equatable {
     case reference
 }
 
+public enum VMGuestAgentTransport: String, Codable, Sendable, Equatable {
+    case vsock
+    case tcp
+    case ssh
+    case serial
+}
+
+public struct VMGuestAgentSpec: Codable, Sendable, Equatable {
+    public var enabled: Bool
+    public var transport: VMGuestAgentTransport
+    public var host: String?
+    public var port: UInt32
+    public var authTokenRef: String?
+    public var installedVersion: String?
+    public var trustStatus: String?
+
+    public init(
+        enabled: Bool = true,
+        transport: VMGuestAgentTransport,
+        host: String? = nil,
+        port: UInt32 = 3294,
+        authTokenRef: String? = nil,
+        installedVersion: String? = nil,
+        trustStatus: String? = nil
+    ) {
+        self.enabled = enabled
+        self.transport = transport
+        self.host = host
+        self.port = port
+        self.authTokenRef = authTokenRef
+        self.installedVersion = installedVersion
+        self.trustStatus = trustStatus
+    }
+}
+
 /// virtio-fs share. `tag` is the mount label the guest uses: `mount -t virtiofs <tag>`.
 public struct VMShareSpec: Codable, Sendable, Equatable {
     public var hostPath: String
@@ -105,6 +140,9 @@ public struct VMSpec: Codable, Sendable, Equatable {
     /// keeps NAT DHCP leases stable across boots and lets the host map a
     /// running macOS guest back to its bridge100 IP.
     public var macAddress: String?
+    /// Guest control transport. A nil value preserves legacy specs, but new
+    /// code treats TCP as explicit only when this field says transport == tcp.
+    public var agent: VMGuestAgentSpec?
 
     public init(
         name: String,
@@ -123,7 +161,8 @@ public struct VMSpec: Codable, Sendable, Equatable {
         provider: VMProviderKind? = nil,
         sourcePath: String? = nil,
         adoptMode: VMAdoptMode? = nil,
-        macAddress: String? = nil
+        macAddress: String? = nil,
+        agent: VMGuestAgentSpec? = nil
     ) {
         self.name = name
         self.id = id
@@ -142,6 +181,7 @@ public struct VMSpec: Codable, Sendable, Equatable {
         self.sourcePath = sourcePath
         self.adoptMode = adoptMode
         self.macAddress = macAddress
+        self.agent = agent
     }
 
     /// Static validation that does NOT require Virtualization framework

--- a/interceptor-bridge/Tests/InterceptorBridgeTests/VmDomainTests.swift
+++ b/interceptor-bridge/Tests/InterceptorBridgeTests/VmDomainTests.swift
@@ -101,9 +101,19 @@ final class VMRegistryTests: XCTestCase {
         XCTAssertEqual(resolved.path, "/tmp/from-env")
     }
 
-    func test_resolveStateDir_cwdDefault() {
+    func test_resolveStateDir_appSupportDefault() {
+        // No override and no env var → a stable per-user Application Support
+        // path, independent of CWD. The bridge LaunchAgent's CWD is "/", so the
+        // old $CWD/.interceptor default resolved to "/.interceptor" on the
+        // read-only root volume and every registry write failed.
+        unsetenv("INTERCEPTOR_VM_STATE_DIR")
         let resolved = VMRegistry.resolveStateDir(actionOverride: nil)
-        XCTAssertTrue(resolved.path.hasSuffix("/.interceptor"))
+        XCTAssertTrue(
+            resolved.path.hasSuffix("/Library/Application Support/Interceptor"),
+            "expected Application Support default, got \(resolved.path)")
+        XCTAssertFalse(
+            resolved.path.hasPrefix("/.interceptor"),
+            "must not resolve to a CWD-relative root path")
     }
 
     func test_create_then_get_roundtrip() async throws {
@@ -176,6 +186,12 @@ final class VMRegistryTests: XCTestCase {
 }
 
 final class VmDomainDispatchTests: XCTestCase {
+    private func makeTmpStateDir(_ prefix: String = "interceptor-vm-domain") -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
 
     func test_unknownVerb_returnsError() async {
         let domain = VmDomain()
@@ -200,12 +216,50 @@ final class VmDomainDispatchTests: XCTestCase {
         XCTAssertEqual(result["success"] as? Bool, false)
     }
 
+    func test_adoptInstallAgentFlagsFailClosedBeforeImport() async throws {
+        let stateDir = makeTmpStateDir()
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+        let domain = VmDomain()
+        let action: [String: Any] = [
+            "type": "macos_vm_adopt",
+            "sub": "adopt",
+            "name": "gold",
+            "sourcePath": "/tmp/nonexistent-gold",
+            "kind": "macos",
+            "provider": "auto",
+            "mode": "clone",
+            "installAgent": true,
+            "waitForAgent": true,
+            "stateDir": stateDir.path,
+        ]
+        let result = await withCheckedContinuation { (cc: CheckedContinuation<TestDictBox, Never>) in
+            domain.handle("adopt", action: action) { result in
+                cc.resume(returning: TestDictBox(d: result))
+            }
+        }.d
+
+        XCTAssertEqual(result["success"] as? Bool, false)
+        XCTAssertTrue((result["error"] as? String ?? "").contains("unsupported-transport"))
+        XCTAssertNotNil(result["setup_required"])
+
+        let registry = try VMRegistry(stateDir: stateDir)
+        await self.expectAsyncThrow(try await registry.get("gold"))
+    }
+
     func test_pull_resolvesPathDeterministically() async throws {
-        let stateDir = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("interceptor-vm-pull-\(UUID().uuidString)", isDirectory: true)
+        let stateDir = makeTmpStateDir("interceptor-vm-pull")
         defer { try? FileManager.default.removeItem(at: stateDir) }
         let url1 = try await VMImage.resolveOCIImage(ref: "docker.io/library/alpine:3", stateDir: stateDir)
         let url2 = try await VMImage.resolveOCIImage(ref: "docker.io/library/alpine:3", stateDir: stateDir)
         XCTAssertEqual(url1.path, url2.path)
+    }
+
+    private func expectAsyncThrow<T>(_ expr: @autoclosure () async throws -> T, file: StaticString = #filePath, line: UInt = #line) async {
+        do {
+            _ = try await expr()
+            XCTFail("expected throw", file: file, line: line)
+        } catch {
+            // ok
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.16.2",
+  "version": "0.16.6",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/build-interceptord-pkg.sh
+++ b/scripts/build-interceptord-pkg.sh
@@ -11,6 +11,8 @@ UNSIGNED_PKG="$OUT_DIR/InterceptorD-${VERSION}-unsigned.pkg"
 INTERCEPTOR_SIGNING_IDENTITY="${INTERCEPTOR_SIGNING_IDENTITY:-Developer ID Application: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)}"
 INTERCEPTOR_INSTALLER_IDENTITY="${INTERCEPTOR_INSTALLER_IDENTITY:-Developer ID Installer: HACKER VALLEY MEDIA, LLC (TPWBZD35WW)}"
 
+export COPYFILE_DISABLE=1
+
 mkdir -p "$OUT_DIR"
 
 cd "$BRIDGE_DIR"
@@ -65,6 +67,8 @@ if [[ "${INTERCEPTOR_SKIP_SIGNING:-0}" != "1" ]] && security find-identity -v 2>
 fi
 
 rm -f "$PKG" "$UNSIGNED_PKG"
+
+xattr -cr "$STAGE" 2>/dev/null || true
 
 pkgbuild \
   --root "$STAGE" \

--- a/test/vm-lifecycle.test.ts
+++ b/test/vm-lifecycle.test.ts
@@ -17,7 +17,7 @@
 
 import { test, expect } from "bun:test"
 import { parseMacosCommand } from "../cli/commands/macos"
-import { existsSync, rmSync, mkdtempSync } from "node:fs"
+import { existsSync, rmSync, mkdtempSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -102,6 +102,14 @@ test("vm start — flags wire into action correctly", () => {
   const action = p(["macos", "vm", "start", "lin1", "--headless", "--wait-for-vsock"])
   expect(action.type).toBe("macos_vm_start")
   expect(action.headless).toBe(true)
+  expect(action.waitForAgent).toBe(true)
+  expect(action.waitForVsock).toBe(true)
+})
+
+test("vm start — accepts --wait-for-agent as public readiness flag", () => {
+  const action = p(["macos", "vm", "start", "lin1", "--wait-for-agent"])
+  expect(action.type).toBe("macos_vm_start")
+  expect(action.waitForAgent).toBe(true)
   expect(action.waitForVsock).toBe(true)
 })
 
@@ -149,6 +157,16 @@ test("vm snapshot — defaults to op=create", () => {
   expect(action.snapshotOp).toBe("create")
 })
 
+test("vm restore — parses paused-state and disk-only flags", () => {
+  const action = p(["macos", "vm", "restore", "lin1", "scratch", "--paused-state", "--disk-only", "--headless"])
+  expect(action.type).toBe("macos_vm_restore")
+  expect(action.name).toBe("lin1")
+  expect(action.tag).toBe("scratch")
+  expect(action.pausedStateOnly).toBe(true)
+  expect(action.diskOnly).toBe(true)
+  expect(action.headless).toBe(true)
+})
+
 test("vm list — minimal action with no flags", () => {
   const action = p(["macos", "vm", "list"])
   expect(action.type).toBe("macos_vm_list")
@@ -178,6 +196,15 @@ test("vm port-forward — renamed to port_forward in action type", () => {
   expect(action.type).toBe("macos_vm_port_forward")
 })
 
+test("vm console — parses bounded read and write flags", () => {
+  const action = p(["macos", "vm", "console", "lin1", "--write", "status\n", "--max-bytes", "2048", "--timeout", "2"])
+  expect(action.type).toBe("macos_vm_console")
+  expect(action.name).toBe("lin1")
+  expect(action.write).toBe("status\n")
+  expect(action.maxBytes).toBe(2048)
+  expect(action.timeout).toBe(2)
+})
+
 test("vm tcc profile generate — parses guest profile request", () => {
   const action = p([
     "macos",
@@ -196,6 +223,35 @@ test("vm tcc profile generate — parses guest profile request", () => {
   expect(action.name).toBe("mactest")
   expect(action.out).toBe("/tmp/guest.mobileconfig")
   expect(action.services).toEqual(["Accessibility", "PostEvent"])
+})
+
+test("vm trust — parses guest prompt and reset flags", () => {
+  const action = p(["macos", "vm", "trust", "mactest", "--walkthrough", "--reset-denied", "--timeout", "45"])
+  expect(action.type).toBe("macos_vm_trust")
+  expect(action.name).toBe("mactest")
+  expect(action.prompt).toBe(true)
+  expect(action.walkthrough).toBe(true)
+  expect(action.resetDenied).toBe(true)
+  expect(action.timeout).toBe(45)
+})
+
+test("vm trust — no-prompt disables prompt/reset flags", () => {
+  const action = p([
+    "macos",
+    "vm",
+    "trust",
+    "mactest",
+    "--no-prompt",
+    "--prompt",
+    "--accessibility-prompt",
+    "--screen-prompt",
+    "--reset-denied",
+  ])
+  expect(action.noPrompt).toBe(true)
+  expect(action.prompt).toBe(false)
+  expect(action.accessibilityPrompt).toBe(false)
+  expect(action.screenPrompt).toBe(false)
+  expect(action.resetDenied).toBe(false)
 })
 
 test("vm cp — infers vm name from destination", () => {
@@ -272,4 +328,14 @@ test("vm create — stateDir override propagates", () => {
     "/tmp/explicit",
   ])
   expect(action.stateDir).toBe("/tmp/explicit")
+})
+
+test("InterceptorD macOS guest agent defaults to VSOCK transport", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "interceptor-bridge", "InterceptorD", "main.swift"), "utf8")
+  expect(source).toContain("func serveVsock()")
+  expect(source).toContain("AF_VSOCK")
+  expect(source).toContain("VMADDR_CID_ANY")
+  expect(source).toContain("INTERCEPTOR_GUEST_TCP_LISTEN")
+  expect(source).not.toContain("Darwin doesn't expose AF_VSOCK")
+  expect(source).not.toContain("macOS guests currently listen")
 })


### PR DESCRIPTION
## What's in this release

### Native macOS VM control plane (`interceptor macos vm *`)
Launch, adopt, and drive macOS guests through Apple's Virtualization framework:
lifecycle (create/start/stop/pause/resume/snapshot/restore), an AF_VSOCK guest
agent, and guest control — `exec`, `screenshot`, `read-ax`, `click`/`type`/`keys`,
`cp`/`mount`, host port-forward, bounded serial console, and a public TCC
trust/bootstrap flow. Background-first. Linux guests are guarded with a
`setup_required` error pending Containerization wiring.

- VM registry state dir now defaults to a stable per-user `~/Library/Application Support/Interceptor`
  location (the launchd bridge's CWD is `/`, so the old CWD-relative default
  failed on the read-only root volume). `--state-dir` / `INTERCEPTOR_VM_STATE_DIR` still override.

### Spotlight `fs_search` fix
`NSMetadataQuery`'s async delivery never fires in the faceless launchd-agent
context, so every `fs_search` timed out and fell back to a filename-only walk.
Replaced with a synchronous `mdfind` subprocess (enriched in-process) — content
and filename queries now return `source=spotlight`. BFS fallback retained.

### Docs
- Document task-scoped monitor envelopes in the README.

## Verification
- `swift test`: 335 passed / 16 skipped / 0 failed
- `bun test test/vm-lifecycle.test.ts`: 29/29
- Built, signed, notarized, installed, and verified live on the deployed bridge:
  `fs_search` content query returns spotlight results matching `mdfind`; `vm list`
  + registry + dispatch work; the state-dir fix resolves to Application Support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-scoped monitor commands for enhanced workflow management
  * Introduced VM console access with read/write capabilities
  * Added port forwarding support for guest VM networking
  * Enhanced macOS trust workflow with configurable permission prompts and accessibility checks
  * Improved application targeting for input automation

* **Documentation**
  * Updated with task-scoped command examples and monitor feature details

* **Chores**
  * Version bumped to 0.16.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->