### PR TITLE
test: fix install-modes assertions after Chrome-channel changes (#98)

### DIFF
--- a/test/install-modes.test.ts
+++ b/test/install-modes.test.ts
@@ -193,11 +193,11 @@ describe("install browser selection — dry-run", () => {
     const { stdout, status } = runInstallDryRun(["--browser-only"])
     expect(status).toBe(0)
     // Two valid auto-select paths:
-    //   1. Both browsers installed → script prints "defaulting to 'chrome' (non-interactive)"
+    //   1. Both browsers installed → script prints "defaulting to 'chrome' (non-interactive, first installed)"
     //   2. Only one installed     → script prints "Browser: <X> (only supported browser found)"
     const hasBoth = browserInstalled("chrome") && browserInstalled("brave")
     if (hasBoth) {
-      expect(stdout).toContain("defaulting to 'chrome' (non-interactive)")
+      expect(stdout).toContain("defaulting to 'chrome' (non-interactive")
       expect(stdout).toContain("Browser: chrome")
       expect(stdout).toContain(CHROME_NM_SUBSTR)
       expect(stdout).not.toContain(BRAVE_NM_SUBSTR)
@@ -206,11 +206,11 @@ describe("install browser selection — dry-run", () => {
       // both are valid auto-selections of the single installed browser. (The
       // install script's detection can differ from browserInstalled() on CI
       // runners, so assert the outcome, not the exact phrasing.)
-      expect(stdout).toMatch(/only supported browser found|defaulting to 'chrome' \(non-interactive\)/)
+      expect(stdout).toMatch(/only supported browser found|defaulting to 'chrome' \(non-interactive/)
       expect(stdout).toContain("Browser: chrome")
       expect(stdout).toContain(CHROME_NM_SUBSTR)
     } else if (browserInstalled("brave")) {
-      expect(stdout).toMatch(/only supported browser found|defaulting to 'brave' \(non-interactive\)/)
+      expect(stdout).toMatch(/only supported browser found|defaulting to 'brave' \(non-interactive/)
       expect(stdout).toContain("Browser: brave")
       expect(stdout).toContain(BRAVE_NM_SUBSTR)
     } else {
@@ -298,10 +298,16 @@ describe("install browser selection — Edge + Vivaldi (Darwin)", () => {
  * of the Edge case.
  */
 describe("install branded-Chromium messaging — static checks", () => {
-  test("install.sh prints branded-build remediation for Chrome AND Edge", () => {
+  test("install.sh prints branded-build remediation for Chrome (all channels) AND Edge", () => {
     const src = require("node:fs").readFileSync(INSTALL_SCRIPT, "utf8")
-    // Single block; both vendors should be handled together.
-    expect(src).toContain('target" == "chrome" || "$target" == "edge"')
+    // Single block; all branded Chrome channels + Edge are handled together.
+    // (#98 wrapped the condition across lines, so assert each token rather than
+    // the combined single-line literal.)
+    expect(src).toContain('"$target" == "chrome"')
+    expect(src).toContain('"$target" == "chrome-beta"')
+    expect(src).toContain('"$target" == "chrome-canary"')
+    expect(src).toContain('"$target" == "chrome-dev"')
+    expect(src).toContain('"$target" == "edge"')
     expect(src).toContain("ignores --load-extension in branded desktop builds")
     // Developer flow URL substitution must be present for Edge.
     expect(src).toMatch(/SCHEMA="edge"/)


### PR DESCRIPTION
## Why

After #98 (Chrome channel install flags) + its follow-up fix, two assertions in `test/install-modes.test.ts` were pinned to the old `install.sh` text and went red on `main`:

1. The branded-build `--load-extension` condition was wrapped across lines with the new `chrome-beta/canary/dev` tokens, so the single-line literal `"$target" == "chrome" || "$target" == "edge"` no longer appears.
2. The non-interactive default message is now `defaulting to '<x>' (non-interactive, first installed)` (picks the first *installed* browser).

## What

- Assert each branded token individually (`chrome`, `chrome-beta`, `chrome-canary`, `chrome-dev`, `edge`) — same intent, robust to line-wrapping.
- Loosen the three non-interactive-default message assertions to match the new suffix.

Verified locally: `bun test` → **474 pass / 0 fail**, typecheck clean. Greens `main` after #98/#108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for browser selection and installation mode handling to improve validation of selected browser and native messaging directory paths across multiple browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->