### PR TITLE
Release 0.17.6 — workflow-capture reliability hardening

### DIFF
--- a/cli/commands/macos.ts
+++ b/cli/commands/macos.ts
@@ -12,6 +12,14 @@ import {
   markMonitorTaskSourceAttachFailed,
   resolveOrCreateMonitorTask,
   validateMonitorTaskMode,
+  findLatestSessionSidForTask,
+  readMonitorTaskMeta,
+  resolveMonitorTaskId,
+  stopMonitorTask,
+  synthesizeMonitorTaskTranscript,
+  generateMonitorTaskCaptureQuality,
+  renderMonitorTaskStatus,
+  renderMonitorTaskQualitySummary,
 } from "../../shared/monitor-tasks"
 import { runCdpCommand } from "./cdp"
 import { runNativeCommand } from "./native"
@@ -133,7 +141,12 @@ export async function runMacosCommand(
 
   if (pendingMonitorTaskId) {
     const data = (result.data || {}) as Record<string, unknown>
-    const sid = typeof data.sid === "string" ? data.sid : typeof data.sessionId === "string" ? data.sessionId : undefined
+    // prefer the sid in the response, but if a slow/garbled RPC
+    // dropped it, recover the sid from the freshly-written session meta so the
+    // source still attaches (no more split-brain envelope with empty sources).
+    const sid = typeof data.sid === "string" ? data.sid
+      : typeof data.sessionId === "string" ? data.sessionId
+      : findLatestSessionSidForTask(pendingMonitorTaskId)
     if (sid) {
       try {
         attachMonitorTaskSource(pendingMonitorTaskId, sid, {
@@ -142,7 +155,16 @@ export async function runMacosCommand(
           rootBundleId: typeof data.rootBundleId === "string" ? data.rootBundleId : undefined,
           rootApp: typeof data.rootApp === "string" ? data.rootApp : undefined,
         })
+        // post-attach verification — confirm the source actually landed.
+        const verify = readMonitorTaskMeta(pendingMonitorTaskId)
+        const attached = verify?.sourceSessions.some((s) => s.sid === sid && s.status !== "detached")
+        if (!attached) {
+          markMonitorTaskSourceAttachFailed(pendingMonitorTaskId, sid, "source attach did not register in task meta")
+          console.error(`error: macOS monitor session ${sid} did not register as a source of task ${pendingMonitorTaskId}`)
+          process.exit(1)
+        }
         data.taskId = pendingMonitorTaskId
+        data.sid = sid
         result.data = data
       } catch (err) {
         markMonitorTaskSourceAttachFailed(pendingMonitorTaskId, sid, (err as Error).message)
@@ -151,6 +173,28 @@ export async function runMacosCommand(
       }
     } else {
       markMonitorTaskSourceAttachFailed(pendingMonitorTaskId, undefined, "macos monitor response did not include sid")
+    }
+  }
+
+  // `interceptor macos monitor stop --task <t>` must finalize
+  // the envelope locally (the bridge only stops the session). Mirror the browser
+  // path: snapshot sources, transcribe offline audio, regenerate the
+  // timeline/transcript/segments, re-grade, and print status + quality.
+  if (action.type === "macos_monitor" && action.sub === "stop" && typeof action.taskRef === "string") {
+    try {
+      const taskId = resolveMonitorTaskId(action.taskRef)
+      stopMonitorTask(taskId, {}) // snapshots + transcribes offline audio
+      synthesizeMonitorTaskTranscript(taskId) // timeline + transcript + segments + grade
+      generateMonitorTaskCaptureQuality(taskId)
+      if (opts.jsonMode) {
+        console.log(JSON.stringify(readMonitorTaskMeta(taskId), null, 2))
+      } else {
+        console.log(`${renderMonitorTaskStatus(taskId)}\n${renderMonitorTaskQualitySummary(taskId)}`)
+      }
+      return
+    } catch (err) {
+      console.error(`error: ${(err as Error).message}`)
+      process.exit(1)
     }
   }
 
@@ -263,14 +307,19 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
       // every prompt-triggering flag is forced false in the wire payload so
       // a future caller-side bug cannot accidentally modify TCC state.
       const noPrompt = filtered.includes("--no-prompt")
+      // `interceptor macos trust speech [--prompt]` is sugar for
+      // `interceptor macos trust --speech-prompt`; both surface the distinct
+      // Speech-Recognition TCC dialog.
+      const speechSub = filtered[2] === "speech"
       return {
         type: "macos_trust",
         noPrompt,
-        prompt: !noPrompt && (filtered.includes("--prompt") || filtered.includes("--walkthrough")),
+        prompt: !noPrompt && (filtered.includes("--prompt") || filtered.includes("--walkthrough")) && !speechSub,
         walkthrough: !noPrompt && filtered.includes("--walkthrough"),
         accessibilityPrompt: !noPrompt && filtered.includes("--accessibility-prompt"),
         screenPrompt: !noPrompt && filtered.includes("--screen-prompt"),
         microphonePrompt: !noPrompt && filtered.includes("--microphone-prompt"),
+        speechPrompt: !noPrompt && (filtered.includes("--speech-prompt") || (speechSub && (filtered.includes("--prompt") || filtered.length <= 3))),
       }
     }
 
@@ -733,6 +782,27 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
       // Log-predicate override.
       const logPredicate = flagVal(filtered, "--log-predicate")
 
+      // new capture knobs.
+      const speechMode = flagVal(filtered, "--speech-mode")
+      // --video takes an optional fps (defaults to 4 when bare).
+      const videoIdx = filtered.indexOf("--video")
+      let video: number | undefined
+      if (videoIdx !== -1) {
+        const next = filtered[videoIdx + 1]
+        video = next && /^\d+$/.test(next) ? parseInt(next) : 4
+      }
+      const videoMaxMb = flagInt(filtered, "--video-max-mb")
+      const frameBudget = flagInt(filtered, "--frame-budget")
+      const frameDiskCapMb = flagInt(filtered, "--frame-disk-cap")
+      const framePixelScale = flagInt(filtered, "--frame-pixel-scale")
+      const scrollCoalesceMs = flagInt(filtered, "--scroll-coalesce-ms")
+      const axCoalesceMs = flagInt(filtered, "--ax-coalesce-ms")
+      const includeSystemApps = filtered.includes("--include-system-apps")
+      const excludeAppsRaw = collectMulti(filtered, "--exclude-app")
+      const excludeApps = excludeAppsRaw.length > 0
+        ? excludeAppsRaw.flatMap((s) => s.split(",")).map((s) => s.trim()).filter((s) => s.length > 0)
+        : undefined
+
       const action: Action = {
         type: "macos_monitor",
         sub: op,
@@ -774,6 +844,17 @@ export function parseMacosCommand(filtered: string[], extensionPrefixes?: Set<st
       if (watchPath) action.watchPath = watchPath
       if (watchPaths) action.watchPaths = watchPaths
       if (logPredicate) action.logPredicate = logPredicate
+      // capture knobs (MB flags converted to bytes for the bridge).
+      if (speechMode) action.speechMode = speechMode
+      if (typeof video === "number") action.video = video
+      if (typeof videoMaxMb === "number") action.videoMaxBytes = videoMaxMb * 1024 * 1024
+      if (typeof frameBudget === "number") action.frameBudget = frameBudget
+      if (typeof frameDiskCapMb === "number") action.frameDiskCap = frameDiskCapMb * 1024 * 1024
+      if (typeof framePixelScale === "number") action.framePixelScale = framePixelScale
+      if (typeof scrollCoalesceMs === "number") action.scrollCoalesceMs = scrollCoalesceMs
+      if (typeof axCoalesceMs === "number") action.axCoalesceMs = axCoalesceMs
+      if (includeSystemApps) action.includeSystemApps = true
+      if (excludeApps) action.excludeApps = excludeApps
       return action
     }
 

--- a/cli/commands/monitor.ts
+++ b/cli/commands/monitor.ts
@@ -30,6 +30,7 @@ import {
   resolveMonitorTaskId,
   snapshotMonitorTaskSources,
   stopMonitorTask,
+  repairMonitorTask,
   synthesizeMonitorTaskTranscript,
   validateMonitorTaskMode,
 } from "../../shared/monitor-tasks"
@@ -712,6 +713,9 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
         try {
           const taskId = resolveMonitorTaskId(flagValue(filtered, "--task"))
           const task = stopMonitorTask(taskId, { stopSourcesRequested: flagPresent(filtered, "--stop-sources") })
+          // auto-finalize: regenerate the transcript/segments so the
+          // done→export flow yields a graded, non-empty envelope with no extra steps.
+          synthesizeMonitorTaskTranscript(taskId)
           if (jsonMode) console.log(JSON.stringify(task, null, 2))
           else console.log(`${renderMonitorTaskStatus(task.taskId)}\n${renderMonitorTaskQualitySummary(task.taskId)}`)
           return null
@@ -741,8 +745,51 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
       }
       return { type: "monitor_status" }
 
+    case "repair": {
+      // the long-advertised `monitor repair`. Recovers any
+      // live-but-unattached sessions for the task, snapshots sources, transcribes
+      // offline audio, regenerates the timeline/transcript/segments, and re-grades.
+      if (!flagPresent(filtered, "--task")) {
+        console.error("error: interceptor monitor repair requires --task <taskId>")
+        process.exit(1)
+      }
+      try {
+        const taskId = resolveMonitorTaskId(flagValue(filtered, "--task"))
+        const { report, attached } = repairMonitorTask(taskId, {
+          snapshotSources: flagPresent(filtered, "--snapshot-sources"),
+          regenerate: !flagPresent(filtered, "--no-regenerate"),
+        })
+        if (jsonMode) {
+          console.log(JSON.stringify({ taskId, attached, report }, null, 2))
+        } else {
+          if (attached.length > 0) console.log(`recovered + attached ${attached.length} session(s): ${attached.join(", ")}`)
+          console.log(`${renderMonitorTaskStatus(taskId)}\n${renderMonitorTaskQualitySummary(taskId)}`)
+        }
+        return null
+      } catch (err) {
+        console.error(`error: ${(err as Error).message}`)
+        process.exit(1)
+      }
+    }
+
     case "task": {
       const op = filtered[2]
+      if (op === "repair") {
+        const taskId = filtered[3]
+        if (!taskId) {
+          console.error("error: interceptor monitor task repair requires <taskId>")
+          process.exit(1)
+        }
+        try {
+          const { report, attached } = repairMonitorTask(taskId, { snapshotSources: true })
+          if (jsonMode) console.log(JSON.stringify({ taskId, attached, report }, null, 2))
+          else console.log(`${renderMonitorTaskStatus(taskId)}\n${renderMonitorTaskQualitySummary(taskId)}`)
+          return null
+        } catch (err) {
+          console.error(`error: ${(err as Error).message}`)
+          process.exit(1)
+        }
+      }
       if (op === "attach") {
         const taskId = filtered[3]
         const sid = filtered[4]
@@ -816,7 +863,7 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
           process.exit(1)
         }
       }
-      console.error("error: unknown monitor task subcommand. Try: attach, snapshot, quality, diagnose, compile-blueprint")
+      console.error("error: unknown monitor task subcommand. Try: attach, snapshot, repair, quality, diagnose, compile-blueprint")
       process.exit(1)
     }
 
@@ -989,7 +1036,7 @@ export async function parseMonitorCommand(filtered: string[], jsonMode = false):
     }
 
     default:
-      console.error(`error: unknown monitor subcommand '${sub}'. Try: start, stop, status, pause, resume, tail, list, export.`)
+      console.error(`error: unknown monitor subcommand '${sub}'. Try: start, stop, status, pause, resume, repair, tail, list, export.`)
       process.exit(1)
   }
 }
