### PR TITLE
fix(content): guard against double content-script injection (double-dispatch)

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -29,7 +29,20 @@ import { handleDomScreenshot } from "./content/dom-screenshot"
 type Action = { type: string; [key: string]: unknown }
 type ActionResult = { success: boolean; error?: string; warning?: string; data?: unknown; changes?: unknown }
 
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+// Idempotency guard. content.js is injected by the manifest at document_idle AND
+// re-injected programmatically (chrome.scripting.executeScript) on retry / eager
+// paths — e.g. `interceptor open` reading a fresh tab before document_idle fires.
+// Both injections share this frame's isolated world, so without a guard the page
+// accrues TWO action listeners and every action runs twice. That double-dispatch
+// was historically masked (isolated-world synthetic clicks rarely drove framework
+// handlers), but once clicks are bridged to the page MAIN world a doubled click
+// toggles pointerdown-driven menus (Radix / Floating UI) right back shut. Register
+// the action listener (and the keepalive) only on the first load in this world.
+const __interceptorContentGlobal = globalThis as unknown as { __interceptorContentLoaded?: boolean }
+const __interceptorContentAlreadyLoaded = __interceptorContentGlobal.__interceptorContentLoaded === true
+__interceptorContentGlobal.__interceptorContentLoaded = true
+
+if (!__interceptorContentAlreadyLoaded) chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === "execute_action") {
     handleAction(msg.action)
       .then(sendResponse)
@@ -215,7 +228,7 @@ async function executeAction(action: Action): Promise<ActionResult> {
 
 // --- SW Keepalive Heartbeat (leader-elected, zero network) ---
 let _swKeepaliveLeader = true
-setInterval(() => {
+if (!__interceptorContentAlreadyLoaded) setInterval(() => {
   if (!_swKeepaliveLeader) return
   try {
     chrome.runtime.sendMessage({ type: "sw_keepalive" })


### PR DESCRIPTION
## Problem
`content.js` is injected by the manifest (`document_idle`) **and** re-injected via `chrome.scripting.executeScript` on retry/eager paths (e.g. `interceptor open` reading a fresh tab before `document_idle`). Both share the frame's isolated world, so without a guard the page accrues **two** action listeners and **every action runs twice**.

This was masked historically (isolated-world synthetic clicks rarely drove framework handlers), but after #106 bridged clicks to the page MAIN world, a doubled click **toggles pointerdown-driven menus (Radix / Floating UI) shut** — `act` on a dropdown opened then immediately closed it.

## Fix
A once-per-world idempotency guard in `content.ts` so a second injection doesn't register a duplicate action listener (or keepalive).

## Verification (live, shipped extension)
| Test | Result |
|---|---|
| `act` a Radix DropdownMenu | **1** click dispatch (was 2), `aria-expanded → true`, **10 menuitems** |
| plain non-Radix button | fires **exactly once** |
| cross-site link nav | navigates correctly |
| full suite | **482 pass / 0 fail** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues from duplicate content script initialization when the extension is reloaded
  * Prevented duplicate message listeners and multiple keepalive processes from affecting extension reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->