### PR TITLE
fix(extension): route Trusted-Types/CSP eval failures to the CSP-strip bypass (v0.17.7)

### DIFF
--- a/cli/version.ts
+++ b/cli/version.ts
@@ -1,6 +1,6 @@
 // Sentinel values used when running from source (`bun run cli`).
 // scripts/build.sh stamps real build values into this file just before
 // each `bun build --compile` and restores it afterwards via `git checkout`.
-export const VERSION = "0.17.2"
+export const VERSION = "0.17.7"
 export const BUILD_SHA = "dev"
 export const BUILD_DATE = "dev"

--- a/extension/dist-mv2/background-electron.js
+++ b/extension/dist-mv2/background-electron.js
@@ -2007,10 +2007,12 @@ async function handleEvaluateActions(action, tabId) {
   if (userScriptAttempt.available) {
     if (!userScriptAttempt.result?.success && world === "MAIN" && isCspEvalError(userScriptAttempt.result?.error)) {
       const fallback = await executeWithUserScripts(tabId, "USER_SCRIPT", code);
-      if (fallback.available)
+      if (fallback.available && (fallback.result?.success || !isCspEvalError(fallback.result?.error))) {
         return fallback.result ?? { success: false, error: "no result" };
+      }
+    } else {
+      return userScriptAttempt.result ?? { success: false, error: "no result" };
     }
-    return userScriptAttempt.result ?? { success: false, error: "no result" };
   }
   const first = await executeEval(tabId, world, code);
   if (first.success || world !== "MAIN") {
@@ -2028,16 +2030,8 @@ async function handleEvaluateActions(action, tabId) {
         }
       };
     }
-    return {
-      success: false,
-      error: isolated.error || first.error,
-      data: {
-        originalError: first.error,
-        trustedTypesFallbackAttempted: true
-      }
-    };
   }