@@ -1002,8 +1049,10 @@ Usage:
   interceptor monitor status [--task <taskId>]
   interceptor monitor pause
   interceptor monitor resume
+  interceptor monitor repair --task <taskId> [--snapshot-sources] [--no-regenerate]
   interceptor monitor task attach <taskId> <sessionId>
   interceptor monitor task snapshot <taskId>
+  interceptor monitor task repair <taskId>
   interceptor monitor task quality <taskId>
   interceptor monitor task compile-blueprint <taskId> [--force-diagnostic]
   interceptor monitor tail [--session <sid>] [--raw]
@@ -1018,6 +1067,7 @@ stop     End the active session and emit a summary.
 status   Show active sessions and counts, or a task envelope when --task is present.
 pause    Pause emission temporarily (does not unhook listeners).
 resume   Resume emission.
+repair   Recover unattached sessions for a task, snapshot sources, transcribe offline audio, regenerate timeline/transcript, and re-grade.
 task     Manage task-scoped source membership.
          snapshot copies source evidence under the task root; quality renders readiness gates; compile-blueprint enforces them.
 tail     Live tail of recorded events. Pretty by default; --raw for JSONL.

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -71,7 +71,7 @@ const ALL_KNOWN_CMDS = new Set<string>([
 ])
 
 // Monitor subcommands that are handled locally (no daemon needed)
