### PR TITLE
Release 0.17.3 — daemon split-brain hardening + Chrome channel install flags

### DIFF
--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
Bumps every surface to **0.17.3**.

## Daemon single-instance gate (#104)
Fixes a split-brain where two daemons could run at once (one owning the CLI socket, another the WebSocket port the extension connects to) → `context '<id>' not found (no extensions connected)`. The WS port is now the atomic singleton token (bound before the CLI socket; a loser exits cleanly instead of hijacking the socket). Stress-validated: hundreds of concurrent duplicate spawns, a full kill+respawn thundering herd, and ~120 concurrent tab-opens across 3 live extensions — zero split-brains, zero hijacks, zero mis-routes. (PR by @vitorfhc; reapplied onto the 0.17.2 relay architecture.)

## Chrome channel install flags (#98)
`install.sh` adds `--chrome-beta`, `--chrome-canary`, `--chrome-dev`, `--chrome-for-testing` (Darwin), each routable to a distinct `--context`. Correct native-messaging dir for Chrome for Testing (Chrome 146+). (PR by @trillium.)

## Internal / CI
`bash -n` shell-syntax gate over scripts/*.sh (#108); install-modes test updates (#109).

## Rollup for users updating from 0.16.9
Carries the full 0.17.x line: Electron/Chromium CDP app control, the Native Runtime Agent, and the capability-blind Extension Fabric.

Version: 0.17.2 → 0.17.3. Both pkgs (Browser + Full) built, signed, notarized, stapled; ready for the Sparkle push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.17.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->