-  if (!isCspUnsafeEvalError(first.error)) {
+  if (!isCspUnsafeEvalError(first.error) && !isTrustedTypesError(first.error)) {
     return first;
   }
   try {

--- a/extension/dist-mv2/content.js
+++ b/extension/dist-mv2/content.js
@@ -271,15 +271,22 @@ function buildA11yTree(root, depth, maxDepth, filter, includeStyle = false, form
   function walk(el, d) {
     if (d > maxDepth)
       return;
-    if (!isVisible(el) && el.tagName !== "BODY")
-      return;
+    const style = el.tagName === "BODY" ? null : getComputedStyle(el);
+    const selfVisible = el.tagName === "BODY" || isVisible(el, style);
+    if (!selfVisible) {
+      if (style.display === "none" || style.visibility === "hidden")
+        return;
+      const pos = style.position;
+      if (pos !== "fixed" && pos !== "absolute")
+        return;
+    }
     const role = getEffectiveRole(el);
     const tag = el.tagName.toLowerCase();
     const isLandmark = LANDMARK_ROLES.has(role) || LANDMARK_TAGS.has(el.tagName);
     const isHeading = /^h[1-6]$/.test(tag) || role === "heading";
     const isInteractiveEl = isInteractive(el, INTERACTIVE_TAGS, INTERACTIVE_ROLES);
     const prefix = compact ? ">".repeat(d) : "  ".repeat(d);
-    if (isLandmark && !isInteractiveEl) {
+    if (selfVisible && isLandmark && !isInteractiveEl) {
       const name = getAccessibleName(el);
       const hasName = !!name && name !== (el.textContent || "").trim().slice(0, 80);
       if (compact) {
@@ -289,7 +296,7 @@ function buildA11yTree(root, depth, maxDepth, filter, includeStyle = false, form
         lines.push(`${prefix}${role || tag}${nameStr}`);
       }
     }
-    if (isHeading && filter === "all") {
+    if (selfVisible && isHeading && filter === "all") {
       const name = getAccessibleName(el);
       if (compact) {
         lines.push(`${prefix}heading|${name}`);
@@ -297,7 +304,7 @@ function buildA11yTree(root, depth, maxDepth, filter, includeStyle = false, form
         lines.push(`${prefix}heading "${name}"`);
       }
     }
-    if (isInteractiveEl) {
+    if (selfVisible && isInteractiveEl) {
       const refId = getOrAssignRef(el);
       const name = getAccessibleName(el);
       const attrs = getRelevantAttrs(el);
@@ -318,12 +325,12 @@ function buildA11yTree(root, depth, maxDepth, filter, includeStyle = false, form
     if (shadow) {
       const shadowPrefix = compact ? ">".repeat(d + 1) : `${prefix}  `;
       lines.push(`${shadowPrefix}shadow-root`);
-      for (const child of shadow.children) {
+      for (const child of Array.from(shadow.children)) {
         walk(child, d + 2);
       }
     }
-    for (const child of el.children) {
-      walk(child, isLandmark ? d + 1 : d);
+    for (const child of Array.from(el.children)) {
+      walk(child, isLandmark && selfVisible ? d + 1 : d);
     }
   }
   walk(root, depth);
@@ -362,8 +369,7 @@ function walkWithShadow(root, callback) {
     node = walker.nextNode();
   }
 }
-function isVisible(el) {
-  const style = getComputedStyle(el);
+function isVisible(el, style = getComputedStyle(el)) {
   if (style.visibility === "hidden" || style.display === "none")
     return false;
   const pos = style.position;
@@ -639,6 +645,18 @@ function dispatchClickSequence(el, atX, atY) {
   const rect = el.getBoundingClientRect();
   const x = atX !== undefined ? rect.left + atX : rect.left + rect.width / 2;
   const y = atY !== undefined ? rect.top + atY : rect.top + rect.height / 2;
+  let acked = false;
+  const onAck = () => {
+    acked = true;
+  };
+  el.addEventListener("__interceptor_click_ack", onAck, true);
+  try {
+    el.dispatchEvent(new CustomEvent("__interceptor_click", { bubbles: true, detail: { x, y } }));
+  } finally {
+    el.removeEventListener("__interceptor_click_ack", onAck, true);
+  }
+  if (acked)
+    return;
   const opts = { bubbles: true, cancelable: true, clientX: x, clientY: y, button: 0 };
   el.dispatchEvent(new PointerEvent("pointerover", opts));
   el.dispatchEvent(new MouseEvent("mouseover", opts));
@@ -4262,20 +4280,24 @@ async function handleDomScreenshot(action) {
 }
 
 // extension/src/content.ts
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  if (msg.type === "execute_action") {
-    handleAction(msg.action).then(sendResponse).catch((err) => sendResponse({ success: false, error: err.message }));
-    return true;
-  }
-  if (msg.type === "get_state") {
-    try {
-      sendResponse(getPageState(msg.full));
-    } catch (err) {
-      sendResponse({ success: false, error: err.message });
+var __interceptorContentGlobal = globalThis;
+var __interceptorContentAlreadyLoaded = __interceptorContentGlobal.__interceptorContentLoaded === true;
+__interceptorContentGlobal.__interceptorContentLoaded = true;
+if (!__interceptorContentAlreadyLoaded)
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type === "execute_action") {
+      handleAction(msg.action).then(sendResponse).catch((err) => sendResponse({ success: false, error: err.message }));
+      return true;
     }
-    return true;
-  }
-});
+    if (msg.type === "get_state") {
+      try {
+        sendResponse(getPageState(msg.full));
+      } catch (err) {
+        sendResponse({ success: false, error: err.message });
+      }
+      return true;
+    }
+  });
 async function handleAction(action) {
   const warnDirty = getDomDirty();
   clearStaleWarning();
@@ -4502,13 +4524,14 @@ async function executeAction(action) {
   }
 }
 var _swKeepaliveLeader = true;
-setInterval(() => {
-  if (!_swKeepaliveLeader)
-    return;
-  try {
-    chrome.runtime.sendMessage({ type: "sw_keepalive" }).then((resp) => {
-      if (resp && resp.leader === false)
-        _swKeepaliveLeader = false;
-    }).catch(() => {});
-  } catch {}
-}, 25000);
+if (!__interceptorContentAlreadyLoaded)
+  setInterval(() => {
+    if (!_swKeepaliveLeader)
+      return;
+    try {
+      chrome.runtime.sendMessage({ type: "sw_keepalive" }).then((resp) => {
+        if (resp && resp.leader === false)
+          _swKeepaliveLeader = false;
+      }).catch(() => {});
+    } catch {}
+  }, 25000);

--- a/extension/dist-mv2/manifest.json
+++ b/extension/dist-mv2/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Interceptor Electron App Bridge",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "Electron app bridge",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8I3MwCNVrLcP0OCP8fRpiGWHIpbu2iMsyweU4YcX/CWdmO2fnZAJ6UP+IKkM5Zw9mt9kY4CFW4tZt096ChuMKiVBg4HM47ffWHTlo6rXOzdLuXMQ6MtFDuqbQuq6x0tLgYlOr7UxSiPVFgPRuczOz+kPkTO/h8nJNDaouNY1WnG4/ESruv10gwLwxgNKEvisnjxDU6lw9zDm/+pF8aAB8RMJbJQpRRBKDVL8rTRb4yCp6qi8E9VkJRK3sTD9sX0fgZoYd4pkvbK+7kPh9oxiuzPKNCKm9v8XTCVBh+sWBJBdke7PAoERkdXOs2MEijjO2A0X4/tzqygr3oARSghkQIDAQAB",
   "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Interceptor",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "minimum_chrome_version": "116",
   "description": "Browser bridge",
   "icons": {

--- a/extension/src/background/capabilities/evaluate.ts
+++ b/extension/src/background/capabilities/evaluate.ts
@@ -152,9 +152,17 @@ export async function handleEvaluateActions(
       isCspEvalError(userScriptAttempt.result?.error)
     ) {
       const fallback = await executeWithUserScripts(tabId, "USER_SCRIPT", code)
-      if (fallback.available) return fallback.result ?? { success: false, error: "no result" }
+      if (
+        fallback.available &&
+        (fallback.result?.success || !isCspEvalError(fallback.result?.error))
+      ) {
+        return fallback.result ?? { success: false, error: "no result" }
+      }
+      // userScripts could not beat the page's CSP / Trusted-Types either — fall
+      // through to the executeEval CSP-strip bypass + reload path below.
+    } else {
+      return userScriptAttempt.result ?? { success: false, error: "no result" }
     }
-    return userScriptAttempt.result ?? { success: false, error: "no result" }
   }
   const first = await executeEval(tabId, world as "MAIN" | "ISOLATED", code)
   if (first.success || world !== "MAIN") {
@@ -173,17 +181,15 @@ export async function handleEvaluateActions(
         }
       }
     }
-    return {
-      success: false,
-      error: isolated.error || first.error,
-      data: {
-        originalError: first.error,
-        trustedTypesFallbackAttempted: true
-      }
-    }
+    // ISOLATED also failed under Trusted Types (e.g. require-trusted-types-for
+    // 'script' blocks eval in every world). Fall through to the CSP-strip
+    // bypass + reload path below — buildCspBypassRule removes the entire CSP
+    // response header (including require-trusted-types-for), so a reloaded
+    // page accepts MAIN-world eval. (Previously this returned early, leaving
+    // strict-TT sites like NotebookLM permanently un-evaluable.)
   }
 
-  if (!isCspUnsafeEvalError(first.error)) {
+  if (!isCspUnsafeEvalError(first.error) && !isTrustedTypesError(first.error)) {
     return first
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interceptor",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "type": "module",
   "license": "Elastic-2.0",
   "bin": {


### PR DESCRIPTION
## Summary
- MAIN-world `eval` on pages with a strict Trusted-Types CSP (`require-trusted-types-for 'script'`) was rejected and returned early, never reaching the extension's existing per-tab CSP-header-strip + reload bypass. This routes Trusted-Types and userScript-CSP failures into that bypass so strict-Trusted-Types sites become eval-able.
- Refreshes the built content bundle to match source already on `main` (a11y out-of-flow portal visibility, MAIN-world pointerdown gesture for Radix/Floating-UI menus, double content-script injection guard).
- Bumps the version across all surfaces (extension manifests, `package.json`, CLI) to `0.17.7`.

## Behavior
| Page CSP | Before | After |
| --- | --- | --- |
| no CSP / `unsafe-eval` allowed | eval works | unchanged |
| `unsafe-eval` blocked | strip + reload → works | unchanged |
| `require-trusted-types-for 'script'` | early return → fails | strip + reload → works |

## Notes
- No new permissions or API surface; widens the trigger of an existing mechanism, not the mechanism.
- Not a Sparkle release — `main` merge only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.17.7

* **Chores**
  * Version bumped to 0.17.7 across all packages and manifests

* **Bug Fixes**
  * Improved evaluation logic for scripts subject to Content Security Policy restrictions
  * Enhanced accessibility tree walker with better element visibility computation
  * Prevented duplicate content script injection

* **New Features**
  * Added cooperative click interception mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->