-const MONITOR_LOCAL_SUBCOMMANDS = new Set(["tail", "list", "export", "task"])
+const MONITOR_LOCAL_SUBCOMMANDS = new Set(["tail", "list", "export", "task", "repair"])
 
 function unwrapResult(response: DaemonResponse): DaemonResult {
   return response.result

--- a/cli/transport.ts
+++ b/cli/transport.ts
@@ -18,6 +18,12 @@ export const INTERCEPTOR_TIMEOUT_MS = parseInt(process.env.INTERCEPTOR_TIMEOUT |
 const ACTION_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
   macos_listen: 60_000,
   macos_vad: 60_000,
+  // monitor start/stop can do non-trivial setup/teardown (AX
+  // attach across many apps under --all-apps, frame/video/speech engines,
+  // source snapshot). Even though the bridge now acks early, give the
+  // RPC an elevated deadline as a safety margin so a momentarily busy main
+  // run loop never trips the old 15s timeout that left a split-brain envelope.
+  macos_monitor: 60_000,
   screenshot: 45_000,
   screenshot_background: 45_000,
   canvas_read: 45_000,

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.17.3",
+  "version": "0.17.6",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.17.3",
+  "version": "0.17.6",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/interceptor-bridge/Sources/Domains/MonitorAxBridge.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorAxBridge.swift
@@ -49,6 +49,23 @@ final class MonitorAxBridge: @unchecked Sendable {
     private var registered: [pid_t: [String]] = [:]
     private var callback: EventCallback?
 
+    // coalesce the two highest-rate AX notifications
+    // (kAXValueChanged → "input", kAXLayoutChanged → "layout_change"). These
+    // fire continuously during scroll/typing; debouncing them per (pid,kind)
+    // within `coalesceMs` collapses a storm into one event carrying the latest
+    // value + a coalesced count, without dropping lower-rate notifications.
+    // 0 = emit every notification (truly everything).
+    private var coalesceMs = 0
+    private var pendingCoalesced: [String: (event: String, data: [String: Any])] = [:]
+    private var coalesceCounts: [String: Int] = [:]
+    private var coalesceTimer: DispatchSourceTimer?
+    private let coalesceQueue = DispatchQueue(label: "interceptor.monitor.ax.coalesce")
+
+    func setCoalesceMs(_ ms: Int) {
+        lock.lock(); defer { lock.unlock() }
+        coalesceMs = max(0, ms)
+    }
+
     // Holds context the C-style AXObserverCallback needs. The void * `refcon`
     // is an Unmanaged<MonitorAxBridge> opaque pointer; the per-PID context is
     // stored on the bridge instance and looked up by the element's pid.
@@ -130,6 +147,7 @@ final class MonitorAxBridge: @unchecked Sendable {
     }
 
     func detachAll() {
+        flushCoalesced()
         lock.lock()
         let pids = Array(observers.keys)
         lock.unlock()
@@ -187,7 +205,7 @@ final class MonitorAxBridge: @unchecked Sendable {
             } else if isSecure {
                 data["v"] = "***SECURE***"
             }
-            cb("input", data)
+            emitMaybeCoalesced("input", data: data, pid: pid, cb: cb)
 
         case kAXFocusedUIElementChangedNotification as String:
             cb("focus", data)
@@ -211,7 +229,8 @@ final class MonitorAxBridge: @unchecked Sendable {
             cb("menu_select", data)
 
         case kAXSheetCreatedNotification as String:  cb("sheet", data)
-        case kAXLayoutChangedNotification as String: cb("layout_change", data)
+        case kAXLayoutChangedNotification as String:
+            emitMaybeCoalesced("layout_change", data: data, pid: pid, cb: cb)
 
         case kAXSelectedRowsChangedNotification as String,
              kAXSelectedCellsChangedNotification as String:
@@ -247,6 +266,46 @@ final class MonitorAxBridge: @unchecked Sendable {
             // changes here.
             data["notification"] = notification
             cb("ax_other", data)
+        }
+    }
+
+    // debounce a high-rate notification per (pid,kind).
+    private func emitMaybeCoalesced(_ event: String, data: [String: Any], pid: pid_t, cb: @escaping EventCallback) {
+        let ms = lock.withLock { self.coalesceMs }
+        if ms <= 0 { cb(event, data); return }
+        let key = "\(pid):\(event)"
+        lock.lock()
+        pendingCoalesced[key] = (event, data)
+        coalesceCounts[key] = (coalesceCounts[key] ?? 0) + 1
+        let needTimer = coalesceTimer == nil
+        if needTimer {
+            let timer = DispatchSource.makeTimerSource(queue: coalesceQueue)
+            timer.schedule(deadline: .now() + .milliseconds(ms))
+            timer.setEventHandler { [weak self] in self?.flushCoalesced() }
+            coalesceTimer = timer
+            lock.unlock()
+            timer.resume()
+        } else {
+            lock.unlock()
+        }
+    }
+
+    private func flushCoalesced() {
+        lock.lock()
+        let cb = callback
+        let pending = pendingCoalesced
+        let counts = coalesceCounts
+        pendingCoalesced.removeAll()
+        coalesceCounts.removeAll()
+        coalesceTimer?.cancel()
+        coalesceTimer = nil
+        lock.unlock()
+        guard let cb = cb else { return }
+        for (key, entry) in pending {
+            var data = entry.data
+            let n = counts[key] ?? 1
+            if n > 1 { data["coalesced"] = n }
+            cb(entry.event, data)
         }
     }
 

--- a/interceptor-bridge/Sources/Domains/MonitorDomain.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorDomain.swift
@@ -4,6 +4,8 @@ import ApplicationServices
 import CoreFoundation
 import CoreImage
 import CoreMedia
+import CoreVideo
+import AVFoundation
 import ImageIO
 import Network
 import UniformTypeIdentifiers
@@ -88,9 +90,21 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         let excludeKey = excludes.contains("key")
         let useTap = (action["tap"] as? Bool) ?? false
 
-        // Screen recording preflight if --frames or --vision-text.
+        // new capture config knobs.
+        let speechMode = ((action["speechMode"] as? String) ?? "auto").lowercased()
+        let videoFps = action["video"] as? Int            // nil = video off
+        let videoMaxBytes = Int64((action["videoMaxBytes"] as? Int) ?? 0)
+        let frameBudget = (action["frameBudget"] as? Int) ?? 7200
+        let frameDiskCapBytes = Int64((action["frameDiskCap"] as? Int) ?? 0)
+        let framePixelScale = max(1, (action["framePixelScale"] as? Int) ?? 2)
+        let scrollCoalesceMs = (action["scrollCoalesceMs"] as? Int) ?? 100
+        let axCoalesceMs = (action["axCoalesceMs"] as? Int) ?? 100
+        let includeSystemApps = (action["includeSystemApps"] as? Bool) ?? false
+        let excludeApps = parseSet(action["excludeApps"])
+
+        // Screen recording preflight if --frames, --video, or --vision-text.
         var screenRecordingTcc: Bool? = nil
-        if framesPerSec > 0 || visionText {
+        if framesPerSec > 0 || visionText || videoFps != nil {
             #if canImport(ScreenCaptureKit)
             let granted = CGPreflightScreenCaptureAccess()
             screenRecordingTcc = granted
@@ -125,6 +139,17 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
             tcc: tcc
         )
         let runtime = MonitorRuntime(session: session, domain: self)
+        // stash capture config on the runtime.
+        runtime.speechMode = speechMode
+        runtime.framePixelScale = framePixelScale
+        runtime.frameBudget = frameBudget
+        runtime.frameDiskCapBytes = frameDiskCapBytes
+        runtime.videoMaxBytes = videoMaxBytes
+        runtime.scrollCoalesceMs = scrollCoalesceMs
+        runtime.axCoalesceMs = axCoalesceMs
+        runtime.includeSystemApps = includeSystemApps
+        runtime.excludeApps = excludeApps
+        runtime.axBridge.setCoalesceMs(axCoalesceMs)
 
         // Wire bridge callbacks to record into THIS session.
         runtime.axBridge.setCallback { [weak self, weak runtime] event, data in
@@ -138,7 +163,7 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         runtime.workspaceBridge.setAppLifecycleHooks(
             launch: { [weak self, weak runtime] pid, bundleId, name in
                 guard let self = self, let r = runtime else { return }
-                if r.session.scope.mode == .all {
+                if r.session.scope.mode == .all, !self.isExcludedApp(runtime: r, bundleId: bundleId, name: name) {
                     self.attachToPid(runtime: r, pid: pid, bundleId: bundleId, appName: name)
                 }
             },
@@ -161,77 +186,43 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         runtimes[sid] = runtime
         lock.unlock()
 
-        // Initial AX attachments.
-        let initialPids = resolveInitialPids(scope: scope)
-        if initialPids.isEmpty && scope.mode != .all {
-            recordEvent(runtime: runtime, event: "scope_warning", data: ["reason": "no apps matched initial scope"])
-        }
-        for (pid, bundleId, appName) in initialPids {
-            attachToPid(runtime: runtime, pid: pid, bundleId: bundleId, appName: appName)
-        }
+        // speech is enabled by `--include speech` OR an explicit
+        // `--speech-mode live|offline`; `--speech-mode off` disables it.
+        let speechEnabled = speechMode != "off" && (includes.contains("speech") || speechMode == "live" || speechMode == "offline")
 
-        // Start workspace + input always.
-        runtime.workspaceBridge.start()
-        runtime.inputBridge.start(includeMouseMoved: includeMouseMoved, excludeKey: excludeKey)
+        // Sendable locals so the async heavy-setup closure doesn't capture the
+        // non-Sendable `action` dictionary.
+        let watchPathLocal = action["watchPath"] as? String
+        let watchPathsLocal = action["watchPaths"] as? [String]
+        let logPredicateLocal = action["logPredicate"] as? String
 
-        // CGEventTap fallback when --tap is set. Records its own structured
-        // `tap_unavailable` event if creation fails.
-        if useTap {
-            let ok = runtime.tapBridge.start()
-            runtime.tapActive = ok
-            if !ok {
-                recordEvent(runtime: runtime, event: "tap_unavailable", data: [
-                    "reason": "CGEventTap creation failed (Accessibility TCC may be missing or kCGSessionEventTap was rejected)"
-                ])
-            }
-        }
-
-        // Optional sources, gated by --include.
-        if includes.contains("clipboard") { startPasteboardWatch(runtime: runtime) }
-        if includes.contains("files") { startFileWatch(runtime: runtime, action: action) }
-        if includes.contains("network") { startPathMonitor(runtime: runtime) }
-        if includes.contains("log") { startLogPolling(runtime: runtime, action: action) }
-        if includes.contains("notifications") { startDistributedNotificationsWatch(runtime: runtime) }
-        #if canImport(ScreenCaptureKit)
-        if framesPerSec > 0 {
-            startFrameCapture(
-                runtime: runtime,
-                framesPerSec: framesPerSec,
-                visionText: visionText,
-                format: frameFormat,
-                quality: frameQuality,
-                maxLongEdge: frameMaxLongEdge
-            )
-        }
-        #endif
-        #if canImport(Speech)
-        if includes.contains("speech") { startSpeechRecognition(runtime: runtime) }
-        #endif
-
-        // Auto-stop timer.
+        // Auto-stop timer + meta are cheap; do them before the ack.
         startAutoStopTimer(runtime: runtime)
-
         Platform.writeSessionMeta(sid: sid, meta: session.toMetaDict())
 
         var startData: [String: Any] = [
             "surface": "macos",
             "scope": scope.toDict(),
             "includes": Array(includes).sorted(),
-            "tap": runtime.tapActive
+            "speechMode": speechMode,
+            "tap": useTap
         ]
         if let inst = instruction { startData["ins"] = inst }
         if let taskId = taskId { startData["taskId"] = taskId }
-        if let bid = session.rootBundleId { startData["rootBundleId"] = bid }
-        if let app = session.rootAppName { startData["rootApp"] = app }
-        if let pid = session.rootPid { startData["rootPid"] = Int(pid) }
         recordEvent(runtime: runtime, event: "mon_start", data: startData)
 
+        // ACK as soon as the session is registered. All heavy
+        // setup (AX attach for every app under --all-apps, source timers, frame
+        // / video / speech engines, and the speech-TCC prompt) runs async so the
+        // start ack never blocks on capture volume or a permission prompt. This
+        // makes the old "15s waiting on speech TCC" hang impossible.
         var ok: [String: Any] = [
             "sid": sid,
             "status": "recording",
             "surface": "macos",
             "tcc": tcc.toDict(),
-            "tap": runtime.tapActive
+            "speechMode": speechMode,
+            "tap": useTap
         ]
         if let inst = instruction { ok["instruction"] = inst }
         if let taskId = taskId { ok["taskId"] = taskId }
@@ -240,6 +231,64 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         ok["sessionDir"] = Platform.sessionDir(sid)
         ok["activeCount"] = lockedRuntimes().count
         completion(WireFormat.success(ok))
+
+        // ── async heavy setup ──
+        DispatchQueue.global(qos: .userInitiated).async { [weak self, weak runtime] in
+            guard let self = self, let runtime = runtime else { return }
+
+            // Initial AX attachments (scope-hygiene filtered).
+            let initialPids = self.resolveInitialPids(scope: scope)
+            if initialPids.isEmpty && scope.mode != .all {
+                self.recordEvent(runtime: runtime, event: "scope_warning", data: ["reason": "no apps matched initial scope"])
+            }
+            for (pid, bundleId, appName) in initialPids where !self.isExcludedApp(runtime: runtime, bundleId: bundleId, name: appName) {
+                self.attachToPid(runtime: runtime, pid: pid, bundleId: bundleId, appName: appName)
+            }
+
+            runtime.workspaceBridge.start()
+            runtime.inputBridge.start(includeMouseMoved: includeMouseMoved, excludeKey: excludeKey, scrollCoalesceMs: scrollCoalesceMs)
+
+            if useTap {
+                let okTap = runtime.tapBridge.start()
+                runtime.tapActive = okTap
+                if !okTap {
+                    self.recordEvent(runtime: runtime, event: "tap_unavailable", data: [
+                        "reason": "CGEventTap creation failed (Accessibility TCC may be missing or kCGSessionEventTap was rejected)"
+                    ])
+                }
+            }
+
+            if includes.contains("clipboard") { self.startPasteboardWatch(runtime: runtime) }
+            if includes.contains("files") {
+                var a: [String: Any] = [:]
+                if let p = watchPathLocal { a["watchPath"] = p }
+                if let ps = watchPathsLocal { a["watchPaths"] = ps }
+                self.startFileWatch(runtime: runtime, action: a)
+            }
+            if includes.contains("network") { self.startPathMonitor(runtime: runtime) }
+            if includes.contains("log") {
+                var a: [String: Any] = [:]
+                if let lp = logPredicateLocal { a["logPredicate"] = lp }
+                self.startLogPolling(runtime: runtime, action: a)
+            }
+            if includes.contains("notifications") { self.startDistributedNotificationsWatch(runtime: runtime) }
+            #if canImport(ScreenCaptureKit)
+            if framesPerSec > 0 || videoFps != nil {
+                self.startFrameCapture(
+                    runtime: runtime,
+                    framesPerSec: framesPerSec,
+                    videoFps: videoFps,
+                    visionText: visionText,
+                    format: frameFormat,
+                    quality: frameQuality,
+                    maxLongEdge: frameMaxLongEdge
+                )
+            }
+            #endif
+            #if canImport(Speech)
+            if speechEnabled { self.startSpeechRecognition(runtime: runtime) }
+            #endif
+        }
     }
 
     // MARK: - lifecycle: stop / pause / resume / status
@@ -253,6 +302,12 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
             return
         }
         let s = r.session
+        // pause-before-stop. Flip the write gate closed first so
+        // an in-flight scroll/AX storm stops being written; then flush what was
+        // already enqueued. This is what previously had to be done manually
+        // (`pause` then `stop`) for the stop ack to land within the deadline.
+        s.paused = true
+        MonitorEventWriter.shared.flush()
         s.endTime = Date()
         s.stopReason = reason
         let summary: [String: Any] = [
@@ -281,13 +336,18 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         #endif
 
         // Record mon_stop while the runtime is still in the map so
-        // recordEvent can find it and tally counts.
+        // recordEvent can find it and tally counts. (mon_stop is a lifecycle
+        // event so it writes through even though the session is now paused.)
         recordEvent(runtime: r, event: "mon_stop", data: summary)
 
         lock.lock()
         runtimes.removeValue(forKey: s.id)
         lock.unlock()
 
+        // durably flush + release the open session file handle so
+        // the snapshot/transcript pipeline reads a complete events.jsonl.
+        MonitorEventWriter.shared.flush()
+        MonitorEventWriter.shared.close(path: Platform.sessionEventsPath(s.id))
         Platform.writeSessionMeta(sid: s.id, meta: metaSnapshot)
         completion(WireFormat.success(summary))
     }
@@ -420,10 +480,37 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         return runtimes
     }
 
+    // the highest-rate event kinds. Under sustained backpressure
+    // (writer over its high-water mark) these are shed so the writer can drain;
+    // everything else (clicks, focus, nav, frames, speech, lifecycle) still
+    // writes. Coalescing already collapses most of these; shedding is the
+    // last-resort valve so a pathological flood can never wedge the session.
+    static let noisyEvents: Set<String> = ["scroll", "input", "layout_change", "move", "mouseup", "ax_other"]
+
     func recordEvent(runtime: MonitorRuntime, event: String, data: [String: Any]) {
         let s = runtime.session
         let lifecycle = event == "mon_start" || event == "mon_stop" || event == "mon_pause" || event == "mon_resume"
         if s.paused, !lifecycle { return }
+
+        // Backpressure valve: when the disk writer is saturated, drop the
+        // noisiest kinds and emit a single capture_backpressure marker so the
+        // transcript records that shedding happened (never a silent gap).
+        if !lifecycle, MonitorDomain.noisyEvents.contains(event), MonitorEventWriter.shared.isOverHighWater {
+            if !runtime.backpressureNotified {
+                runtime.backpressureNotified = true
+                var marker: [String: Any] = ["note": "event writer over high-water mark; shedding high-rate events (scroll/value/layout)"]
+                if let taskId = s.taskId { marker["taskId"] = taskId }
+                marker["s"] = s.nextSeq()
+                s.tally(event: "capture_backpressure")
+                Platform.appendMonitorEvent(sid: s.id, event: "capture_backpressure", data: marker)
+            }
+            return
+        }
+        // Recovered — allow a future backpressure notice if it recurs.
+        if runtime.backpressureNotified, !MonitorEventWriter.shared.isOverHighWater {
+            runtime.backpressureNotified = false
+        }
+
         var enriched = data
         if let taskId = s.taskId { enriched["taskId"] = taskId }
         enriched["s"] = s.nextSeq()
@@ -494,6 +581,40 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
         }
         if let app = action["app"] as? String, !app.isEmpty { return .apps([app]) }
         return .frontmost()
+    }
+
+    // `--all-apps` scope hygiene. By default we do NOT attach an
+    // AXObserver to system chrome/helpers (loginwindow, Dock, WindowServer,
+    // Control Center, Spotlight, etc.) — they generate high-rate noise and
+    // little workflow signal, and attaching to loginwindow was a top source of
+    // the RPC-saturation timeouts. `--include-system-apps` opts back in; each
+    // `--exclude-app <bundleId|name>` adds to the denylist.
+    static let systemAppDenylist: Set<String> = [
+        "com.apple.loginwindow",
+        "com.apple.dock",
+        "com.apple.WindowManager",
+        "com.apple.controlcenter",
+        "com.apple.systemuiserver",
+        "com.apple.notificationcenterui",
+        "com.apple.Spotlight",
+        "com.apple.wifi.WiFiAgent",
+        "com.apple.TextInputMenuAgent",
+        "com.apple.TextInputSwitcher",
+        "com.apple.universalcontrol",
+        "com.apple.screencaptureui",
+        "com.apple.coreservices.uiagent",
+    ]
+
+    private func isExcludedApp(runtime r: MonitorRuntime, bundleId: String?, name: String?) -> Bool {
+        // Per-session explicit excludes always apply (match bundle id or name).
+        if let b = bundleId, r.excludeApps.contains(b) { return true }
+        if let n = name, r.excludeApps.contains(n) { return true }
+        if r.includeSystemApps { return false }
+        if let b = bundleId, MonitorDomain.systemAppDenylist.contains(b) { return true }
+        // WindowServer / loginwindow can appear with empty/odd bundle ids; also
+        // filter the obvious agent-name pattern as a backstop.
+        if let n = name, MonitorDomain.systemAppDenylist.contains(n) { return true }
+        return false
     }
 
     private func readSessionEvents(sid: String) -> [[String: Any]] {
@@ -717,11 +838,14 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
     private func startFrameCapture(
         runtime r: MonitorRuntime,
         framesPerSec: Int,
+        videoFps: Int?,
         visionText: Bool,
         format: String,
         quality: Int,
         maxLongEdge: Int
     ) {
+        let wantFrames = framesPerSec > 0
+        let wantVideo = videoFps != nil
         Task { [weak r, weak self] in
             guard let r = r, let self = self else { return }
             do {
@@ -729,24 +853,60 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
                 guard let display = content.displays.first else { return }
                 let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
                 let config = SCStreamConfiguration()
-                config.width = Int(display.width)
-                config.height = Int(display.height)
-                config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(max(1, framesPerSec)))
-                config.queueDepth = 3
-                let output = MonitorCaptureOutput(
-                    domain: self,
-                    runtime: r,
-                    sid: r.session.id,
-                    visionText: visionText,
-                    format: format,
-                    quality: quality,
-                    maxLongEdge: maxLongEdge
-                )
+                // correct geometry. Point dims × pixel scale, with
+                // scalesToFit + captureResolution + explicit pixelFormat, mirroring
+                // the working CaptureDomain path. Without this SCK can hand back an
+                // aspect-broken sliver (the 7680×60 bug) or drop frames.
+                let pixelScale = max(1, r.framePixelScale)
+                config.width = Int(display.width) * pixelScale
+                config.height = Int(display.height) * pixelScale
+                config.scalesToFit = true
+                config.showsCursor = true
+                config.captureResolution = .best
+                config.pixelFormat = kCVPixelFormatType_32BGRA
+                let effectiveFps = max(wantFrames ? framesPerSec : 1, wantVideo ? (videoFps ?? 1) : 1)
+                config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(max(1, effectiveFps)))
+                config.queueDepth = 5
+
                 let stream = SCStream(filter: filter, configuration: config, delegate: nil)
-                try stream.addStreamOutput(output, type: .screen, sampleHandlerQueue: DispatchQueue.global(qos: .userInitiated))
+
+                // Still frames — only when --frames was requested.
+                if wantFrames {
+                    let output = MonitorCaptureOutput(
+                        domain: self,
+                        runtime: r,
+                        sid: r.session.id,
+                        visionText: visionText,
+                        format: format,
+                        quality: quality,
+                        maxLongEdge: maxLongEdge,
+                        frameBudget: r.frameBudget,
+                        diskCapBytes: r.frameDiskCapBytes
+                    )
+                    try stream.addStreamOutput(output, type: .screen, sampleHandlerQueue: DispatchQueue.global(qos: .userInitiated))
+                    r.captureOutput = output
+                }
+
+                // Continuous video — SCRecordingOutput → recording/screen.mp4.
+                if wantVideo {
+                    let dir = Platform.sessionDir(r.session.id) + "/recording"
+                    try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+                    let mp4 = dir + "/screen.mp4"
+                    try? FileManager.default.removeItem(atPath: mp4)
+                    let recCfg = SCRecordingOutputConfiguration()
+                    recCfg.outputURL = URL(fileURLWithPath: mp4)
+                    recCfg.outputFileType = .mp4
+                    let recDelegate = MonitorRecordingDelegate(domain: self, runtime: r, path: mp4)
+                    let recOutput = SCRecordingOutput(configuration: recCfg, delegate: recDelegate)
+                    try stream.addRecordingOutput(recOutput)
+                    r.recordingOutput = recOutput
+                    r.recordingPath = mp4
+                    r.recordingDelegate = recDelegate
+                    self.recordEvent(runtime: r, event: "video_start", data: ["path": mp4, "fps": videoFps ?? 0])
+                }
+
                 try await stream.startCapture()
                 r.captureStream = stream
-                r.captureOutput = output
             } catch {
                 self.recordEvent(runtime: r, event: "frame_error", data: ["error": "\(error.localizedDescription)"])
             }
@@ -755,76 +915,232 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
 
     @available(macOS 12.3, *)
     private func stopFrameCapture(runtime r: MonitorRuntime) {
-        Task { [weak r] in
-            try? await r?.captureStream?.stopCapture()
+        let path = r.recordingPath
+        Task { [weak r, weak self] in
+            if let stream = r?.captureStream {
+                if let recOutput = r?.recordingOutput {
+                    try? stream.removeRecordingOutput(recOutput)
+                }
+                try? await stream.stopCapture()
+            }
+            if let p = path, let r = r, let self = self {
+                self.recordEvent(runtime: r, event: "video_stop", data: ["path": p])
+            }
             r?.captureStream = nil
             r?.captureOutput = nil
+            r?.recordingOutput = nil
+            r?.recordingDelegate = nil
+            r?.recordingPath = nil
         }
     }
     #endif
 
     #if canImport(Speech)
+    // speech capture that works or fails loudly,
+    // never silently, and always yields a transcript when the mic is available.
+    //   • mode "offline": skip live ASR, tee mic → speech.caf for offline xcribe.
+    //   • mode "live":    live ASR only (no offline fallback).
+    //   • mode "auto":    attempt live ASR; if denied/unavailable, fall back to
+    //                     the offline .caf so the transcript is never empty.
+    // The whole thing runs async (called from the async start path) so it can
+    // never block the start ack.
     private func startSpeechRecognition(runtime r: MonitorRuntime) {
+        let mode = r.speechMode
+
+        if mode == "offline" {
+            DispatchQueue.main.async { [weak self, weak r] in
+                guard let self = self, let r = r else { return }
+                self.spinUpSpeechEngine(runtime: r, recognizer: nil, writeCaf: true)
+            }
+            return
+        }
+
+        // runtime key-guard — Apple CRASHES if we call requestAuthorization
+        // with NSSpeechRecognitionUsageDescription absent. Defensively no-op live
+        // ASR if the running bundle lacks the key (older build); auto still teed.
+        let hasSpeechKey = Bundle.main.object(forInfoDictionaryKey: "NSSpeechRecognitionUsageDescription") != nil
+        guard hasSpeechKey else {
+            recordEvent(runtime: r, event: "speech_unavailable", data: [
+                "reason": "missing NSSpeechRecognitionUsageDescription in Info.plist; live ASR disabled",
+                "remediation": "rebuild interceptor-bridge so the speech usage key ships",
+            ])
+            if mode == "auto" {
+                DispatchQueue.main.async { [weak self, weak r] in
+                    guard let self = self, let r = r else { return }
+                    self.spinUpSpeechEngine(runtime: r, recognizer: nil, writeCaf: true)
+                }
+            }
+            return
+        }
+
+        // actor-neutral authorization. Do NOT pass a @MainActor
+        // closure to requestAuthorization: Apple does not guarantee the callback
+        // runs on the main queue and a main-actor closure would crash. We only
+        // hop to main to touch AVAudioEngine.
         SFSpeechRecognizer.requestAuthorization { [weak self, weak r] status in
             guard let self = self, let r = r else { return }
-            guard status == .authorized else {
-                self.recordEvent(runtime: r, event: "speech_unavailable", data: ["reason": "authorization \(status.rawValue)"])
-                return
-            }
-            guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
-                self.recordEvent(runtime: r, event: "speech_unavailable", data: ["reason": "recognizer not available"])
-                return
-            }
-            DispatchQueue.main.async {
-                self.spinUpSpeechEngine(runtime: r, recognizer: recognizer)
+            if status == .authorized, let recognizer = SFSpeechRecognizer(), recognizer.isAvailable {
+                DispatchQueue.main.async {
+                    self.spinUpSpeechEngine(runtime: r, recognizer: recognizer, writeCaf: r.speechMode == "auto")
+                }
+            } else {
+                self.recordEvent(runtime: r, event: "speech_unavailable", data: [
+                    "reason": "authorization \(status.rawValue) (\(MonitorDomain.speechAuthName(status)))",
+                    "fallback": r.speechMode == "auto" ? "offline_caf" : "none",
+                    "remediation": "interceptor macos trust speech --prompt",
+                ])
+                if r.speechMode == "auto" {
+                    DispatchQueue.main.async {
+                        self.spinUpSpeechEngine(runtime: r, recognizer: nil, writeCaf: true)
+                    }
+                }
             }
         }
     }
 
-    private func spinUpSpeechEngine(runtime r: MonitorRuntime, recognizer: SFSpeechRecognizer) {
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        request.addsPunctuation = true
+    static func speechAuthName(_ status: SFSpeechRecognizerAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "authorized"
+        case .denied: return "denied"
+        case .restricted: return "restricted"
+        case .notDetermined: return "notDetermined"
+        @unknown default: return "unknown"
+        }
+    }
 
+    // One AVAudioEngine + one tap fans out to (a) the live recognizer request
+    // and (b) the offline .caf writer, so audio is never captured twice and the
+    // .caf is a faithful backup of exactly what the recognizer heard.
+    private func spinUpSpeechEngine(runtime r: MonitorRuntime, recognizer: SFSpeechRecognizer?, writeCaf: Bool) {
         let engine = AVAudioEngine()
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)
-        input.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
-            request.append(buffer)
+
+        // offline .caf tee under the session dir (Microphone grant).
+        if writeCaf {
+            Platform.ensureSessionDir(r.session.id)
+            let cafPath = Platform.sessionDir(r.session.id) + "/speech.caf"
+            if let file = try? AVAudioFile(forWriting: URL(fileURLWithPath: cafPath), settings: format.settings) {
+                r.speechAudioFile = file
+                r.speechCafPath = cafPath
+                recordEvent(runtime: r, event: "speech_audio", data: ["path": cafPath, "kind": "offline_caf"])
+            }
         }
 
-        let task = recognizer.recognitionTask(with: request) { [weak self, weak r] result, error in
-            guard let self = self, let r = r else { return }
-            if let res = result {
-                self.recordEvent(runtime: r, event: "speech_segment", data: [
-                    "text": res.bestTranscription.formattedString,
-                    "isFinal": res.isFinal
-                ])
-            }
-            if let e = error {
-                self.recordEvent(runtime: r, event: "speech_unavailable", data: ["reason": "\(e.localizedDescription)"])
-            }
+        // live recognizer when authorized.
+        if let recognizer = recognizer {
+            let req = makeSpeechRequest(recognizer: recognizer)
+            r.speechRequest = req
+            r.speechTask = recognizer.recognitionTask(with: req, resultHandler: makeSpeechResultHandler(runtime: r))
+            r.speechRingFrameBudget = AVAudioFrameCount(format.sampleRate * 2) // ~2s replay
+            scheduleSpeechRestart(runtime: r)
+        }
+
+        input.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self, weak r] buffer, _ in
+            guard let r = r else { return }
+            r.speechRequest?.append(buffer)
+            if writeCaf { try? r.speechAudioFile?.write(from: buffer) }
+            self?.pushSpeechRing(runtime: r, buffer: buffer)
         }
 
         do {
             engine.prepare()
             try engine.start()
             r.speechEngine = engine
-            r.speechRequest = request
-            r.speechTask = task
         } catch {
             recordEvent(runtime: r, event: "speech_unavailable", data: ["reason": "engine start failed: \(error.localizedDescription)"])
         }
     }
 
+    private func makeSpeechRequest(recognizer: SFSpeechRecognizer) -> SFSpeechAudioBufferRecognitionRequest {
+        let req = SFSpeechAudioBufferRecognitionRequest()
+        req.shouldReportPartialResults = true
+        req.addsPunctuation = true
+        req.taskHint = .dictation
+        // Apple: requiresOnDeviceRecognition is "only honored if
+        // supportsOnDeviceRecognition is also true" — gate it, else it's silently
+        // ignored and we'd quietly fall back to the network path.
+        if recognizer.supportsOnDeviceRecognition { req.requiresOnDeviceRecognition = true }
+        return req
+    }
+
+    private func makeSpeechResultHandler(runtime r: MonitorRuntime) -> (SFSpeechRecognitionResult?, Error?) -> Void {
+        return { [weak self, weak r] result, error in
+            guard let self = self, let r = r else { return }
+            if let res = result {
+                self.recordEvent(runtime: r, event: "speech_segment", data: [
+                    "text": res.bestTranscription.formattedString,
+                    "isFinal": res.isFinal,
+                    "source": "live",
+                ])
+            }
+            if let e = error {
+                self.recordEvent(runtime: r, event: "speech_unavailable", data: ["reason": "\(e.localizedDescription)"])
+            }
+        }
+    }
+
+    // restart the recognition task before Apple's ~60s hard limit
+    // ("the framework stops speech recognition tasks that last longer than one
+    // minute"). The ring buffer replays the trailing ~2s so a word straddling
+    // the boundary isn't lost.
+    private func scheduleSpeechRestart(runtime r: MonitorRuntime) {
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+        timer.schedule(deadline: .now() + .seconds(55))
+        timer.setEventHandler { [weak self, weak r] in
+            guard let self = self, let r = r else { return }
+            guard r.session.endTime == nil, !r.session.paused else { return }
+            self.restartSpeechTask(runtime: r)
+        }
+        timer.resume()
+        r.speechRestartTimer = timer
+    }
+
+    private func restartSpeechTask(runtime r: MonitorRuntime) {
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else { return }
+        r.speechTask?.finish()
+        r.speechRequest?.endAudio()
+        let req = makeSpeechRequest(recognizer: recognizer)
+        r.speechLock.lock()
+        let replay = r.speechRing
+        r.speechLock.unlock()
+        for buf in replay { req.append(buf) }
+        r.speechRequest = req
+        r.speechTask = recognizer.recognitionTask(with: req, resultHandler: makeSpeechResultHandler(runtime: r))
+        recordEvent(runtime: r, event: "speech_restart", data: ["replayBuffers": replay.count])
+        scheduleSpeechRestart(runtime: r)
+    }
+
+    private func pushSpeechRing(runtime r: MonitorRuntime, buffer: AVAudioPCMBuffer) {
+        guard r.speechRingFrameBudget > 0 else { return }
+        r.speechLock.lock()
+        r.speechRing.append(buffer)
+        var total: AVAudioFrameCount = r.speechRing.reduce(0) { $0 + $1.frameLength }
+        while total > r.speechRingFrameBudget, r.speechRing.count > 1 {
+            let dropped = r.speechRing.removeFirst()
+            total -= dropped.frameLength
+        }
+        r.speechLock.unlock()
+    }
+
     private func stopSpeechRecognition(runtime r: MonitorRuntime) {
-        r.speechTask?.cancel()
+        r.speechRestartTimer?.cancel()
+        r.speechRestartTimer = nil
+        r.speechTask?.finish()
         r.speechRequest?.endAudio()
         r.speechEngine?.stop()
         r.speechEngine?.inputNode.removeTap(onBus: 0)
         r.speechTask = nil
         r.speechRequest = nil
         r.speechEngine = nil
+        r.speechLock.lock(); r.speechRing.removeAll(); r.speechLock.unlock()
+        // finalize the .caf so the offline transcriber can read it, and
+        // emit a marker the snapshot/synthesis step keys on.
+        if let caf = r.speechCafPath {
+            r.speechAudioFile = nil // releasing AVAudioFile flushes the CAF header
+            recordEvent(runtime: r, event: "speech_audio_done", data: ["path": caf])
+        }
+        r.speechCafPath = nil
     }
     #endif
 
@@ -863,6 +1179,10 @@ final class MonitorDomain: DomainHandler, @unchecked Sendable {
             idx += 1
         }
         let archive = dir + "/events.jsonl.\(idx)"
+        // Release the writer's open handle so the move targets the live file and
+        // the next append re-opens the fresh events.jsonl (not the moved inode).
+        MonitorEventWriter.shared.flush()
+        MonitorEventWriter.shared.close(path: cur)
         do {
             try FileManager.default.moveItem(atPath: cur, toPath: archive)
             recordEvent(runtime: r, event: "rotation", data: ["archived": archive, "index": idx])
@@ -888,7 +1208,13 @@ final class MonitorCaptureOutput: NSObject, SCStreamOutput, @unchecked Sendable 
     let format: String      // "jpeg" | "png" | "webp"
     let quality: Int        // 0..100; ignored for png
     let maxLongEdge: Int    // 0 = no resize; otherwise scale so max(w,h) == this
+    // bound disk usage so a long session can't fill /tmp.
+    let frameBudget: Int    // 0 = unbounded; else stop writing frames after N
+    let diskCapBytes: Int64 // 0 = uncapped; else stop after this many bytes
     private var frameCount = 0
+    private var bytesWritten: Int64 = 0
+    private var lastFrameHash = 0
+    private var budgetReached = false
 
     init(
         domain: MonitorDomain?,
@@ -897,7 +1223,9 @@ final class MonitorCaptureOutput: NSObject, SCStreamOutput, @unchecked Sendable 
         visionText: Bool,
         format: String = "jpeg",
         quality: Int = 80,
-        maxLongEdge: Int = 0
+        maxLongEdge: Int = 0,
+        frameBudget: Int = 0,
+        diskCapBytes: Int64 = 0
     ) {
         self.domain = domain
         self.runtime = runtime
@@ -906,18 +1234,19 @@ final class MonitorCaptureOutput: NSObject, SCStreamOutput, @unchecked Sendable 
         self.format = format.lowercased()
         self.quality = max(0, min(100, quality))
         self.maxLongEdge = max(0, maxLongEdge)
+        self.frameBudget = max(0, frameBudget)
+        self.diskCapBytes = max(0, diskCapBytes)
     }
 
+    // Runs serially on the sampleHandlerQueue, so the counters below need no
+    // extra locking.
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        guard type == .screen, CMSampleBufferIsValid(sampleBuffer),
+        guard type == .screen, !budgetReached, CMSampleBufferIsValid(sampleBuffer),
               let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
         let framesDir = Platform.sessionDir(sid) + "/frames"
         try? FileManager.default.createDirectory(atPath: framesDir, withIntermediateDirectories: true)
-        let frameIndex = frameCount
-        frameCount += 1
         let ext = format == "png" ? "png" : (format == "webp" ? "webp" : "jpeg")
-        let path = framesDir + "/\(String(format: "%06d", frameIndex)).\(ext)"
 
         let ciImage = CIImage(cvImageBuffer: imageBuffer)
         let context = CIContext()
@@ -953,7 +1282,18 @@ final class MonitorCaptureOutput: NSObject, SCStreamOutput, @unchecked Sendable 
             }
             return
         }
+
+        // dedup: skip a frame byte-identical to the previous one (a still
+        // screen at 1fps would otherwise write hundreds of identical frames).
+        let hash = data.hashValue
+        if hash == lastFrameHash { return }
+        lastFrameHash = hash
+
+        let frameIndex = frameCount
+        let path = framesDir + "/\(String(format: "%06d", frameIndex)).\(ext)"
         try? data.write(to: URL(fileURLWithPath: path))
+        frameCount += 1
+        bytesWritten += Int64(data.count)
 
         if let r = runtime, let d = domain {
             d.recordEvent(runtime: r, event: "frame", data: [
@@ -965,6 +1305,55 @@ final class MonitorCaptureOutput: NSObject, SCStreamOutput, @unchecked Sendable 
                 "quality": quality
             ])
             if visionText { d.runOCROnImage(runtime: r, cg: cg, framePath: path) }
+
+            // stop ONLY the frame output (not the whole session / video)
+            // when a cap is hit, and say so loudly.
+            if (frameBudget > 0 && frameCount >= frameBudget) || (diskCapBytes > 0 && bytesWritten >= diskCapBytes) {
+                budgetReached = true
+                d.recordEvent(runtime: r, event: "frame_budget_reached", data: [
+                    "frames": frameCount,
+                    "bytes": bytesWritten,
+                    "frameBudget": frameBudget,
+                    "diskCapBytes": diskCapBytes,
+                ])
+            }
+        }
+    }
+}
+
+// receives SCRecordingOutput lifecycle callbacks and records
+// them into the session so the timeline knows when video started/finished and
+// how large the file is.
+final class MonitorRecordingDelegate: NSObject, SCRecordingOutputDelegate, @unchecked Sendable {
+    weak var domain: MonitorDomain?
+    weak var runtime: MonitorRuntime?
+    let path: String
+
+    init(domain: MonitorDomain?, runtime: MonitorRuntime?, path: String) {
+        self.domain = domain
+        self.runtime = runtime
+        self.path = path
+    }
+
+    func recordingOutputDidStartRecording(_ recordingOutput: SCRecordingOutput) {
+        if let r = runtime, let d = domain {
+            d.recordEvent(runtime: r, event: "video_recording", data: ["path": path, "state": "started"])
+        }
+    }
+
+    func recordingOutput(_ recordingOutput: SCRecordingOutput, didFailWithError error: Error) {
+        if let r = runtime, let d = domain {
+            d.recordEvent(runtime: r, event: "video_error", data: ["path": path, "error": error.localizedDescription])
+        }
+    }
+
+    func recordingOutputDidFinishRecording(_ recordingOutput: SCRecordingOutput) {
+        if let r = runtime, let d = domain {
+            d.recordEvent(runtime: r, event: "video_finished", data: [
+                "path": path,
+                "bytes": recordingOutput.recordedFileSize,
+                "durationSec": recordingOutput.recordedDuration.seconds,
+            ])
         }
     }
 }

--- a/interceptor-bridge/Sources/Domains/MonitorInputBridge.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorInputBridge.swift
@@ -34,15 +34,27 @@ final class MonitorInputBridge: @unchecked Sendable {
     private var includeMouseMoved = false
     private var excludeKey = false
 
+    // scroll coalescing. Within `scrollCoalesceMs`, accumulate
+    // scrollingDelta into one event carrying summed deltas + a sample count, so
+    // "log everything" stays full-fidelity (no lost direction/magnitude) without
+    // flooding the main run loop with one write per wheel tick. 0 = per-event.
+    private var scrollCoalesceMs = 0
+    private var scrollAccumX: Double = 0
+    private var scrollAccumY: Double = 0
+    private var scrollSamples = 0
+    private var scrollLatest: [String: Any]?
+    private var scrollFlushTimer: DispatchSourceTimer?
+
     func setCallback(_ cb: @escaping EventCallback) {
         lock.lock(); defer { lock.unlock() }
         callback = cb
     }
 
-    func start(includeMouseMoved: Bool = false, excludeKey: Bool = false) {
+    func start(includeMouseMoved: Bool = false, excludeKey: Bool = false, scrollCoalesceMs: Int = 0) {
         lock.lock()
         self.includeMouseMoved = includeMouseMoved
         self.excludeKey = excludeKey
+        self.scrollCoalesceMs = max(0, scrollCoalesceMs)
         lock.unlock()
 
         // Mask: clicks, scroll, key presses (when included), modifier flags
@@ -70,6 +82,11 @@ final class MonitorInputBridge: @unchecked Sendable {
     }
 
     func stop() {
+        flushScroll()
+        lock.lock()
+        scrollFlushTimer?.cancel()
+        scrollFlushTimer = nil
+        lock.unlock()
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.lock.lock()
@@ -80,6 +97,50 @@ final class MonitorInputBridge: @unchecked Sendable {
                 NSEvent.removeMonitor(m)
             }
         }
+    }
+
+    // MARK: - scroll coalescing
+
+    private func accumulateScroll(dx: CGFloat, dy: CGFloat, base: [String: Any], coalesceMs: Int) {
+        lock.lock()
+        scrollAccumX += Double(dx)
+        scrollAccumY += Double(dy)
+        scrollSamples += 1
+        scrollLatest = base
+        let needTimer = scrollFlushTimer == nil
+        if needTimer {
+            let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+            timer.schedule(deadline: .now() + .milliseconds(coalesceMs))
+            timer.setEventHandler { [weak self] in self?.flushScroll() }
+            scrollFlushTimer = timer
+            lock.unlock()
+            timer.resume()
+        } else {
+            lock.unlock()
+        }
+    }
+
+    private func flushScroll() {
+        lock.lock()
+        let cb = callback
+        let samples = scrollSamples
+        guard samples > 0, let cb = cb, var data = scrollLatest else {
+            scrollFlushTimer?.cancel()
+            scrollFlushTimer = nil
+            lock.unlock()
+            return
+        }
+        data["sx"] = scrollAccumX
+        data["sy"] = scrollAccumY
+        data["samples"] = samples
+        scrollAccumX = 0
+        scrollAccumY = 0
+        scrollSamples = 0
+        scrollLatest = nil
+        scrollFlushTimer?.cancel()
+        scrollFlushTimer = nil
+        lock.unlock()
+        cb("scroll", data)
     }
 
     // MARK: - dispatch
@@ -136,9 +197,14 @@ final class MonitorInputBridge: @unchecked Sendable {
             cb("mods", data)
 
         case .scrollWheel:
-            data["sx"] = event.scrollingDeltaX
-            data["sy"] = event.scrollingDeltaY
-            cb("scroll", data)
+            let coalesce = lock.withLock { self.scrollCoalesceMs }
+            if coalesce <= 0 {
+                data["sx"] = event.scrollingDeltaX
+                data["sy"] = event.scrollingDeltaY
+                cb("scroll", data)
+            } else {
+                accumulateScroll(dx: event.scrollingDeltaX, dy: event.scrollingDeltaY, base: data, coalesceMs: coalesce)
+            }
 
         case .mouseMoved:
             data["x"] = Int(NSEvent.mouseLocation.x)

--- a/interceptor-bridge/Sources/Domains/MonitorRuntime.swift
+++ b/interceptor-bridge/Sources/Domains/MonitorRuntime.swift
@@ -69,13 +69,45 @@ final class MonitorRuntime: @unchecked Sendable {
     #if canImport(ScreenCaptureKit)
     var captureStream: SCStream?
     var captureOutput: MonitorCaptureOutput?
+    // continuous video via SCRecordingOutput (macOS 15+).
+    var recordingOutput: SCRecordingOutput?
+    var recordingPath: String?
+    var recordingDelegate: AnyObject?
     #endif
+
+    // guards the speech ring buffer (mutated on the audio render
+    // thread, read on the restart timer queue).
+    let speechLock = NSLock()
 
     #if canImport(Speech)
     var speechEngine: AVAudioEngine?
     var speechRequest: SFSpeechAudioBufferRecognitionRequest?
     var speechTask: SFSpeechRecognitionTask?
+    // restart the SFSpeechRecognitionTask before Apple's ~60s
+    // hard limit. The ring buffer replays the trailing ~2s of audio across the
+    // restart so a word spanning the boundary isn't dropped.
+    var speechRestartTimer: DispatchSourceTimer?
+    var speechRing: [AVAudioPCMBuffer] = []
+    var speechRingFrameBudget: AVAudioFrameCount = 0
+    var speechRestarting = false
+    // offline fallback: always tee mic audio to a .caf under the
+    // session dir using the (already-granted) Microphone permission, so a
+    // transcript exists even when live Speech-Recognition TCC is denied.
+    var speechAudioFile: AVAudioFile?
+    var speechCafPath: String?
     #endif
+
+    // per-session capture configuration (parsed from monitor start).
+    var speechMode: String = "auto"          // auto | live | offline | off
+    var framePixelScale: Int = 2
+    var frameBudget: Int = 7200              // 0 = unbounded
+    var frameDiskCapBytes: Int64 = 0         // 0 = uncapped
+    var videoMaxBytes: Int64 = 0             // 0 = uncapped
+    var scrollCoalesceMs: Int = 100
+    var axCoalesceMs: Int = 100
+    var includeSystemApps: Bool = false
+    var excludeApps: Set<String> = []        // bundle ids or localized names
+    var backpressureNotified = false         // emit capture_backpressure once
 
     init(session: MonitorSession, domain: MonitorDomain) {
         self.session = session

--- a/interceptor-bridge/Sources/Domains/TrustDomain.swift
+++ b/interceptor-bridge/Sources/Domains/TrustDomain.swift
@@ -3,6 +3,9 @@ import ApplicationServices
 import AppKit
 import CoreGraphics
 import AVFoundation
+#if canImport(Speech)
+import Speech
+#endif
 
 // Trust response payload — schema lifted from Apple's AVAuthorizationStatus
 // vocabulary. Status values:
@@ -68,14 +71,19 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         let accessibilityPrompt = !noPrompt && (action["accessibilityPrompt"] as? Bool ?? false)
         let screenPrompt = !noPrompt && (action["screenPrompt"] as? Bool ?? false)
         let microphonePrompt = !noPrompt && (action["microphonePrompt"] as? Bool ?? false)
+        // Speech Recognition is a distinct TCC service from
+        // Microphone. `macos trust speech --prompt` (or --speech-prompt) surfaces it.
+        let speechPrompt = !noPrompt && (action["speechPrompt"] as? Bool ?? false)
 
         let shouldPromptAccessibility = prompt || walkthrough || accessibilityPrompt
         let shouldPromptScreen = prompt || walkthrough || screenPrompt
         let shouldPromptMicrophone = prompt || walkthrough || microphonePrompt
+        let shouldPromptSpeech = prompt || walkthrough || speechPrompt
 
         let accessibilityStatus = checkAccessibility(prompt: shouldPromptAccessibility)
         let screenStatus = checkScreenRecording(prompt: shouldPromptScreen)
         let microphoneStatus = checkMicrophone(prompt: shouldPromptMicrophone)
+        let speechStatus = checkSpeech(prompt: shouldPromptSpeech)
 
         let displayName =
             (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
@@ -106,6 +114,14 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
                 path: "System Settings → Privacy & Security → Screen Recording → Enable \(displayName)",
                 reason: "Required for screenshots, screen capture, and vision analysis",
                 limitation: "Apple's CGPreflightScreenCaptureAccess returns Bool only; cannot distinguish denied from not_determined"
+            ),
+            Permission(
+                name: "Speech Recognition",
+                status: speechStatus,
+                required: false,
+                path: "System Settings → Privacy & Security → Speech Recognition → Enable \(displayName)",
+                reason: "Required for live speech-to-text during workflow capture (mac_monitor --include speech)",
+                limitation: nil
             )
         ]
 
@@ -123,6 +139,9 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
             } else if microphoneStatus != .granted {
                 openPrivacyPane("Privacy_Microphone")
                 openedPanes.append("Microphone")
+            } else if speechStatus != .granted {
+                openPrivacyPane("Privacy_SpeechRecognition")
+                openedPanes.append("Speech Recognition")
             }
         }
 
@@ -139,11 +158,15 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         if shouldPromptMicrophone && microphoneStatus == .notDetermined {
             pendingUserAction.append("Microphone")
         }
+        if shouldPromptSpeech && speechStatus == .notDetermined {
+            pendingUserAction.append("Speech Recognition")
+        }
 
         var result: [String: Any] = [
             "accessibility": accessibilityStatus.rawValue,
             "screenRecording": screenStatus.rawValue,
             "microphone": microphoneStatus.rawValue,
+            "speechRecognition": speechStatus.rawValue,
             "permissions": permissions.map { $0.toDictionary() },
             "bundlePath": Bundle.main.bundlePath,
             "displayName": displayName
@@ -157,6 +180,7 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         if shouldPromptAccessibility { prompted.append("Accessibility") }
         if shouldPromptScreen { prompted.append("Screen Recording") }
         if shouldPromptMicrophone { prompted.append("Microphone") }
+        if shouldPromptSpeech { prompted.append("Speech Recognition") }
         if !prompted.isEmpty {
             result["prompted"] = prompted
         }
@@ -271,6 +295,53 @@ final class TrustDomain: DomainHandler, @unchecked Sendable {
         // emit pending_user_action upstream.
         return microphoneProvider.currentStatus().permissionStatus
     }
+
+    // ── Speech Recognition ───────────────────────────────────────────────
+    // distinct TCC service from Microphone. Same LSUIElement
+    // activation-policy-upgrade trick as the mic prompt: a faceless .accessory
+    // agent can't reliably surface a TCC dialog, so go .regular for the request
+    // then back to .accessory. Authorization is requested with an actor-neutral
+    // closure (Apple may call it off the main queue; a @MainActor closure would
+    // crash). Defensively no-op if the usage string is missing — calling
+    // requestAuthorization without it CRASHES per Apple's docs.
+    #if canImport(Speech)
+    private func checkSpeech(prompt: Bool) -> PermissionStatus {
+        let current = speechPermissionStatus(SFSpeechRecognizer.authorizationStatus())
+        if current != .notDetermined { return current }
+        guard prompt else { return .notDetermined }
+        guard Bundle.main.object(forInfoDictionaryKey: "NSSpeechRecognitionUsageDescription") != nil else {
+            return .notDetermined
+        }
+
+        let isLiveBridge = Bundle.main.bundleIdentifier == "com.interceptor.bridge"
+        if isLiveBridge {
+            DispatchQueue.main.async {
+                NSApplication.shared.setActivationPolicy(.regular)
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+        }
+        SFSpeechRecognizer.requestAuthorization { _ in
+            if isLiveBridge {
+                DispatchQueue.main.async {
+                    NSApplication.shared.setActivationPolicy(.accessory)
+                }
+            }
+        }
+        return speechPermissionStatus(SFSpeechRecognizer.authorizationStatus())
+    }
+
+    private func speechPermissionStatus(_ status: SFSpeechRecognizerAuthorizationStatus) -> PermissionStatus {
+        switch status {
+        case .authorized: return .granted
+        case .denied: return .denied
+        case .restricted: return .restricted
+        case .notDetermined: return .notDetermined
+        @unknown default: return .notDetermined
+        }
+    }
+    #else
+    private func checkSpeech(prompt: Bool) -> PermissionStatus { .notDetermined }
+    #endif
 
     private func openPrivacyPane(_ anchor: String) {
         guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(anchor)") else {

--- a/interceptor-bridge/Sources/Platform.swift
+++ b/interceptor-bridge/Sources/Platform.swift
@@ -91,7 +91,15 @@ enum Platform {
     // NDJSON (so `monitor tail` against /tmp/interceptor-bridge-events.jsonl
     // still works) AND the session-local events.jsonl. The CLI prefers the
     // session-local file when it exists, falling back to the rolling log.
-    static func appendMonitorEvent(sid: String, event: String, data: [String: Any] = [:]) {
+    //
+    // the actual disk I/O is delegated to MonitorEventWriter,
+    // a single-writer serial queue with open-once FileHandles, so a scroll/AX
+    // flood under `--all-apps` no longer performs blocking open→seek→write→close
+    // on TWO files per event on the main run loop (which previously starved the
+    // start/stop ack past the 15s client deadline). Returns true when the writer
+    // is over its high-water mark (backpressure signal).
+    @discardableResult
+    static func appendMonitorEvent(sid: String, event: String, data: [String: Any] = [:]) -> Bool {
         var entry = data
         entry["event"] = event
         entry["sid"] = sid
@@ -102,32 +110,14 @@ enum Platform {
             entry["timestamp"] = ISO8601DateFormatter().string(from: Date())
         }
         guard let jsonData = try? JSONSerialization.data(withJSONObject: entry),
-              let line = String(data: jsonData, encoding: .utf8) else { return }
+              let line = String(data: jsonData, encoding: .utf8) else { return false }
         let payload = (line + "\n").data(using: .utf8) ?? Data()
-
-        // Tee 1: rolling bridge log.
-        if FileManager.default.fileExists(atPath: bridgeEventsPath) {
-            if let handle = FileHandle(forWritingAtPath: bridgeEventsPath) {
-                handle.seekToEndOfFile()
-                handle.write(payload)
-                handle.closeFile()
-            }
-        } else {
-            FileManager.default.createFile(atPath: bridgeEventsPath, contents: payload)
-        }
-
-        // Tee 2: per-session NDJSON.
         ensureSessionDir(sid)
-        let sessionPath = sessionEventsPath(sid)
-        if FileManager.default.fileExists(atPath: sessionPath) {
-            if let handle = FileHandle(forWritingAtPath: sessionPath) {
-                handle.seekToEndOfFile()
-                handle.write(payload)
-                handle.closeFile()
-            }
-        } else {
-            FileManager.default.createFile(atPath: sessionPath, contents: payload)
-        }
+        return MonitorEventWriter.shared.enqueue(
+            sessionPath: sessionEventsPath(sid),
+            rollingPath: bridgeEventsPath,
+            payload: payload
+        )
     }
 
     /// Atomically write the session.json meta file.
@@ -136,5 +126,95 @@ enum Platform {
         guard let json = try? JSONSerialization.data(withJSONObject: meta, options: [.prettyPrinted]) else { return }
         let path = sessionMetaPath(sid)
         try? json.write(to: URL(fileURLWithPath: path), options: [.atomic])
+    }
+}
+
+// non-blocking monitor event writer.
+//
+// Each monitor event was previously written with a synchronous
+// open→seekToEnd→write→close on TWO files on the calling (main run-loop)
+// thread. Under `--all-apps` AX/scroll volume that saturated the main thread
+// and delayed the start/stop ack past the 15s client deadline. This writer
+// moves all disk I/O to a dedicated serial queue, keeps the two target files
+// open across the session, preserves submission order (serial queue), bounds
+// the in-flight queue (backpressure signal), and exposes flush/close so a
+// graceful SIGINT/SIGTERM (or `pause`/`stop`) durably persists what was
+// captured.
+final class MonitorEventWriter: @unchecked Sendable {
+    static let shared = MonitorEventWriter()
+
+    private let queue = DispatchQueue(label: "interceptor.monitor.writer", qos: .utility)
+    private let lock = NSLock()
+    private var handles: [String: FileHandle] = [:]
+    private var pendingCount = 0
+    // High-water mark for in-flight events. ~20k events is generous headroom
+    // for any real human-teach session; crossing it means the producer is
+    // outrunning the disk and the caller should shed the noisiest event kinds.
+    private let highWaterMark = 20_000
+
+    /// True when the in-flight queue is over the high-water mark — the producer
+    /// is outrunning the disk and the caller should shed its noisiest events.
+    var isOverHighWater: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return pendingCount > highWaterMark
+    }
+
+    /// Enqueue a line for append to both the session file and the rolling
+    /// bridge log. Returns true when the in-flight queue is over the high-water
+    /// mark (backpressure).
+    @discardableResult
+    func enqueue(sessionPath: String, rollingPath: String, payload: Data) -> Bool {
+        lock.lock()
+        pendingCount += 1
+        let over = pendingCount > highWaterMark
+        lock.unlock()
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            self.appendLocked(path: rollingPath, data: payload)
+            self.appendLocked(path: sessionPath, data: payload)
+            self.lock.lock(); self.pendingCount -= 1; self.lock.unlock()
+        }
+        return over
+    }
+
+    // Must run on `queue`. Opens the handle once and appends.
+    private func appendLocked(path: String, data: Data) {
+        let handle: FileHandle
+        if let existing = handles[path] {
+            handle = existing
+        } else {
+            if !FileManager.default.fileExists(atPath: path) {
+                FileManager.default.createFile(atPath: path, contents: nil)
+            }
+            guard let opened = FileHandle(forWritingAtPath: path) else { return }
+            _ = try? opened.seekToEnd()
+            handles[path] = opened
+            handle = opened
+        }
+        do { try handle.write(contentsOf: data) } catch { /* drop on irrecoverable IO error */ }
+    }
+
+    /// Flush all buffered writes to disk. Drains the queue (sync barrier) then
+    /// fsyncs each open handle. Safe to call from any thread except `queue`.
+    func flush() {
+        queue.sync {
+            for (_, handle) in handles { try? handle.synchronize() }
+        }
+    }
+
+    /// Close a single path's handle (used before rotating a session log so the
+    /// next write re-opens the fresh file rather than the moved inode).
+    func close(path: String) {
+        queue.sync {
+            if let handle = handles.removeValue(forKey: path) { try? handle.close() }
+        }
+    }
+
+    /// Close every open handle (process shutdown).
+    func closeAll() {
+        queue.sync {
+            for (_, handle) in handles { try? handle.close() }
+            handles.removeAll()
+        }
     }
 }

--- a/interceptor-bridge/Sources/main.swift
+++ b/interceptor-bridge/Sources/main.swift
@@ -168,6 +168,9 @@ GlobalOverlayDomainRef.shared = overlayDomain
 signal(SIGINT) { _ in
     Platform.log("SIGINT received — shutting down")
     GlobalOverlayDomainRef.shared?.handle("stop", action: ["sub": "stop"]) { _ in }
+    // durably persist any buffered monitor events before exit.
+    MonitorEventWriter.shared.flush()
+    MonitorEventWriter.shared.closeAll()
     Thread.sleep(forTimeInterval: 0.1)
     Platform.cleanup()
     exit(0)
@@ -176,6 +179,9 @@ signal(SIGINT) { _ in
 signal(SIGTERM) { _ in
     Platform.log("SIGTERM received — shutting down")
     GlobalOverlayDomainRef.shared?.handle("stop", action: ["sub": "stop"]) { _ in }
+    // durably persist any buffered monitor events before exit.
+    MonitorEventWriter.shared.flush()
+    MonitorEventWriter.shared.closeAll()
     Thread.sleep(forTimeInterval: 0.1)
     Platform.cleanup()
     exit(0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.17.3",
+  "version": "0.17.6",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {

--- a/scripts/build-bridge.sh
+++ b/scripts/build-bridge.sh
@@ -162,6 +162,8 @@ cat > "$APP_DIR/Contents/Info.plist" <<PLIST
     <string>interceptor-bridge captures screen frames when you ask Interceptor to take screenshots or run screen capture / stream commands.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>interceptor-bridge captures microphone input when you ask Interceptor to use listen / audio commands.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>interceptor-bridge transcribes speech during workflow capture so Interceptor can build a semantic transcript of what you demonstrate (mac_monitor --include speech, mac_listen).</string>
 
     <!-- personal data and distribution surfaces.
          Each TCC-gated framework gets a usage description string that surfaces

--- a/shared/monitor-tasks.ts
+++ b/shared/monitor-tasks.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs"
 import { createHash, randomUUID } from "node:crypto"
 import { join } from "node:path"
-import { TEMP } from "./platform"
+import { TEMP, MONITOR_SESSIONS_DIR } from "./platform"
 import {
   getSessionDir,
   hasSessionArtifacts,
@@ -988,7 +988,7 @@ export function attachMonitorTaskSource(
       code: "source_metadata_binding_sidecar_required",
       sid,
       message: `Could not update source session metadata for ${sid}; task-owned binding metadata will be used.`,
-      recommendedFix: "Run monitor repair while source artifacts are still available.",
+      recommendedFix: "Run interceptor monitor repair --task <taskId> --snapshot-sources while source artifacts are still available.",
     })
   }
   return { task: updated, source }
@@ -1213,7 +1213,7 @@ export function snapshotMonitorTaskSources(taskId: string): MonitorTaskSourceMan
         code: "source_snapshot_incomplete",
         sid: source.sid,
         message: `Source snapshot for ${source.surface} session ${source.sid} is ${snapshotStatus}.`,
-        recommendedFix: "Run monitor repair --task <taskId> --snapshot-sources before temporary source artifacts are removed.",
+        recommendedFix: "Run interceptor monitor repair --task <taskId> --snapshot-sources before temporary source artifacts are removed.",
       })
     }
   }
@@ -1289,7 +1289,109 @@ export function stopMonitorTask(
     }
   }
   snapshotMonitorTaskSources(taskId)
+  transcribeTaskSpeechAudio(taskId)
   return readMonitorTaskMeta(taskId) || task
+}
+
+// recover the sid of a live monitor session bound to this task
+// by scanning session metas. Used when a slow/garbled start RPC response did not
+// carry the sid (so the CLI can still attach instead of leaving an empty
+// envelope). Returns the newest matching session.
+export function findLatestSessionSidForTask(taskId: string): string | undefined {
+  let best: { sid: string; startedAt: number } | undefined
+  let entries: string[]
+  try {
+    entries = readdirSync(MONITOR_SESSIONS_DIR)
+  } catch {
+    return undefined
+  }
+  for (const sid of entries) {
+    const meta = readSessionMeta(sid) as ({ taskId?: string; startedAt?: number } | null)
+    if (!meta || meta.taskId !== taskId) continue
+    const startedAt = typeof meta.startedAt === "number" ? meta.startedAt : 0
+    if (!best || startedAt > best.startedAt) best = { sid, startedAt }
+  }
+  return best?.sid
+}
+
+// offline transcription hook. The bridge writes speech.caf when
+// live Speech-Recognition was unavailable. This is the integration point that
+// turns that audio into transcript rows. The default build ships the interface
+// + detection; the concrete engine (Whisper, etc.) is selected at packaging
+// time (PRD open question). When a source has captured audio but no live
+// transcript and no engine is configured, we record an actionable diagnostic
+// rather than silently leaving the audio untranscribed.
+export function transcribeTaskSpeechAudio(taskId: string): { audioFound: number; alreadyTranscribed: number } {
+  const task = readMonitorTaskMeta(taskId)
+  if (!task) throw new Error(`task not found: ${taskId}`)
+  let audioFound = 0
+  let alreadyTranscribed = 0
+  for (const source of task.sourceSessions) {
+    const roots = [
+      source.sourceSnapshotRoot,
+      source.sourceArtifactRoot,
+      source.originalSourceArtifactRoot,
+      getSessionDir(source.sid),
+    ].filter((r): r is string => typeof r === "string" && r.length > 0)
+    const cafPath = roots.map((r) => join(r, "speech.caf")).find((p) => existsSync(p))
+    if (!cafPath) continue
+    audioFound++
+    const hasLiveSpeech = readTaskSourceEvents(source).some((e) => e.event === "speech_segment")
+    if (hasLiveSpeech) {
+      alreadyTranscribed++
+      continue
+    }
+    appendMonitorTaskDiagnostic(taskId, {
+      severity: "warning",
+      code: "speech_transcription_pending",
+      sid: source.sid,
+      message: `Captured offline audio (${cafPath}) has no live transcript; configure an offline speech engine to transcribe it.`,
+      recommendedFix: "Grant live ASR with 'interceptor macos trust speech --prompt' and re-capture, or wire an offline transcription engine.",
+    })
+  }
+  return { audioFound, alreadyTranscribed }
+}
+
+// the `monitor repair` operation the codebase has long advertised
+// in recommendedFix strings. Recovers any live-but-unattached sessions for the
+// task, durably snapshots all sources, runs the offline-transcription hook, then
+// regenerates the timeline/transcript/segments and re-grades.
+export function repairMonitorTask(
+  taskId: string,
+  options: { snapshotSources?: boolean; regenerate?: boolean } = {}
+): { manifest: MonitorTaskSourceManifestEntry[]; report: MonitorTaskCaptureQualityReport; attached: string[] } {
+  const task = readMonitorTaskMeta(taskId)
+  if (!task) throw new Error(`task not found: ${taskId}`)
+
+  // 1. Recover + attach live sessions that name this task but never registered.
+  const attached: string[] = []
+  const knownSids = new Set(task.sourceSessions.map((s) => s.sid))
+  let entries: string[] = []
+  try {
+    entries = readdirSync(MONITOR_SESSIONS_DIR)
+  } catch {
+    entries = []
+  }
+  for (const sid of entries) {
+    if (knownSids.has(sid)) continue
+    const meta = readSessionMeta(sid) as ({ taskId?: string; surface?: MonitorTaskSurface } | null)
+    if (!meta || meta.taskId !== taskId) continue
+    try {
+      attachMonitorTaskSource(taskId, sid, { surface: meta.surface })
+      attached.push(sid)
+    } catch {
+      /* already attached to another active task, or no artifacts — skip */
+    }
+  }
+
+  // 2. Snapshot (default), transcribe offline audio, regenerate, re-grade.
+  const manifest = snapshotMonitorTaskSources(taskId)
+  transcribeTaskSpeechAudio(taskId)
+  if (options.regenerate !== false) {
+    synthesizeMonitorTaskTranscript(taskId)
+  }
+  const report = generateMonitorTaskCaptureQuality(taskId)
+  return { manifest, report, attached }
 }
 
 function stableId(prefix: string, parts: unknown[]): string {
@@ -1972,7 +2074,7 @@ export function generateMonitorTaskCaptureQuality(taskId: string): MonitorTaskCa
   const blueprintOk = durabilityOk && metadataOk && boundaryOk && evidenceOk && compressionOk && scopeOk && privacyOk
   const findings: MonitorTaskCaptureQualityReport["findings"] = []
 
-  if (!durabilityOk) findings.push({ severity: "blocker", code: "source_durability_incomplete", message: "One or more task sources are not durably snapshotted under the task root.", recommendedFix: "Run monitor repair --task <taskId> --snapshot-sources while source artifacts still exist." })
+  if (!durabilityOk) findings.push({ severity: "blocker", code: "source_durability_incomplete", message: "One or more task sources are not durably snapshotted under the task root.", recommendedFix: "Run interceptor monitor repair --task <taskId> --snapshot-sources while source artifacts still exist." })
   if (!metadataOk) findings.push({ severity: "error", code: "source_metadata_incomplete", message: "One or more task-attached sources lacks complete taskId or surface metadata." })
   if (tmpBackedSourceRefs > 0) findings.push({ severity: "warning", code: "tmp_backed_source_refs", message: `${tmpBackedSourceRefs} source references still point to /tmp.`, recommendedFix: "Regenerate the timeline/transcript after source snapshots complete." })
   if (outOfBoundsEvents > 0) findings.push({ severity: "warning", code: "out_of_bounds_events", message: `${outOfBoundsEvents} timeline events are outside the task boundary window.` })
@@ -1982,6 +2084,42 @@ export function generateMonitorTaskCaptureQuality(taskId: string): MonitorTaskCa
   if (!ratioOk) findings.push({ severity: "warning", code: "weak_transcript_compression", message: `Teachable transcript compression is too weak (${segments.length} segments from ${transcript.length} transcript rows).`, recommendedFix: "Regenerate with the reducer-backed segmenter or add an app-specific semantic adapter." })
   if (!humanScaleOk) findings.push({ severity: "warning", code: "transcript_not_human_scale", message: `Teachable transcript has ${segments.length} segments; expected at most ${humanScaleLimit} for this capture size.`, recommendedFix: "Suppress low-value event kinds and group long text-edit sessions before blueprint compilation." })
   if (!semanticTitlesOk) findings.push({ severity: "warning", code: "semantic_segments_too_raw", message: `${rawTitleSegments} teachable segments still use raw event-style titles.`, recommendedFix: "Map raw monitor event groups into workflow-level titles before marking the task excellent." })
+
+  // capture-specific findings sourced from raw source events so the
+  // operator sees *why* a transcript is thin (permission vs scope vs geometry).
+  let speechDenied = false
+  let speechSegmentRows = 0
+  let degenerateFrames = 0
+  for (const source of task.sourceSessions) {
+    for (const e of readTaskSourceEvents(source)) {
+      if (e.event === "speech_segment") speechSegmentRows++
+      else if (e.event === "speech_unavailable") {
+        const reason = typeof (e as { reason?: unknown }).reason === "string" ? (e as { reason: string }).reason : ""
+        if (/authorization\s+(1|2)|denied|restricted|missing NSSpeechRecognitionUsageDescription/i.test(reason)) speechDenied = true
+      } else if (e.event === "frame") {
+        const w = Number((e as { w?: unknown }).w) || 0
+        const h = Number((e as { h?: unknown }).h) || 0
+        if (w > 0 && h > 0 && Math.max(w, h) / Math.max(1, Math.min(w, h)) > 50) degenerateFrames++
+      }
+    }
+  }
+  if (speechDenied && speechSegmentRows === 0) {
+    findings.push({
+      severity: "warning",
+      code: "speech_permission_denied",
+      message: "Speech Recognition was unavailable (TCC denied or usage key missing); no live transcript was produced.",
+      recommendedFix: "Run interceptor macos trust speech --prompt, then re-run capture (or use --speech-mode offline to capture audio for offline transcription).",
+    })
+  }
+  if (degenerateFrames > 0) {
+    findings.push({
+      severity: "warning",
+      code: "frame_geometry_degenerate",
+      message: `${degenerateFrames} captured frames have implausible geometry (extreme aspect ratio — the SCStream sliver bug).`,
+      recommendedFix: "Re-capture; the pixel-scale + scalesToFit geometry fix resolves sliver frames.",
+    })
+  }
+
   for (const diagnostic of diagnostics.filter((item) => item.severity === "error" || item.severity === "blocker")) {
     findings.push({ severity: diagnostic.severity, code: diagnostic.code, message: diagnostic.message, evidenceRefs: diagnostic.evidenceRefs, recommendedFix: diagnostic.recommendedFix })
   }

--- a/test/monitor-tasks.test.ts
+++ b/test/monitor-tasks.test.ts
@@ -19,7 +19,10 @@ import {
   readMonitorTaskMeta,
   readMonitorTaskSourceManifest,
   readMonitorTaskTranscriptSegments,
+  snapshotMonitorTaskSources,
   stopMonitorTask,
+  repairMonitorTask,
+  findLatestSessionSidForTask,
   synthesizeMonitorTaskTranscript,
   updateMonitorTaskMeta,
   validateSemanticTranscript,
@@ -444,5 +447,68 @@ describe("monitor task envelope", () => {
     expect(segments.every((segment) => !/^(browser|macos) event:/i.test(segment.title))).toBe(true)
     expect(quality.counts.rawTitleSegments).toBe(0)
     expect(quality.scores.transcriptCompression).toBe(1)
+  })
+
+  test("browser + macOS sessions attach to ONE envelope with SEPARATE source logs and a MERGED timeline", () => {
+    const task = createMonitorTask({ instruction: "image generation teach", mode: "human-teach" })
+    writeBrowserSession("task-browser")
+    writeMacosSession("task-macos")
+    attachMonitorTaskSource(task.taskId, "task-browser", { surface: "browser" })
+    attachMonitorTaskSource(task.taskId, "task-macos", { surface: "macos" })
+
+    const manifest = snapshotMonitorTaskSources(task.taskId)
+    expect(manifest.length).toBeGreaterThan(0)
+
+    // Separate source logs under per-sid snapshot dirs.
+    const browserDir = getMonitorTaskSourceSnapshotDir(task.taskId, "task-browser")
+    const macosDir = getMonitorTaskSourceSnapshotDir(task.taskId, "task-macos")
+    expect(browserDir).not.toBe(macosDir)
+    expect(existsSync(browserDir)).toBe(true)
+    expect(existsSync(macosDir)).toBe(true)
+
+    // One envelope, two sources.
+    const meta = readMonitorTaskMeta(task.taskId)!
+    expect(meta.sourceSessions.length).toBe(2)
+
+    // Unified timeline merges both surfaces.
+    const timeline = buildMonitorTaskTimeline(task.taskId)
+    expect(timeline.some((entry) => entry.surface === "browser")).toBe(true)
+    expect(timeline.some((entry) => entry.surface === "macos")).toBe(true)
+  })
+
+  test("monitor repair recovers an unattached macOS session and finalizes the envelope", () => {
+    const task = createMonitorTask({ instruction: "repair me", mode: "human-teach" })
+    // A live macOS session that names the task in its meta but never registered
+    // (the split-brain failure the PRD targets).
+    writeSessionMeta({
+      artifactVersion: 1,
+      surface: "macos",
+      sessionId: "task-macos",
+      startedAt: 2000,
+      status: "stopped",
+      endedAt: 2500,
+      paused: false,
+      taskId: task.taskId,
+      rootPid: 5,
+      rootApp: "Notes",
+      instruction: "repair me",
+      counts: { evt: 2, mut: 0, net: 0, nav: 0, ax: 1 },
+      attachments: [],
+      tcc: { accessibility: true },
+      scope: { mode: "all", apps: [] },
+      includes: [],
+      excludes: [],
+    })
+    appendSessionEvent("task-macos", { event: "mon_start", sid: "task-macos", surface: "macos", s: 0, t: 2000 })
+    appendSessionEvent("task-macos", { event: "window_focus", sid: "task-macos", surface: "macos", s: 1, t: 2100, app: "Notes", n: "Note" })
+
+    // Before repair: empty, but recoverable by sid scan.
+    expect(readMonitorTaskMeta(task.taskId)!.sourceSessions.length).toBe(0)
+    expect(findLatestSessionSidForTask(task.taskId)).toBe("task-macos")
+
+    const { report, attached } = repairMonitorTask(task.taskId, { snapshotSources: true })
+    expect(attached).toContain("task-macos")
+    expect(report.counts.sourceCount).toBe(1)
+    expect(report.status).not.toBe("not_usable")
   })
 })


### PR DESCRIPTION
Makes macOS + browser **workflow capture** (the `monitor` surface) production-grade across speech recognition, screen recording, AX/scroll event volume, and the task envelope. Bumps all surfaces to **0.17.6**.

## Speech
- Ship the Speech Recognition usage string so macOS can present the TCC prompt; guard speech calls so a missing string can't crash on `requestAuthorization`.
- New `interceptor macos trust speech [--prompt]` surfaces the Speech Recognition dialog (momentary activation-policy upgrade) and deep-links Settings; `trust check` now reports speech state.
- Rewritten live recognition: actor-neutral authorization, on-device gated on support, ~55s task restart with a short audio ring buffer, and an always-on offline `.caf` fallback so a transcript exists even when live ASR is denied. New `--speech-mode auto|live|offline|off`. Spin-up is async — never blocks `monitor start`.

## Screen recording
- Fix SCStream frame geometry (pixel scale + `scalesToFit` + capture resolution).
- Continuous video via `SCRecordingOutput` → `screen.mp4` (`--video [fps]`, `--video-max-mb`).
- Frame budget / disk cap / dedup (`--frame-budget`, `--frame-disk-cap`, `--frame-pixel-scale`).

## Event volume
- Coalesce scroll + AX value/layout (`--scroll-coalesce-ms`, `--ax-coalesce-ms`).
- Async batched event writer off the main run loop + bounded queue with backpressure shedding.
- `--all-apps` scope hygiene (skip system chrome by default; `--include-system-apps`, `--exclude-app`). Built-in pause-before-stop.

## Task envelope
- macOS `monitor stop --task` now snapshots + regenerates + grades locally.
- `sid` recovery + post-attach verification (no more empty split-brain envelopes).
- Implement `monitor repair --task`; correct the recommended-fix strings that named a non-existent command. Auto-finalize on stop.

## Lifecycle
- Decouple start/stop acks from heavy setup; raise the monitor RPC deadline; flush the event writer on SIGINT/SIGTERM.

## Verification
- TS typecheck (all configs), `swift build`, and the full test suite green (**484 pass / 0 fail**; +2 new tests: dual-source single-envelope, repair recovery).
- Built, signed, notarized, stapled, and installed locally; verified the speech-permission self-service prompt, full-resolution frames, continuous video, and live+offline audio all capture under one task envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `monitor repair` command to recover incomplete or disconnected monitor tasks
  * Added speech recognition support (offline/live modes) during workflow capture
  * Added capture configuration options: video FPS, frame budgeting, pixel scaling, scroll/accessibility event coalescing, system app filtering
  * Improved event handling with backpressure shedding for high-rate capture events

* **Bug Fixes**
  * Enhanced session recovery and verification for macOS monitor start/stop
  * Increased timeout for monitor operations to prevent split-brain behavior

* **Chores**
  * Version bump: 0.17.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->