### PR TITLE
ci: add shell syntax check (bash -n) for scripts/*.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
+      - name: Shell syntax check (scripts/*.sh)
+        run: |
+          for f in scripts/*.sh; do
+            echo "bash -n $f"
+            bash -n "$f"
+          done
+
       - name: Select newest Xcode (Swift 6.2 toolchain — bridge requires tools 6.2)
         run: |
           ls -d /Applications/Xcode_*.app


### PR DESCRIPTION
## Why

PR #98 (Chrome channel install flags) touched `scripts/install.sh`, but CI never lints the installer scripts — the `test` job only runs typecheck + bun/swift tests + the capability-blind audit. A shell syntax regression in any `scripts/*.sh` would sail through.

## What

Adds a fast, dependency-free **`bash -n`** gate over `scripts/*.sh`, right after Checkout (no toolchain needed, fails fast).

- `bash -n` is syntax-only (no execution) → safe and quick.
- Verified all current `scripts/*.sh` pass `bash -n` locally, so this won't fail on existing scripts.
- `shellcheck` is a future option but would first need the existing scripts triaged for its warnings, so it's deliberately out of scope here.

Follow-up to #98.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Bash syntax validation to the CI workflow to catch shell script errors earlier in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->